### PR TITLE
Defensively check presence of required DataKeys within actions

### DIFF
--- a/config/checker/com.intellij.astub
+++ b/config/checker/com.intellij.astub
@@ -245,10 +245,12 @@ class GuiUtils {
 }
 
 class CollectionComboBoxModel<T> {
-    @SafeEffect T getSelected();
-    @SafeEffect List<T> getItems();
-
+  // This method is annotated as `org.jetbrains.annotations.Nullable` already,
+  // but for some reason Checker unsoundly assumes that it's `NonNull` instead.
+  @Nullable @SafeEffect T getSelected();
+  @SafeEffect List<T> getItems();
 }
+
 
 @UIPackage package com.intellij.ui.border;
 @UIPackage package com.intellij.ui.breadcrumbs;

--- a/config/checkstyle/tree_walker_module_directives.xml
+++ b/config/checkstyle/tree_walker_module_directives.xml
@@ -63,8 +63,14 @@
 <module name="RedundantModifier"/>
 <module name="Regexp">
     <property name="illegalPattern" value="true"/>
-    <property name="format" value="(^|[^@])\binterface\s+[^I]"/>
     <property name="ignoreComments" value="true"/>
+    <property name="format" value="\bgetRequiredData\b"/>
+    <property name="message" value="Usage of prohibited AnActionEvent#getRequiredData, use AnActionEvent#getData and a @NonNull type-parameterized DataKey instead"/>
+</module>
+<module name="Regexp">
+    <property name="illegalPattern" value="true"/>
+    <property name="ignoreComments" value="true"/>
+    <property name="format" value="(^|[^@])\binterface\s+[^I]"/>
     <property name="message" value="Interface names must start with 'I'"/>
 </module>
 <module name="Regexp">

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/ActionUtils.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/ActionUtils.java
@@ -51,7 +51,7 @@ final class ActionUtils {
 
   static Option<BaseGitMacheteBranch> getSelectedMacheteBranch(AnActionEvent anActionEvent) {
     return getGitMacheteRepository(anActionEvent).flatMap(
-        repository -> getSelectedBranchName(anActionEvent).flatMap(branchName -> repository.getBranchByName(branchName)));
+        repository -> getSelectedBranchName(anActionEvent).flatMap(repository::getBranchByName));
   }
 
   static Option<GitRepository> getSelectedVcsRepository(AnActionEvent anActionEvent) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/BaseRebaseBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/BaseRebaseBranchOntoParentAction.java
