### PR TITLE
Apply static verification for is.../as... downcast methods across the project

### DIFF
--- a/backendApi/build.gradle
+++ b/backendApi/build.gradle
@@ -1,5 +1,6 @@
 vavr()
 
 dependencies {
-    api project(":branchLayoutApi")
+  implementation project(':qual')
+  api project(':branchLayoutApi')
 }

--- a/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/BaseGitMacheteBranch.java
+++ b/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/BaseGitMacheteBranch.java
@@ -3,15 +3,30 @@ package com.virtuslab.gitmachete.backend.api;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.EnsuresQualifierIf;
+import org.checkerframework.framework.qual.RequiresQualifier;
+
+import com.virtuslab.qual.gitmachete.backend.api.ConfirmedNonRootBranch;
+import com.virtuslab.qual.gitmachete.backend.api.ConfirmedRootBranch;
 
 /**
  * The only criterion for equality of any instances of any class derived from this one is the reference equality
  */
 public abstract class BaseGitMacheteBranch {
+  @EnsuresQualifierIf(expression = "this", result = true, qualifier = ConfirmedRootBranch.class)
+  @EnsuresQualifierIf(expression = "this", result = false, qualifier = ConfirmedNonRootBranch.class)
   public abstract boolean isRootBranch();
 
+  @EnsuresQualifierIf(expression = "this", result = true, qualifier = ConfirmedNonRootBranch.class)
+  @EnsuresQualifierIf(expression = "this", result = false, qualifier = ConfirmedRootBranch.class)
+  public final boolean isNonRootBranch() {
+    return !isRootBranch();
+  }
+
+  @RequiresQualifier(expression = "this", qualifier = ConfirmedRootBranch.class)
   public abstract BaseGitMacheteRootBranch asRootBranch();
 
+  @RequiresQualifier(expression = "this", qualifier = ConfirmedNonRootBranch.class)
   public abstract BaseGitMacheteNonRootBranch asNonRootBranch();
 
   public abstract String getName();

--- a/build.gradle
+++ b/build.gradle
@@ -37,14 +37,14 @@ import org.ajoberstar.grgit.Grgit
 allprojects {
   apply plugin:'org.ajoberstar.grgit'
   def git = Grgit.open(currentDir: project.rootDir)
-  def snapshot = System.getenv('CIRCLE_BRANCH') == 'master' ? '' : '-SNAPSHOT'
+  def maybeSnapshot = System.getenv('CIRCLE_BRANCH') == 'master' ? '' : '-SNAPSHOT'
   def shortCommitHash = "+git.${git.head().abbreviatedId}"
-  def dirty = git.status().clean ? '' : '-dirty'
+  def maybeDirty = git.status().clean ? '' : '-dirty'
   git.close()
 
   group 'com.virtuslab'
   apply from: "$rootDir/version.gradle"
-  version "${PLUGIN_VERSION}${snapshot}${shortCommitHash}${dirty}"
+  version "${PLUGIN_VERSION}${maybeSnapshot}${shortCommitHash}${maybeDirty}"
 
   repositories {
     jcenter()
@@ -212,6 +212,18 @@ subprojects {
 
 
   ext {
+    applySubtypingChecker = { ->
+      dependencies {
+        implementation project(':qual')
+        checkerFramework project(':qual')
+      }
+      checkerFramework {
+        checkers += 'org.checkerframework.common.subtyping.SubtypingChecker'
+        def qualClassDir = project(':qual').sourceSets.main.output.classesDirs.asPath
+        extraJavacArgs += "-AqualDirs=${qualClassDir}"
+      }
+    }
+
     // For the frontend subprojects we only use the Intellij plugin to provide dependencies,
     // but don't want the associated tasks to be available; they should only be available in the root project.
     disableIntellijTasks = { ->

--- a/config/checkstyle/tree_walker_module_directives.xml
+++ b/config/checkstyle/tree_walker_module_directives.xml
@@ -63,7 +63,7 @@
 <module name="RedundantModifier"/>
 <module name="Regexp">
     <property name="illegalPattern" value="true"/>
-    <property name="format" value="\binterface\s+[^I]"/>
+    <property name="format" value="(^|[^@])\binterface\s+[^I]"/>
     <property name="ignoreComments" value="true"/>
     <property name="message" value="Interface names must start with 'I'"/>
 </module>

--- a/frontendActions/build.gradle
+++ b/frontendActions/build.gradle
@@ -10,6 +10,8 @@ dependencies {
   implementation project(':frontendDataKeys')
 }
 
+applySubtypingChecker()
+
 apply plugin: 'org.jetbrains.intellij'
 disableIntellijTasks()
 intellij {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/ActionUtils.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/ActionUtils.java
@@ -50,7 +50,7 @@ public final class ActionUtils {
     var currentBranchOption = gitMacheteRepository.getCurrentBranchIfManaged();
     assert currentBranchOption.isDefined() : "Can't get current branch";
     var baseGitMacheteBranch = currentBranchOption.get();
-    assert !baseGitMacheteBranch.isRootBranch() : "Selected branch is a root branch";
+    assert baseGitMacheteBranch.isNonRootBranch() : "Selected branch is a root branch";
 
     return baseGitMacheteBranch.asNonRootBranch();
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseSelectedBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseSelectedBranchOntoParentAction.java
@@ -58,7 +58,7 @@ public class RebaseSelectedBranchOntoParentAction extends BaseRebaseBranchOntoPa
     var selectedGitMacheteBranchOption = getSelectedMacheteBranch(anActionEvent);
     assert selectedGitMacheteBranchOption.isDefined() : "Can't get selected branch";
     var baseGitMacheteBranch = selectedGitMacheteBranchOption.get();
-    assert !baseGitMacheteBranch.isRootBranch() : "Selected branch is a root branch";
+    assert baseGitMacheteBranch.isNonRootBranch() : "Selected branch is a root branch";
 
     var branchToRebase = baseGitMacheteBranch.asNonRootBranch();
     doRebase(anActionEvent, branchToRebase);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutSelectedBranchAction.java
@@ -61,7 +61,7 @@ public class SlideOutSelectedBranchAction extends BaseSlideOutBranchAction {
     var selectedMacheteBranchOption = getSelectedMacheteBranch(anActionEvent);
     assert selectedMacheteBranchOption.isDefined() : "Can't get selected branch";
     var baseGitMacheteBranch = selectedMacheteBranchOption.get();
-    assert !baseGitMacheteBranch.isRootBranch() : "Selected branch is a root branch";
+    assert baseGitMacheteBranch.isNonRootBranch() : "Selected branch is a root branch";
 
     doSlideOut(anActionEvent, baseGitMacheteBranch.asNonRootBranch());
   }

--- a/frontendGraphApi/build.gradle
+++ b/frontendGraphApi/build.gradle
@@ -1,6 +1,7 @@
 vavr()
 
 dependencies {
+  implementation project(':qual')
   api project(':backendApi')
 }
 

--- a/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/elements/IGraphElement.java
+++ b/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/elements/IGraphElement.java
@@ -1,7 +1,12 @@
 
 package com.virtuslab.gitmachete.frontend.graph.api.elements;
 
+import org.checkerframework.framework.qual.EnsuresQualifierIf;
+import org.checkerframework.framework.qual.RequiresQualifier;
+
 import com.virtuslab.gitmachete.frontend.graph.api.render.parts.IRenderPart;
+import com.virtuslab.qual.gitmachete.frontend.graph.api.elements.ConfirmedGraphEdge;
+import com.virtuslab.qual.gitmachete.frontend.graph.api.elements.ConfirmedGraphNode;
 
 /**
  * Graph elements ({@link IGraphElement}, {@link GraphEdge}, {@link GraphNode}) represent the LOGICAL graph structure.
@@ -10,10 +15,19 @@ import com.virtuslab.gitmachete.frontend.graph.api.render.parts.IRenderPart;
  * here (unlike with {@link IRenderPart}).
  * */
 public interface IGraphElement {
-
+  @EnsuresQualifierIf(expression = "this", result = true, qualifier = ConfirmedGraphNode.class)
+  @EnsuresQualifierIf(expression = "this", result = false, qualifier = ConfirmedGraphEdge.class)
   boolean isNode();
 
+  @EnsuresQualifierIf(expression = "this", result = true, qualifier = ConfirmedGraphEdge.class)
+  @EnsuresQualifierIf(expression = "this", result = false, qualifier = ConfirmedGraphNode.class)
+  default boolean isEdge() {
+    return !isNode();
+  }
+
+  @RequiresQualifier(expression = "this", qualifier = ConfirmedGraphNode.class)
   GraphNode asNode();
 
+  @RequiresQualifier(expression = "this", qualifier = ConfirmedGraphEdge.class)
   GraphEdge asEdge();
 }

--- a/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/items/IBranchItem.java
+++ b/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/items/IBranchItem.java
@@ -1,5 +1,7 @@
 package com.virtuslab.gitmachete.frontend.graph.api.items;
 
+import io.vavr.NotImplementedError;
+
 import com.virtuslab.gitmachete.backend.api.BaseGitMacheteBranch;
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 
@@ -8,4 +10,20 @@ public interface IBranchItem extends IGraphItem {
   BaseGitMacheteBranch getBranch();
 
   SyncToRemoteStatus getSyncToRemoteStatus();
+
+  // These methods need to be implemented in frontendGraphApi to avoid problems with Subtyping Checker.
+  @Override
+  default boolean isBranchItem() {
+    return true;
+  }
+
+  @Override
+  default IBranchItem asBranchItem() {
+    return this;
+  }
+
+  @Override
+  default ICommitItem asCommitItem() {
+    throw new NotImplementedError();
+  }
 }

--- a/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/items/ICommitItem.java
+++ b/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/items/ICommitItem.java
@@ -1,3 +1,21 @@
 package com.virtuslab.gitmachete.frontend.graph.api.items;
 
-public interface ICommitItem extends IGraphItem {}
+import io.vavr.NotImplementedError;
+
+public interface ICommitItem extends IGraphItem {
+  // These methods need to be implemented in frontendGraphApi to avoid problems with Subtyping Checker.
+  @Override
+  default boolean isBranchItem() {
+    return false;
+  }
+
+  @Override
+  default IBranchItem asBranchItem() {
+    throw new NotImplementedError();
+  }
+
+  @Override
+  default ICommitItem asCommitItem() {
+    return this;
+  }
+}

--- a/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/items/IGraphItem.java
+++ b/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/items/IGraphItem.java
@@ -5,9 +5,13 @@ import org.checkerframework.checker.index.qual.GTENegativeOne;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.qual.EnsuresQualifierIf;
+import org.checkerframework.framework.qual.RequiresQualifier;
 
 import com.virtuslab.gitmachete.frontend.graph.api.coloring.GraphItemColor;
 import com.virtuslab.gitmachete.frontend.graph.api.render.parts.IRenderPart;
+import com.virtuslab.qual.gitmachete.frontend.graph.api.items.ConfirmedBranchItem;
+import com.virtuslab.qual.gitmachete.frontend.graph.api.items.ConfirmedCommitItem;
 
 /**
  * Graph items ({@link IGraphItem}, {@link IBranchItem}, {@link ICommitItem}) represent the DATA of the graph.
@@ -54,9 +58,19 @@ public interface IGraphItem {
   /** @return the childItem which is an indented item (branch or commit) */
   boolean hasChildItem();
 
+  @EnsuresQualifierIf(expression = "this", result = true, qualifier = ConfirmedBranchItem.class)
+  @EnsuresQualifierIf(expression = "this", result = false, qualifier = ConfirmedCommitItem.class)
   boolean isBranchItem();
 
+  @EnsuresQualifierIf(expression = "this", result = true, qualifier = ConfirmedCommitItem.class)
+  @EnsuresQualifierIf(expression = "this", result = false, qualifier = ConfirmedBranchItem.class)
+  default boolean isCommitItem() {
+    return !isBranchItem();
+  }
+
+  @RequiresQualifier(expression = "this", qualifier = ConfirmedBranchItem.class)
   IBranchItem asBranchItem();
 
+  @RequiresQualifier(expression = "this", qualifier = ConfirmedCommitItem.class)
   ICommitItem asCommitItem();
 }

--- a/frontendGraphImpl/build.gradle
+++ b/frontendGraphImpl/build.gradle
@@ -4,7 +4,10 @@ dependencies {
   api project(':frontendGraphApi')
 
   implementation project(':logging')
+  implementation project(':backendApi')
 }
+
+applySubtypingChecker()
 
 apply plugin: 'org.jetbrains.intellij'
 disableIntellijTasks()

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/items/BranchItem.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/items/BranchItem.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 
 import com.intellij.ui.JBColor;
 import com.intellij.ui.SimpleTextAttributes;
-import io.vavr.NotImplementedError;
 import lombok.Getter;
 import org.checkerframework.checker.index.qual.GTENegativeOne;
 import org.checkerframework.checker.index.qual.NonNegative;
@@ -13,7 +12,6 @@ import com.virtuslab.gitmachete.backend.api.BaseGitMacheteBranch;
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 import com.virtuslab.gitmachete.frontend.graph.api.coloring.GraphItemColor;
 import com.virtuslab.gitmachete.frontend.graph.api.items.IBranchItem;
-import com.virtuslab.gitmachete.frontend.graph.api.items.ICommitItem;
 
 @Getter
 public final class BranchItem extends BaseGraphItem implements IBranchItem {
@@ -58,20 +56,5 @@ public final class BranchItem extends BaseGraphItem implements IBranchItem {
   @Override
   public boolean hasChildItem() {
     return hasChildItem;
-  }
-
-  @Override
-  public boolean isBranchItem() {
-    return true;
-  }
-
-  @Override
-  public IBranchItem asBranchItem() {
-    return this;
-  }
-
-  @Override
-  public ICommitItem asCommitItem() {
-    throw new NotImplementedError();
   }
 }

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/items/CommitItem.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/items/CommitItem.java
@@ -2,14 +2,12 @@ package com.virtuslab.gitmachete.frontend.graph.impl.items;
 
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.ui.UIUtil;
-import io.vavr.NotImplementedError;
 import lombok.Getter;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
 
 import com.virtuslab.gitmachete.backend.api.IGitMacheteCommit;
 import com.virtuslab.gitmachete.frontend.graph.api.coloring.GraphItemColor;
-import com.virtuslab.gitmachete.frontend.graph.api.items.IBranchItem;
 import com.virtuslab.gitmachete.frontend.graph.api.items.ICommitItem;
 
 @Getter
@@ -49,20 +47,5 @@ public final class CommitItem extends BaseGraphItem implements ICommitItem {
   @Override
   public boolean hasChildItem() {
     return false;
-  }
-
-  @Override
-  public boolean isBranchItem() {
-    return false;
-  }
-
-  @Override
-  public IBranchItem asBranchItem() {
-    throw new NotImplementedError();
-  }
-
-  @Override
-  public ICommitItem asCommitItem() {
-    return this;
   }
 }

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/render/RenderPartGenerator.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/render/RenderPartGenerator.java
@@ -60,7 +60,7 @@ public final class RenderPartGenerator implements IRenderPartGenerator {
     }
 
     int nodeAndItsDownEdgePos = position;
-    if (graphItem.isBranchItem() && !graphItem.asBranchItem().getBranch().isRootBranch()) {
+    if (graphItem.isBranchItem() && graphItem.asBranchItem().getBranch().isNonRootBranch()) {
       builder.consumeRightEdge(new GraphEdge(rowIndex, rowIndex), position);
       nodeAndItsDownEdgePos++;
     }

--- a/frontendUiTableImpl/build.gradle
+++ b/frontendUiTableImpl/build.gradle
@@ -12,6 +12,8 @@ dependencies {
   api project(':frontendUiApi')
 }
 
+applySubtypingChecker()
+
 apply plugin: 'org.jetbrains.intellij'
 disableIntellijTasks()
 intellij {

--- a/qual/src/main/java/com/virtuslab/qual/gitmachete/backend/api/ConfirmedNonRootBranch.java
+++ b/qual/src/main/java/com/virtuslab/qual/gitmachete/backend/api/ConfirmedNonRootBranch.java
@@ -1,0 +1,12 @@
+package com.virtuslab.qual.gitmachete.backend.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import com.virtuslab.qual.internal.SubtypingTop;
+
+@SubtypeOf(SubtypingTop.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface ConfirmedNonRootBranch {}

--- a/qual/src/main/java/com/virtuslab/qual/gitmachete/backend/api/ConfirmedRootBranch.java
+++ b/qual/src/main/java/com/virtuslab/qual/gitmachete/backend/api/ConfirmedRootBranch.java
@@ -1,0 +1,12 @@
+package com.virtuslab.qual.gitmachete.backend.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import com.virtuslab.qual.internal.SubtypingTop;
+
+@SubtypeOf(SubtypingTop.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface ConfirmedRootBranch {}

--- a/qual/src/main/java/com/virtuslab/qual/gitmachete/frontend/graph/api/elements/ConfirmedGraphEdge.java
+++ b/qual/src/main/java/com/virtuslab/qual/gitmachete/frontend/graph/api/elements/ConfirmedGraphEdge.java
@@ -1,0 +1,12 @@
+package com.virtuslab.qual.gitmachete.frontend.graph.api.elements;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import com.virtuslab.qual.internal.SubtypingTop;
+
+@SubtypeOf(SubtypingTop.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface ConfirmedGraphEdge {}

--- a/qual/src/main/java/com/virtuslab/qual/gitmachete/frontend/graph/api/elements/ConfirmedGraphNode.java
+++ b/qual/src/main/java/com/virtuslab/qual/gitmachete/frontend/graph/api/elements/ConfirmedGraphNode.java
@@ -1,0 +1,12 @@
+package com.virtuslab.qual.gitmachete.frontend.graph.api.elements;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import com.virtuslab.qual.internal.SubtypingTop;
+
+@SubtypeOf(SubtypingTop.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface ConfirmedGraphNode {}

--- a/qual/src/main/java/com/virtuslab/qual/gitmachete/frontend/graph/api/items/ConfirmedBranchItem.java
+++ b/qual/src/main/java/com/virtuslab/qual/gitmachete/frontend/graph/api/items/ConfirmedBranchItem.java
@@ -1,0 +1,12 @@
+package com.virtuslab.qual.gitmachete.frontend.graph.api.items;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import com.virtuslab.qual.internal.SubtypingTop;
+
+@SubtypeOf(SubtypingTop.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface ConfirmedBranchItem {}

--- a/qual/src/main/java/com/virtuslab/qual/gitmachete/frontend/graph/api/items/ConfirmedCommitItem.java
+++ b/qual/src/main/java/com/virtuslab/qual/gitmachete/frontend/graph/api/items/ConfirmedCommitItem.java
@@ -1,0 +1,12 @@
+package com.virtuslab.qual.gitmachete.frontend.graph.api.items;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import com.virtuslab.qual.internal.SubtypingTop;
+
+@SubtypeOf(SubtypingTop.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface ConfirmedCommitItem {}

--- a/qual/src/main/java/com/virtuslab/qual/internal/SubtypingBottom.java
+++ b/qual/src/main/java/com/virtuslab/qual/internal/SubtypingBottom.java
@@ -1,0 +1,32 @@
+package com.virtuslab.qual.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.DefaultFor;
+import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
+
+import com.virtuslab.qual.gitmachete.backend.api.ConfirmedNonRootBranch;
+import com.virtuslab.qual.gitmachete.backend.api.ConfirmedRootBranch;
+import com.virtuslab.qual.gitmachete.frontend.graph.api.elements.ConfirmedGraphEdge;
+import com.virtuslab.qual.gitmachete.frontend.graph.api.elements.ConfirmedGraphNode;
+import com.virtuslab.qual.gitmachete.frontend.graph.api.items.ConfirmedBranchItem;
+import com.virtuslab.qual.gitmachete.frontend.graph.api.items.ConfirmedCommitItem;
+
+// There needs to be single subtyping hierarchy with single bottom and top annotation,
+// otherwise Subtyping Checker would raise an error about multiple top/bottom types.
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({
+    // Despite having a unified type hierarchy, we're actually doing 3 completely independent checks here.
+    ConfirmedRootBranch.class,
+    ConfirmedNonRootBranch.class,
+    ConfirmedGraphNode.class,
+    ConfirmedGraphEdge.class,
+    ConfirmedBranchItem.class,
+    ConfirmedCommitItem.class,
+})
+@DefaultFor(TypeUseLocation.LOWER_BOUND)
+public @interface SubtypingBottom {}

--- a/qual/src/main/java/com/virtuslab/qual/internal/SubtypingTop.java
+++ b/qual/src/main/java/com/virtuslab/qual/internal/SubtypingTop.java
@@ -1,0 +1,12 @@
+package com.virtuslab.qual.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
+import org.checkerframework.framework.qual.SubtypeOf;
+
+@DefaultQualifierInHierarchy
+@SubtypeOf({})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface SubtypingTop {}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'git-machete-intellij-plugin'
 include 'logging'
 include 'binding'
+include 'qual'
 include 'gitCoreApi'
 include 'gitCoreJGit'
 include 'branchLayoutApi'

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.1.13'
+  PLUGIN_VERSION = '0.1.14'
 }


### PR DESCRIPTION
Essentially, if someone accidentally changed e.g. the following piece from `com.virtuslab.gitmachete.frontend.graph.impl.render.RenderPartColorIdProvider#getColorId`:

```java
    if (element.isNode()) {
      nodeIndex = element.asNode().getNodeIndex();
    } else { // isEdge
      nodeIndex = element.asEdge().getDownNodeIndex();
    }
```

into:

```java
    if (element.isNode()) {
      nodeIndex = element.asEdge().getDownNodeIndex(); // WHOOPS
    } else { // isEdge
      nodeIndex = element.asNode().getNodeIndex();
    }
```

then `SubtypingChecker` is gonna raise an error (quite cryptic one, alas):

```
/home/pawellipski/git-machete-intellij-plugin/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/render/RenderPartColorIdProvider.java:22: error: [[all, confirmedbranchitem, confirmedcommititem, confirmedgraphedge, confirmedgraphnode, confirmednonrootbranch, confirmedrootbranch, subtyping, subtypingbottom, subtypingtop]:contracts.precondition.not.satisfied] element.asEdge's precondition about 'element' is not satisfied
      nodeIndex = element.asEdge().getDownNodeIndex();
                                ^
/home/pawellipski/git-machete-intellij-plugin/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/render/RenderPartColorIdProvider.java:24: error: [[all, confirmedbranchitem, confirmedcommititem, confirmedgraphedge, confirmedgraphnode, confirmednonrootbranch, confirmedrootbranch, subtyping, subtypingbottom, subtypingtop]:contracts.precondition.not.satisfied] element.asNode's precondition about 'element' is not satisfied
      nodeIndex = element.asNode().getNodeIndex();
                                ^
```
