### PR TITLE
add visibility predicate (base on git vcs activity) for git machete tab

### DIFF
--- a/intellijPlugin/src/main/java/com/virtuslab/gitmachete/ui/GitMacheteContentProvider.java
+++ b/intellijPlugin/src/main/java/com/virtuslab/gitmachete/ui/GitMacheteContentProvider.java
@@ -7,10 +7,13 @@ import static com.intellij.util.ui.UIUtil.addBorder;
 import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
+import com.intellij.openapi.vcs.ProjectLevelVcsManager;
 import com.intellij.openapi.vcs.changes.ui.ChangesViewContentProvider;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.SideBorder;
+import com.intellij.util.NotNullFunction;
 import com.intellij.util.ui.components.BorderLayoutPanel;
+import git4idea.GitVcs;
 import javax.annotation.Nonnull;
 import javax.swing.JComponent;
 
@@ -43,5 +46,11 @@ public class GitMacheteContentProvider implements ChangesViewContentProvider {
   @Override
   public void disposeContent() {}
 
-  // todo: visibility predicate (invisible when machete file missing???)
+  public static class GitMacheteVisibilityPredicate implements NotNullFunction<Project, Boolean> {
+    @Nonnull
+    @Override
+    public Boolean fun(Project project) {
+      return ProjectLevelVcsManager.getInstance(project).checkVcsIsActive(GitVcs.NAME);
+    }
+  }
 }

--- a/intellijPlugin/src/main/resources/META-INF/plugin.xml
+++ b/intellijPlugin/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@
     <depends>Git4Idea</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <changesViewContent tabName="Git Machete" className="com.virtuslab.gitmachete.ui.GitMacheteContentProvider"/>
+        <changesViewContent tabName="Git Machete" className="com.virtuslab.gitmachete.ui.GitMacheteContentProvider"
+        predicateClassName="com.virtuslab.gitmachete.ui.GitMacheteContentProvider$GitMacheteVisibilityPredicate"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Steps to test:
1. Open project with a git vcs enabled (Git Machete tab should be visible)
2. Go to `Settings > Version Control`
3. Click VCS cell and select any other vcs
4. Apply (Git Machete tab should not be visible)