@@ -96,7 +96,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends GitMacheteReposit
     if (gitMacheteRepository.isDefined() && gitRepository.isDefined()) {
       doRebase(project, gitMacheteRepository.get(), gitRepository.get(), branchToRebase);
     } else {
-      LOG.warn("Skipping the action because gitMacheteRepository and/or gitRepository is empty");
+      LOG.warn("Skipping the action because Git Machete repository and/or Git repository is undefined");
     }
   }
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/BaseSlideOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/BaseSlideOutBranchAction.java
@@ -56,7 +56,7 @@ public abstract class BaseSlideOutBranchAction extends GitMacheteRepositoryReady
     var branchLayout = ActionUtils.getBranchLayout(anActionEvent);
     var gitMacheteFilePath = ActionUtils.getGitMacheteFilePath(anActionEvent);
     if (branchLayout.isEmpty() || gitMacheteFilePath.isEmpty()) {
-      LOG.warn("Skipping the action because branchLayout and/or gitMacheteFilePath is empty");
+      LOG.warn("Skipping the action because branch layout and/or Git Machete file path is undefined");
       return;
     }
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/BaseSlideOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/BaseSlideOutBranchAction.java
@@ -56,11 +56,12 @@ public abstract class BaseSlideOutBranchAction extends GitMacheteRepositoryReady
     var branchLayout = ActionUtils.getBranchLayout(anActionEvent);
     var gitMacheteFilePath = ActionUtils.getGitMacheteFilePath(anActionEvent);
     if (branchLayout.isEmpty() || gitMacheteFilePath.isEmpty()) {
+      LOG.warn("Skipping the action because branchLayout and/or gitMacheteFilePath is empty");
       return;
     }
 
     try {
-      LOG.info(() -> "Sliding out '${branchName}' branch in memory");
+      LOG.info("Sliding out '${branchName}' branch in memory");
       var newBranchLayout = branchLayout.get().slideOut(branchName);
 
       var branchLayoutFileSaver = branchLayoutSaverFactory.create(gitMacheteFilePath.get());

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/CheckOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/CheckOutBranchAction.java
@@ -73,7 +73,7 @@ public class CheckOutBranchAction extends AnAction {
         // TODO (#95): on success, refresh only indication of the current branch
       }.queue();
     } else {
-      LOG.warn("Skipping the action because selectedVcsRepository is empty");
+      LOG.warn("Skipping the action because no VCS repository is selected");
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/CheckOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/CheckOutBranchAction.java
@@ -42,7 +42,7 @@ public class CheckOutBranchAction extends AnAction {
     var presentation = anActionEvent.getPresentation();
     // It's very unlikely that selectedBranchName is empty at this point since it's assigned directly before invoking this
     // action in GitMacheteGraphTable.GitMacheteGraphTableMouseAdapter.mouseClicked; still, it's better to be safe.
-    presentation.setEnabled(selectedBranchName.isDefined());
+    presentation.setEnabledAndVisible(selectedBranchName.isDefined());
   }
 
   @Override

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/GitMacheteRepositoryReadyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/GitMacheteRepositoryReadyAction.java
@@ -1,7 +1,5 @@
 package com.virtuslab.gitmachete.frontend.actions;
 
-import javax.swing.Icon;
-
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
@@ -12,16 +10,9 @@ import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
  * Expects DataKeys:
  * <ul>
  *  <li>{@link DataKeys#KEY_GIT_MACHETE_REPOSITORY}</li>
- *  <li>{@link DataKeys#KEY_IS_GIT_MACHETE_REPOSITORY_READY}</li>
  * </ul>
  */
 public abstract class GitMacheteRepositoryReadyAction extends DumbAwareAction {
-
-  public GitMacheteRepositoryReadyAction(String text, String description, Icon icon) {
-    super(text, description, icon);
-  }
-
-  public GitMacheteRepositoryReadyAction() {}
 
   @Override
   @UIEffect
@@ -29,13 +20,12 @@ public abstract class GitMacheteRepositoryReadyAction extends DumbAwareAction {
     super.update(anActionEvent);
 
     var presentation = anActionEvent.getPresentation();
-    var isReady = anActionEvent.getData(DataKeys.KEY_IS_GIT_MACHETE_REPOSITORY_READY);
-    if (isReady == null || !isReady) {
-      presentation.setEnabled(false);
-      presentation.setVisible(false);
-    } else {
+    if (ActionUtils.getGitMacheteRepository(anActionEvent).isDefined()) {
       presentation.setEnabled(true);
       presentation.setVisible(true);
+    } else {
+      presentation.setEnabled(false);
+      presentation.setVisible(false);
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseCurrentBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseCurrentBranchOntoParentAction.java
@@ -1,15 +1,15 @@
 package com.virtuslab.gitmachete.frontend.actions;
 
-import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getCurrentBaseMacheteNonRootBranch;
-import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getPresentMacheteRepository;
+import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getCurrentMacheteNonRootBranch;
+import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getGitMacheteRepository;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
+import io.vavr.control.Option;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.BaseGitMacheteNonRootBranch;
-import com.virtuslab.gitmachete.backend.api.IGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 import com.virtuslab.logger.IPrefixedLambdaLogger;
 import com.virtuslab.logger.PrefixedLambdaLoggerFactory;
@@ -18,7 +18,6 @@ import com.virtuslab.logger.PrefixedLambdaLoggerFactory;
  * Expects DataKeys:
  * <ul>
  *  <li>{@link DataKeys#KEY_GIT_MACHETE_REPOSITORY}</li>
- *  <li>{@link DataKeys#KEY_IS_GIT_MACHETE_REPOSITORY_READY}</li>
  *  <li>{@link CommonDataKeys#PROJECT}</li>
  * </ul>
  */
@@ -32,33 +31,29 @@ public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoPar
 
     Presentation presentation = anActionEvent.getPresentation();
     if (presentation.isEnabledAndVisible()) {
-      IGitMacheteRepository gitMacheteRepository = getPresentMacheteRepository(anActionEvent);
+      var currentBranch = getGitMacheteRepository(anActionEvent).flatMap(repository -> repository.getCurrentBranchIfManaged());
 
-      var currentBranchOption = gitMacheteRepository.getCurrentBranchIfManaged();
-
-      if (currentBranchOption.isEmpty()) {
+      if (currentBranch.isEmpty()) {
         presentation.setDescription("Current revision is not a branch managed by Git Machete");
         presentation.setEnabled(false);
 
-      } else if (currentBranchOption.get().isRootBranch()) {
-        presentation.setDescription("Can't rebase git machete root branch '${currentBranchOption.get().getName()}'");
+      } else if (currentBranch.get().isRootBranch()) {
+        presentation.setDescription("Can't rebase git machete root branch '${currentBranch.get().getName()}'");
         presentation.setEnabled(false);
 
       } else {
-        var upstreamBranch = currentBranchOption.get().asNonRootBranch().getUpstreamBranch();
-        presentation.setDescription("Rebase '${currentBranchOption.get().getName()}' onto '${upstreamBranch.getName()}'");
+        var upstreamBranch = currentBranch.get().asNonRootBranch().getUpstreamBranch();
+        presentation.setDescription("Rebase '${currentBranch.get().getName()}' onto '${upstreamBranch.getName()}'");
       }
     }
   }
 
-  /**
-   * Assumption to the following code is that the result of {@link com.virtuslab.gitmachete.backend.api.IGitMacheteRepository#getCurrentBranchIfManaged}
-   * is present and it is not a root branch because otherwise the user wouldn't be able to perform action in the first place
-   */
   @Override
   public void actionPerformed(AnActionEvent anActionEvent) {
-    LOG.debug(() -> "Performing");
-    BaseGitMacheteNonRootBranch baseGitMacheteBranch = getCurrentBaseMacheteNonRootBranch(anActionEvent);
-    doRebase(anActionEvent, baseGitMacheteBranch);
+    LOG.debug("Performing");
+    Option<BaseGitMacheteNonRootBranch> baseGitMacheteBranch = getCurrentMacheteNonRootBranch(anActionEvent);
+    if (baseGitMacheteBranch.isDefined()) {
+      doRebase(anActionEvent, baseGitMacheteBranch.get());
+    }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseCurrentBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseCurrentBranchOntoParentAction.java
@@ -55,7 +55,7 @@ public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoPar
     if (currentNonRootBranch.isDefined()) {
       doRebase(anActionEvent, currentNonRootBranch.get());
     } else {
-      LOG.warn("Skipping the action because currentNonRootBranch is empty");
+      LOG.warn("Skipping the action because current non root branch is undefined");
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseCurrentBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseCurrentBranchOntoParentAction.java
@@ -51,9 +51,11 @@ public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoPar
   @Override
   public void actionPerformed(AnActionEvent anActionEvent) {
     LOG.debug("Performing");
-    Option<BaseGitMacheteNonRootBranch> baseGitMacheteBranch = getCurrentMacheteNonRootBranch(anActionEvent);
-    if (baseGitMacheteBranch.isDefined()) {
-      doRebase(anActionEvent, baseGitMacheteBranch.get());
+    Option<BaseGitMacheteNonRootBranch> currentNonRootBranch = getCurrentMacheteNonRootBranch(anActionEvent);
+    if (currentNonRootBranch.isDefined()) {
+      doRebase(anActionEvent, currentNonRootBranch.get());
+    } else {
+      LOG.warn("Skipping the action because currentNonRootBranch is empty");
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseSelectedBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseSelectedBranchOntoParentAction.java
@@ -1,5 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions;
 
+import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getCurrentMacheteNonRootBranch;
 import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getSelectedMacheteBranch;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -8,6 +9,7 @@ import io.vavr.control.Option;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.BaseGitMacheteBranch;
+import com.virtuslab.gitmachete.backend.api.BaseGitMacheteNonRootBranch;
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 import com.virtuslab.logger.IPrefixedLambdaLogger;
 import com.virtuslab.logger.PrefixedLambdaLoggerFactory;
@@ -16,7 +18,6 @@ import com.virtuslab.logger.PrefixedLambdaLoggerFactory;
  * Expects DataKeys:
  * <ul>
  *  <li>{@link DataKeys#KEY_GIT_MACHETE_REPOSITORY}</li>
- *  <li>{@link DataKeys#KEY_IS_GIT_MACHETE_REPOSITORY_READY}</li>
  *  <li>{@link DataKeys#KEY_SELECTED_BRANCH_NAME}</li>
  *  <li>{@link CommonDataKeys#PROJECT}</li>
  * </ul>
@@ -48,19 +49,13 @@ public class RebaseSelectedBranchOntoParentAction extends BaseRebaseBranchOntoPa
     }
   }
 
-  /**
-   * Assumption to the following code is that the result of {@link ActionUtils#getSelectedMacheteBranch}
-   * is present and it is not a root branch because if it was not the user wouldn't be able to perform action in the first place
-   */
   @Override
   public void actionPerformed(AnActionEvent anActionEvent) {
-    LOG.debug(() -> "Performing");
-    var selectedGitMacheteBranchOption = getSelectedMacheteBranch(anActionEvent);
-    assert selectedGitMacheteBranchOption.isDefined() : "Can't get selected branch";
-    var baseGitMacheteBranch = selectedGitMacheteBranchOption.get();
-    assert baseGitMacheteBranch.isNonRootBranch() : "Selected branch is a root branch";
+    LOG.debug("Performing");
 
-    var branchToRebase = baseGitMacheteBranch.asNonRootBranch();
-    doRebase(anActionEvent, branchToRebase);
+    Option<BaseGitMacheteNonRootBranch> baseGitMacheteBranch = getCurrentMacheteNonRootBranch(anActionEvent);
+    if (baseGitMacheteBranch.isDefined()) {
+      doRebase(anActionEvent, baseGitMacheteBranch.get());
+    }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseSelectedBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RebaseSelectedBranchOntoParentAction.java
@@ -50,7 +50,8 @@ public class RebaseSelectedBranchOntoParentAction extends BaseRebaseBranchOntoPa
     if (selectedBranch.isDefined() && selectedBranch.get().isNonRootBranch()) {
       doRebase(anActionEvent, selectedBranch.get().asNonRootBranch());
     } else {
-      LOG.warn("Skipping the action because selectedBranch is empty or is a root branch: selectedBranch='${selectedBranch}'");
+      LOG.warn("Skipping the action because selected branch is undefined or is a root branch: " +
+          "selectedBranch='${selectedBranch}'");
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RefreshStatusAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/RefreshStatusAction.java
@@ -1,6 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions;
 
-import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getPresentGraphTableManager;
+import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getGraphTableManager;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -22,6 +22,6 @@ public class RefreshStatusAction extends AnAction implements DumbAware {
   @Override
   public void actionPerformed(AnActionEvent e) {
     LOG.debug("Performing");
-    getPresentGraphTableManager(e).updateAndRefreshGraphTableInBackground();
+    getGraphTableManager(e).updateAndRefreshGraphTableInBackground();
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutCurrentBranchAction.java
@@ -57,7 +57,7 @@ public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
     if (currentNonRootBranch.isDefined()) {
       doSlideOut(anActionEvent, currentNonRootBranch.get());
     } else {
-      LOG.warn("Skipping the action because currentNonRootBranch is empty");
+      LOG.warn("Skipping the action because current non-root branch is undefined");
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutCurrentBranchAction.java
@@ -53,9 +53,11 @@ public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
     LOG.debug("Performing");
-    Option<BaseGitMacheteNonRootBranch> baseGitMacheteBranch = getCurrentMacheteNonRootBranch(anActionEvent);
-    if (baseGitMacheteBranch.isDefined()) {
-      doSlideOut(anActionEvent, baseGitMacheteBranch.get());
+    Option<BaseGitMacheteNonRootBranch> currentNonRootBranch = getCurrentMacheteNonRootBranch(anActionEvent);
+    if (currentNonRootBranch.isDefined()) {
+      doSlideOut(anActionEvent, currentNonRootBranch.get());
+    } else {
+      LOG.warn("Skipping the action because currentNonRootBranch is empty");
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutSelectedBranchAction.java
@@ -33,14 +33,9 @@ public class SlideOutSelectedBranchAction extends BaseSlideOutBranchAction {
     var presentation = anActionEvent.getPresentation();
     if (presentation.isVisible()) {
       Option<BaseGitMacheteBranch> selectedBranch = getSelectedMacheteBranch(anActionEvent);
-      if (selectedBranch.isDefined()) {
-        if (selectedBranch.get().isRootBranch()) {
-          presentation.setEnabled(false);
-          presentation.setVisible(false);
-        } else {
-          var nonRootBranch = selectedBranch.get().asNonRootBranch();
-          presentation.setDescription("Slide out '${nonRootBranch.getName()}'");
-        }
+      if (selectedBranch.isDefined() && selectedBranch.get().isNonRootBranch()) {
+        var nonRootBranch = selectedBranch.get().asNonRootBranch();
+        presentation.setDescription("Slide out '${nonRootBranch.getName()}'");
       } else {
         presentation.setEnabled(false);
         presentation.setVisible(false);
@@ -53,9 +48,11 @@ public class SlideOutSelectedBranchAction extends BaseSlideOutBranchAction {
   public void actionPerformed(AnActionEvent anActionEvent) {
     LOG.debug("Performing");
 
-    var selectedMacheteBranch = getSelectedMacheteBranch(anActionEvent);
-    if (selectedMacheteBranch.isDefined() && !selectedMacheteBranch.get().isRootBranch()) {
-      doSlideOut(anActionEvent, selectedMacheteBranch.get().asNonRootBranch());
+    var selectedBranch = getSelectedMacheteBranch(anActionEvent);
+    if (selectedBranch.isDefined() && selectedBranch.get().isNonRootBranch()) {
+      doSlideOut(anActionEvent, selectedBranch.get().asNonRootBranch());
+    } else {
+      LOG.warn("Skipping the action because selectedBranch is empty or is a root branch: selectedBranch='${selectedBranch}'");
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutSelectedBranchAction.java
@@ -52,7 +52,8 @@ public class SlideOutSelectedBranchAction extends BaseSlideOutBranchAction {
     if (selectedBranch.isDefined() && selectedBranch.get().isNonRootBranch()) {
       doSlideOut(anActionEvent, selectedBranch.get().asNonRootBranch());
     } else {
-      LOG.warn("Skipping the action because selectedBranch is empty or is a root branch: selectedBranch='${selectedBranch}'");
+      LOG.warn("Skipping the action because selected branch is undefined or is a root branch: " +
+          "selectedBranch='${selectedBranch}'");
     }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/SlideOutSelectedBranchAction.java
@@ -8,7 +8,6 @@ import io.vavr.control.Option;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.BaseGitMacheteBranch;
-import com.virtuslab.gitmachete.backend.api.IGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 import com.virtuslab.logger.IPrefixedLambdaLogger;
 import com.virtuslab.logger.PrefixedLambdaLoggerFactory;
@@ -19,7 +18,6 @@ import com.virtuslab.logger.PrefixedLambdaLoggerFactory;
  *  <li>{@link DataKeys#KEY_BRANCH_LAYOUT}</li>
  *  <li>{@link DataKeys#KEY_GIT_MACHETE_FILE_PATH}</li>
  *  <li>{@link DataKeys#KEY_GIT_MACHETE_REPOSITORY}</li>
- *  <li>{@link DataKeys#KEY_IS_GIT_MACHETE_REPOSITORY_READY}</li>
  *  <li>{@link DataKeys#KEY_SELECTED_BRANCH_NAME}</li>
  *  <li>{@link CommonDataKeys#PROJECT}</li>
  * </ul>
@@ -50,19 +48,14 @@ public class SlideOutSelectedBranchAction extends BaseSlideOutBranchAction {
     }
   }
 
-  /**
-   * Assumption to the following code is that the result of {@link IGitMacheteRepository#getCurrentBranchIfManaged}
-   * is present and it is not a root branch because if it was not the user wouldn't be able to perform action in the first place
-   */
   @Override
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
-    LOG.debug(() -> "Performing");
-    var selectedMacheteBranchOption = getSelectedMacheteBranch(anActionEvent);
-    assert selectedMacheteBranchOption.isDefined() : "Can't get selected branch";
-    var baseGitMacheteBranch = selectedMacheteBranchOption.get();
-    assert baseGitMacheteBranch.isNonRootBranch() : "Selected branch is a root branch";
+    LOG.debug("Performing");
 
-    doSlideOut(anActionEvent, baseGitMacheteBranch.asNonRootBranch());
+    var selectedMacheteBranch = getSelectedMacheteBranch(anActionEvent);
+    if (selectedMacheteBranch.isDefined() && !selectedMacheteBranch.get().isRootBranch()) {
+      doSlideOut(anActionEvent, selectedMacheteBranch.get().asNonRootBranch());
+    }
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/ToggleListCommitsAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/ToggleListCommitsAction.java
@@ -1,6 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions;
 
-import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getPresentGraphTableManager;
+import static com.virtuslab.gitmachete.frontend.actions.ActionUtils.getGraphTableManager;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.ToggleAction;
@@ -22,14 +22,14 @@ public class ToggleListCommitsAction extends ToggleAction implements DumbAware {
 
   @Override
   public boolean isSelected(AnActionEvent e) {
-    return getPresentGraphTableManager(e).isListingCommits();
+    return getGraphTableManager(e).isListingCommits();
   }
 
   @Override
   @UIEffect
   public void setSelected(AnActionEvent e, boolean state) {
     LOG.debug("Triggered with state = ${state}");
-    var graphTableManager = getPresentGraphTableManager(e);
+    var graphTableManager = getGraphTableManager(e);
     graphTableManager.setListingCommits(state);
     graphTableManager.refreshGraphTable();
   }

--- a/frontendDataKeys/src/main/java/com/virtuslab/gitmachete/frontend/datakeys/DataKeys.java
+++ b/frontendDataKeys/src/main/java/com/virtuslab/gitmachete/frontend/datakeys/DataKeys.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 
 import com.intellij.openapi.actionSystem.DataKey;
 import git4idea.repo.GitRepository;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import com.virtuslab.branchlayout.api.IBranchLayout;
 import com.virtuslab.gitmachete.backend.api.IGitMacheteRepository;
@@ -18,14 +19,13 @@ public final class DataKeys {
 
   public static final DataKey<IBranchLayout> KEY_BRANCH_LAYOUT = DataKey.create("BRANCH_LAYOUT");
   public static final DataKey<Path> KEY_GIT_MACHETE_FILE_PATH = DataKey.create("GIT_MACHETE_FILE_PATH");
-  public static final DataKey<IGraphTableManager> KEY_GRAPH_TABLE_MANAGER = DataKey.create("GRAPH_TABLE_MANAGER");
   public static final DataKey<IGitMacheteRepository> KEY_GIT_MACHETE_REPOSITORY = DataKey.create("GIT_MACHETE_REPOSITORY");
-  public static final DataKey<Boolean> KEY_IS_GIT_MACHETE_REPOSITORY_READY = DataKey.create("IS_GIT_MACHETE_REPOSITORY_READY");
+  /** This key must always be available in the container hierarchy, and a DataProvider must always return a non-null value. */
+  public static final DataKey<@NonNull IGraphTableManager> KEY_GRAPH_TABLE_MANAGER = DataKey.create("GRAPH_TABLE_MANAGER");
   public static final DataKey<String> KEY_SELECTED_BRANCH_NAME = DataKey.create("SELECTED_BRANCH_NAME");
   public static final DataKey<GitRepository> KEY_SELECTED_VCS_REPOSITORY = DataKey.create("SELECTED_VCS_REPOSITORY");
 
   public static <T> Match.Case<String, T> typeSafeCase(DataKey<T> key, T value) {
     return Case($(key.getName()), value);
   }
-
 }

--- a/frontendDataKeys/src/main/java/com/virtuslab/gitmachete/frontend/datakeys/DataKeys.java
+++ b/frontendDataKeys/src/main/java/com/virtuslab/gitmachete/frontend/datakeys/DataKeys.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import com.intellij.openapi.actionSystem.DataKey;
 import git4idea.repo.GitRepository;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.virtuslab.branchlayout.api.IBranchLayout;
 import com.virtuslab.gitmachete.backend.api.IGitMacheteRepository;
@@ -17,13 +18,14 @@ import com.virtuslab.gitmachete.frontend.ui.api.table.IGraphTableManager;
 public final class DataKeys {
   private DataKeys() {}
 
-  public static final DataKey<IBranchLayout> KEY_BRANCH_LAYOUT = DataKey.create("BRANCH_LAYOUT");
-  public static final DataKey<Path> KEY_GIT_MACHETE_FILE_PATH = DataKey.create("GIT_MACHETE_FILE_PATH");
-  public static final DataKey<IGitMacheteRepository> KEY_GIT_MACHETE_REPOSITORY = DataKey.create("GIT_MACHETE_REPOSITORY");
+  public static final DataKey<@Nullable IBranchLayout> KEY_BRANCH_LAYOUT = DataKey.create("BRANCH_LAYOUT");
+  public static final DataKey<@Nullable Path> KEY_GIT_MACHETE_FILE_PATH = DataKey.create("GIT_MACHETE_FILE_PATH");
+  public static final DataKey<@Nullable IGitMacheteRepository> KEY_GIT_MACHETE_REPOSITORY = DataKey
+      .create("GIT_MACHETE_REPOSITORY");
   /** This key must always be available in the container hierarchy, and a DataProvider must always return a non-null value. */
   public static final DataKey<@NonNull IGraphTableManager> KEY_GRAPH_TABLE_MANAGER = DataKey.create("GRAPH_TABLE_MANAGER");
-  public static final DataKey<String> KEY_SELECTED_BRANCH_NAME = DataKey.create("SELECTED_BRANCH_NAME");
-  public static final DataKey<GitRepository> KEY_SELECTED_VCS_REPOSITORY = DataKey.create("SELECTED_VCS_REPOSITORY");
+  public static final DataKey<@Nullable String> KEY_SELECTED_BRANCH_NAME = DataKey.create("SELECTED_BRANCH_NAME");
+  public static final DataKey<@Nullable GitRepository> KEY_SELECTED_VCS_REPOSITORY = DataKey.create("SELECTED_VCS_REPOSITORY");
 
   public static <T> Match.Case<String, T> typeSafeCase(DataKey<T> key, T value) {
     return Case($(key.getName()), value);

--- a/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/root/IGitRepositorySelectionProvider.java
+++ b/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/root/IGitRepositorySelectionProvider.java
@@ -3,9 +3,11 @@ package com.virtuslab.gitmachete.frontend.ui.api.root;
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.MinLen;
 
 public interface IGitRepositorySelectionProvider {
+  @Nullable
   GitRepository getSelectedRepository();
 
   void addSelectionChangeObserver(IGitRepositorySelectionChangeObserver observer);

--- a/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/root/IGitRepositorySelectionProvider.java
+++ b/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/root/IGitRepositorySelectionProvider.java
@@ -2,13 +2,12 @@ package com.virtuslab.gitmachete.frontend.ui.api.root;
 
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
+import io.vavr.control.Option;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.MinLen;
 
 public interface IGitRepositorySelectionProvider {
-  @Nullable
-  GitRepository getSelectedRepository();
+  Option<GitRepository> getSelectedRepository();
 
   void addSelectionChangeObserver(IGitRepositorySelectionChangeObserver observer);
 

--- a/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/GitMachetePanel.java
+++ b/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/GitMachetePanel.java
@@ -68,7 +68,7 @@ public final class GitMachetePanel extends SimpleToolWindowPanel implements Data
   public Object getData(String dataId) {
     return Match(dataId).of(
         typeSafeCase(DataKeys.KEY_GRAPH_TABLE_MANAGER, gitMacheteGraphTableManager),
-        typeSafeCase(DataKeys.KEY_SELECTED_VCS_REPOSITORY, vcsRootComboBox.getSelectedRepository()),
+        typeSafeCase(DataKeys.KEY_SELECTED_VCS_REPOSITORY, vcsRootComboBox.getSelectedRepository().getOrNull()),
         typeSafeCase(CommonDataKeys.PROJECT, project),
         Case($(), (Object) null));
   }

--- a/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/VcsRootComboBox.java
+++ b/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/VcsRootComboBox.java
@@ -12,8 +12,8 @@ import com.intellij.ui.SimpleListCellRenderer;
 import com.intellij.util.SmartList;
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
+import io.vavr.control.Option;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.MinLen;
 
 import com.virtuslab.gitmachete.frontend.ui.api.root.IGitRepositorySelectionChangeObserver;
@@ -48,7 +48,7 @@ public final class VcsRootComboBox extends JComboBox<GitRepository> implements I
       getModel().update(repositories.asJavaMutable());
     }
 
-    boolean selectedItemUpdateRequired = !getModel().getItems().contains(selected);
+    boolean selectedItemUpdateRequired = selected == null || !getModel().getItems().contains(selected);
     if (selectedItemUpdateRequired) {
       getModel().setSelectedItem(repositories.get(0));
     } else {
@@ -59,9 +59,8 @@ public final class VcsRootComboBox extends JComboBox<GitRepository> implements I
   }
 
   @Override
-  @Nullable
-  public GitRepository getSelectedRepository() {
-    return getModel().getSelected();
+  public Option<GitRepository> getSelectedRepository() {
+    return Option.of(getModel().getSelected());
   }
 
   @Override

--- a/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/VcsRootComboBox.java
+++ b/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/VcsRootComboBox.java
@@ -13,6 +13,7 @@ import com.intellij.util.SmartList;
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.MinLen;
 
 import com.virtuslab.gitmachete.frontend.ui.api.root.IGitRepositorySelectionChangeObserver;
@@ -41,7 +42,7 @@ public final class VcsRootComboBox extends JComboBox<GitRepository> implements I
   public void updateRepositories(@MinLen(1) List<GitRepository> repositories) {
     // `com.intellij.ui.CollectionComboBoxModel.getSelected` must be performed
     // before `com.intellij.ui.MutableCollectionComboBoxModel.update`
-    // because the update method sets selected item to null
+    // because the update method sets the selected item to null
     GitRepository selected = getModel().getSelected();
     if (!getModel().getItems().equals(repositories)) {
       getModel().update(repositories.asJavaMutable());
@@ -58,6 +59,7 @@ public final class VcsRootComboBox extends JComboBox<GitRepository> implements I
   }
 
   @Override
+  @Nullable
   public GitRepository getSelectedRepository() {
     return getModel().getSelected();
   }

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
@@ -114,13 +114,11 @@ public final class GitMacheteGraphTable extends JBTable implements DataProvider 
   @Override
   @Nullable
   public Object getData(String dataId) {
-    var gitMacheteRepository = gitMacheteRepositoryRef.get();
     return Match(dataId).of(
         // Other keys are handled up the container hierarchy, in GitMachetePanel.
         typeSafeCase(DataKeys.KEY_BRANCH_LAYOUT, branchLayout),
         typeSafeCase(DataKeys.KEY_GIT_MACHETE_FILE_PATH, macheteFilePath),
-        typeSafeCase(DataKeys.KEY_IS_GIT_MACHETE_REPOSITORY_READY, gitMacheteRepository != null),
-        typeSafeCase(DataKeys.KEY_GIT_MACHETE_REPOSITORY, gitMacheteRepository),
+        typeSafeCase(DataKeys.KEY_GIT_MACHETE_REPOSITORY, gitMacheteRepositoryRef.get()),
         typeSafeCase(DataKeys.KEY_SELECTED_BRANCH_NAME, selectedBranchName),
         Case($(), (Object) null));
   }

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
@@ -90,7 +90,7 @@ public final class GitMacheteGraphTable extends JBTable implements DataProvider 
 
     ScrollingUtil.installActions(/* table */ this, /* cycleScrolling */ false);
 
-    addMouseListener(new GitMacheteGraphTableMouseAdapter(/* graphTable */ this));
+    addMouseListener(new GitMacheteGraphTableMouseAdapter());
   }
 
   @UIEffect
@@ -131,15 +131,11 @@ public final class GitMacheteGraphTable extends JBTable implements DataProvider 
     this.macheteFilePath = newMacheteFilePath;
   }
 
-  protected class GitMacheteGraphTableMouseAdapter extends MouseAdapter {
-
-    private final GitMacheteGraphTable graphTable;
-
+  private class GitMacheteGraphTableMouseAdapter extends MouseAdapter {
     @UIEffect
-    public GitMacheteGraphTableMouseAdapter(GitMacheteGraphTable graphTable) {
-      this.graphTable = graphTable;
-    }
+    GitMacheteGraphTableMouseAdapter() {}
 
+    @Override
     @UIEffect
     public void mouseClicked(MouseEvent e) {
       Point point = e.getPoint();
@@ -163,10 +159,10 @@ public final class GitMacheteGraphTable extends JBTable implements DataProvider 
       if (SwingUtilities.isRightMouseButton(e)) {
         ActionGroup contextMenuActionGroup = (ActionGroup) actionManager.getAction(ActionGroupIds.ACTION_GROUP_CONTEXT_MENU);
         ActionPopupMenu actionPopupMenu = actionManager.createActionPopupMenu(ActionPlaces.UNKNOWN, contextMenuActionGroup);
-        actionPopupMenu.getComponent().show(graphTable, (int) point.getX(), (int) point.getY());
+        actionPopupMenu.getComponent().show(GitMacheteGraphTable.this, (int) point.getX(), (int) point.getY());
       } else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2 && !e.isConsumed()) {
         e.consume();
-        DataContext dataContext = DataManager.getInstance().getDataContext(graphTable);
+        DataContext dataContext = DataManager.getInstance().getDataContext(GitMacheteGraphTable.this);
         AnActionEvent actionEvent = AnActionEvent.createFromDataContext(ActionPlaces.UNKNOWN, new Presentation(), dataContext);
         actionManager.getAction(ACTION_CHECK_OUT).actionPerformed(actionEvent);
       }

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTableManager.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTableManager.java
@@ -216,7 +216,7 @@ public final class GitMacheteGraphTableManager implements IGraphTableManager {
           graphTable.setMacheteFilePath(macheteFilePath);
           gitMacheteRepositoryRef.set(gitMacheteRepositoryFactory.create(mainDirectoryPath, gitDirectoryPath, branchLayout));
         } else {
-          LOG.warn("Skipping the repository update because gitRepository is empty");
+          LOG.warn("Skipping the repository update because no VCS repository is selected");
         }
       } catch (Exception e) {
         LOG.error("Unable to create Git Machete repository", e);

--- a/logging/src/main/java/com/virtuslab/logger/IPrefixedLambdaLogger.java
+++ b/logging/src/main/java/com/virtuslab/logger/IPrefixedLambdaLogger.java
@@ -8,11 +8,7 @@ public interface IPrefixedLambdaLogger {
   void debug(String format);
   void debug(Supplier<String> msgSupplier);
   void info(String format);
-  void info(Supplier<String> msgSupplier);
   void warn(String format);
-  void warn(Supplier<String> msgSupplier);
   void error(String format);
-  void error(Supplier<String> msgSupplier);
   void error(String format, Throwable t);
-  void error(Supplier<String> msgSupplier, Throwable t);
 }

--- a/logging/src/main/java/com/virtuslab/logger/PrefixedLambdaLogger.java
+++ b/logging/src/main/java/com/virtuslab/logger/PrefixedLambdaLogger.java
@@ -61,18 +61,8 @@ public class PrefixedLambdaLogger implements IPrefixedLambdaLogger {
   }
 
   @Override
-  public void info(Supplier<String> msgSupplier) {
-    logger.info(() -> getLogMessagePrefix() + msgSupplier.get());
-  }
-
-  @Override
   public void warn(String format) {
     logger.warn(() -> getLogMessagePrefix() + format);
-  }
-
-  @Override
-  public void warn(Supplier<String> msgSupplier) {
-    logger.warn(() -> getLogMessagePrefix() + msgSupplier.get());
   }
 
   @Override
@@ -81,17 +71,7 @@ public class PrefixedLambdaLogger implements IPrefixedLambdaLogger {
   }
 
   @Override
-  public void error(Supplier<String> msgSupplier) {
-    logger.error(() -> getLogMessagePrefix() + msgSupplier.get());
-  }
-
-  @Override
   public void error(String format, Throwable t) {
     logger.error(() -> getLogMessagePrefix() + format, t);
-  }
-
-  @Override
-  public void error(Supplier<String> msgSupplier, Throwable t) {
-    logger.error(() -> getLogMessagePrefix() + msgSupplier.get(), t);
   }
 }

--- a/scripts/enforce-data-keys-javadoc-for-actions
+++ b/scripts/enforce-data-keys-javadoc-for-actions
@@ -10,5 +10,5 @@ if git grep --files-without-match '^ \* Expects DataKeys:$' -- '*Action.java'; t
 fi
 
 if git grep --files-with-match 'getProject' -- '*Action.java' | xargs git grep --files-without-match '^ \*  <li>{@link CommonDataKeys#PROJECT}</li>$' -- ; then
-  die 'Provide a Javadoc documenting the `DataKey` (`CommonDataKeys#PROJECT`) required by the method `com.intellij.openapi.actionSystem.AnActionEvent#getProject` invoked in the above files.'
+  die 'Provide a Javadoc documenting the `DataKey` (`CommonDataKeys#PROJECT`) required by the method `com.intellij.openapi.actionSystem.AnActionEvent#getProject` invoked (possibly indirectly via `ActionUtils#getProject`) in the above files.'
 fi

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.1.14'
+  PLUGIN_VERSION = '0.1.15'
 }


### PR DESCRIPTION
Try e.g. clicking super-fast on the Refresh or Toggle List Commits button before and after this change ;)

My aim was to remove all but the really really safe assertions from `frontendActions` (only 2 are left, in `ActionUtils`)