### PR TITLE
Instantiate actions for sliding out/rebase current branch declaratively + decouple frontendUiRoot from frontendActions

### DIFF
--- a/config/checkstyle/tree_walker_module_directives.xml
+++ b/config/checkstyle/tree_walker_module_directives.xml
@@ -65,7 +65,7 @@
     <property name="illegalPattern" value="true"/>
     <property name="format" value="\binterface\s+[^I]"/>
     <property name="ignoreComments" value="true"/>
-    <property name="message" value="Interface names must start with 'I'" />
+    <property name="message" value="Interface names must start with 'I'"/>
 </module>
 <module name="Regexp">
     <property name="illegalPattern" value="true"/>

--- a/frontendActionIds/src/main/java/com/virtuslab/gitmachete/frontend/actionids/ActionIds.java
+++ b/frontendActionIds/src/main/java/com/virtuslab/gitmachete/frontend/actionids/ActionIds.java
@@ -5,6 +5,8 @@ public final class ActionIds {
 
   // These entries are defined in plugin.xml file
   public static final String ACTION_CHECK_OUT = "GitMachete.CheckOutBranchAction";
+  public static final String ACTION_REBASE_CURRENT_ONTO_PARENT = "GitMachete.RebaseCurrentBranchOntoParentAction";
   public static final String ACTION_REFRESH = "GitMachete.RefreshAction";
+  public static final String ACTION_SLIDE_OUT_CURRENT = "GitMachete.SlideOutCurrentBranchAction";
   public static final String GROUP_TO_INVOKE_AS_CONTEXT_MENU = "GitMachete.ContextMenu";
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseCurrentBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseCurrentBranchOntoParentAction.java
@@ -3,7 +3,6 @@ package com.virtuslab.gitmachete.frontend.actions;
 import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getCurrentBaseMacheteNonRootBranch;
 import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getPresentMacheteRepository;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
@@ -25,17 +24,6 @@ import com.virtuslab.logger.PrefixedLambdaLoggerFactory;
  */
 public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoParentAction {
   public static final IPrefixedLambdaLogger LOG = PrefixedLambdaLoggerFactory.getLogger("frontendActions");
-
-  private static final String ACTION_TEXT = "Rebase Current Branch Onto Parent";
-  private static final String ACTION_DESCRIPTION = "Rebase current branch onto parent";
-
-  /**
-   * This action "construction" happens here (not within plugin.xml, as in the case of {@link RebaseSelectedBranchOntoParentAction})
-   * because declaration of such GUI elements (the button in this case) is apparently less obvious than a context menu option.
-   */
-  public RebaseCurrentBranchOntoParentAction() {
-    super(ACTION_TEXT, ACTION_DESCRIPTION, AllIcons.Actions.Menu_cut);
-  }
 
   @Override
   @UIEffect

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutCurrentBranchAction.java
@@ -3,7 +3,6 @@ package com.virtuslab.gitmachete.frontend.actions;
 import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getCurrentBaseMacheteNonRootBranch;
 import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getPresentMacheteRepository;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
@@ -27,13 +26,6 @@ import com.virtuslab.logger.PrefixedLambdaLoggerFactory;
  */
 public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
   public static final IPrefixedLambdaLogger LOG = PrefixedLambdaLoggerFactory.getLogger("frontendActions");
-
-  private static final String ACTION_TEXT = "Slide Out Current Branch";
-  private static final String ACTION_DESCRIPTION = "Slide out current branch";
-
-  public SlideOutCurrentBranchAction() {
-    super(ACTION_TEXT, ACTION_DESCRIPTION, AllIcons.Actions.GC);
-  }
 
   @Override
   @UIEffect

--- a/frontendUiRoot/build.gradle
+++ b/frontendUiRoot/build.gradle
@@ -3,7 +3,6 @@ vavr()
 dependencies {
   implementation project(':logging')
   implementation project(':frontendActionIds')
-  implementation project(':frontendActions')
   implementation project(':frontendUiTable')
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,6 @@
 <idea-plugin>
     <id>com.virtuslab.git-machete</id>
     <name>Git Machete</name>
-    <version>"${version}"</version>
     <vendor email="mkondratek@virtuslab.com" url="http://virtuslab.com">VirtusLab</vendor>
 
     <description><![CDATA[
@@ -42,6 +41,18 @@
             <reference id="GitMachete.RebaseSelectedBranchOntoParentAction"/>
             <reference id="GitMachete.SlideOutSelectedBranchAction"/>
         </group>
+
+        <action id="GitMachete.RebaseCurrentBranchOntoParentAction"
+                class="com.virtuslab.gitmachete.frontend.actions.RebaseCurrentBranchOntoParentAction"
+                text="Rebase Current Branch Onto Parent"
+                description="Rebase current branch onto parent"
+                icon="AllIcons.Actions.Menu_cut"/>
+
+        <action id="GitMachete.SlideOutCurrentBranchAction"
+                class="com.virtuslab.gitmachete.frontend.actions.SlideOutCurrentBranchAction"
+                text="Slide Out Current Branch"
+                description="Slide out current branch"
+                icon="AllIcons.Actions.GC"/>
 
         <!-- Note that certain other actions aren't listed here since they're instead instantiated directly from Java code. -->
     </actions>

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.1.7'
+  PLUGIN_VERSION = '0.1.8-SNAPSHOT'
 }


### PR DESCRIPTION
This PR partially adresses #220; still the harder part left for a follow-up PR (`RefreshGitMacheteStatusAction` + `ToggleListCommitsAction`, both dangerously tightly coupled with `GitMacheteGraphTableManager`; in the current shape it's still unlikely to work correctly when multiple project windows are opened)