### PR TITLE
Extract user-facing strings from plugin.xml to a resource bundle

### DIFF
--- a/frontendActions/src/main/resources/actions/ResourceBundle.properties
+++ b/frontendActions/src/main/resources/actions/ResourceBundle.properties
@@ -1,0 +1,33 @@
+
+# Context menu
+
+action.GitMachete.CheckOutBranchAction.text=Git Machete: Check Out Selected Branch
+action.GitMachete.CheckOutBranchAction.GitMacheteContextMenu.text=_Check Out Branch
+action.GitMachete.CheckOutBranchAction.description=Check out this branch
+
+action.GitMachete.RebaseSelectedBranchOntoParentAction.text=Git Machete: Rebase Selected Branch Onto Parent
+action.GitMachete.RebaseSelectedBranchOntoParentAction.GitMacheteContextMenu.text=_Rebase Branch Onto Parent
+action.GitMachete.RebaseSelectedBranchOntoParentAction.description=Rebase this branch onto parent
+
+action.GitMachete.SlideOutSelectedBranchAction.text=Git Machete: Slide Out Selected Branch
+action.GitMachete.SlideOutSelectedBranchAction.GitMacheteContextMenu.text=_Slide Out Branch
+action.GitMachete.SlideOutSelectedBranchAction.description=Slide out this branch
+
+
+# Toolbar
+
+action.GitMachete.RefreshStatusAction.text=Git Machete: Refresh Status
+action.GitMachete.RefreshStatusAction.GitMacheteToolbar.text=Refresh Status
+action.GitMachete.RefreshStatusAction.description=Refresh status
+
+action.GitMachete.ToggleListingCommitsAction.text=Git Machete: Toggle Listing Commits
+action.GitMachete.ToggleListingCommitsAction.GitMacheteToolbar.text=Toggle Listing Commits
+action.GitMachete.ToggleListingCommitsAction.description=Toggle listing commits
+
+action.GitMachete.RebaseCurrentBranchOntoParentAction.text=Git Machete: Rebase Current Branch Onto Parent
+action.GitMachete.RebaseCurrentBranchOntoParentAction.GitMacheteToolbar.text=Rebase Current Branch Onto Parent
+action.GitMachete.RebaseCurrentBranchOntoParentAction.description=Rebase current branch onto parent
+
+action.GitMachete.SlideOutCurrentBranchAction.text=Git Machete: Slide Out Current Branch
+action.GitMachete.SlideOutCurrentBranchAction.GitMacheteToolbar.text=Slide Out Current Branch
+action.GitMachete.SlideOutCurrentBranchAction.description=Slide out current branch

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,63 +18,51 @@
                             predicateClassName="com.virtuslab.gitmachete.frontend.ui.impl.root.GitMacheteVisibilityPredicate"/>
     </extensions>
 
+    <resource-bundle>actions.ResourceBundle</resource-bundle>
+
     <actions>
         <group id="GitMachete.ContextMenu">
             <!-- These actions are used in right-click context menu on branches. -->
             <action id="GitMachete.CheckOutBranchAction"
-                    class="com.virtuslab.gitmachete.frontend.actions.CheckOutBranchAction"
-                    text="Git Machete: Check Out Selected Branch"
-                    description="Check out this branch">
-                <override-text place="GitMacheteContextMenu" text="_Check Out Branch"/>
+                    class="com.virtuslab.gitmachete.frontend.actions.CheckOutBranchAction">
+                <override-text place="GitMacheteContextMenu"/>
             </action>
 
             <action id="GitMachete.RebaseSelectedBranchOntoParentAction"
-                    class="com.virtuslab.gitmachete.frontend.actions.RebaseSelectedBranchOntoParentAction"
-                    text="Git Machete: Rebase Selected Branch Onto Parent"
-                    description="Rebase this branch onto parent">
-                <override-text place="GitMacheteContextMenu" text="_Rebase Branch Onto Parent"/>
+                    class="com.virtuslab.gitmachete.frontend.actions.RebaseSelectedBranchOntoParentAction">
+                <override-text place="GitMacheteContextMenu"/>
             </action>
 
             <action id="GitMachete.SlideOutSelectedBranchAction"
-                    class="com.virtuslab.gitmachete.frontend.actions.SlideOutSelectedBranchAction"
-                    text="Git Machete: Slide Out Selected Branch"
-                    description="Slide out this branch">
-                <override-text place="GitMacheteContextMenu" text="_Slide Out Branch"/>
+                    class="com.virtuslab.gitmachete.frontend.actions.SlideOutSelectedBranchAction">
+                <override-text place="GitMacheteContextMenu"/>
             </action>
         </group>
 
         <group id="GitMachete.Toolbar">
             <action id="GitMachete.RefreshStatusAction"
                     class="com.virtuslab.gitmachete.frontend.actions.RefreshStatusAction"
-                    text="Git Machete: Refresh Status"
-                    description="Refresh status"
                     icon="AllIcons.Actions.Refresh"
                     use-shortcut-of="Refresh">
-                <override-text place="GitMacheteToolbar" text="Refresh Status"/>
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.ToggleListingCommitsAction"
                     class="com.virtuslab.gitmachete.frontend.actions.ToggleListingCommitsAction"
-                    text="Git Machete: Toggle Listing Commits"
-                    description="Toggle listing commits"
                     icon="AllIcons.Actions.ShowHiddens">
-                <override-text place="GitMacheteToolbar" text="Toggle Listing Commits"/>
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.RebaseCurrentBranchOntoParentAction"
                     class="com.virtuslab.gitmachete.frontend.actions.RebaseCurrentBranchOntoParentAction"
-                    text="Git Machete: Rebase Current Branch Onto Parent"
-                    description="Rebase current branch onto parent"
                     icon="AllIcons.Actions.Menu_cut">
-                <override-text place="GitMacheteToolbar" text="Rebase Current Branch Onto Parent"/>
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.SlideOutCurrentBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.SlideOutCurrentBranchAction"
-                    text="Git Machete: Slide Out Current Branch"
-                    description="Slide out current branch"
                     icon="AllIcons.Actions.GC">
-                <override-text place="GitMacheteToolbar" text="Slide Out Current Branch"/>
+                <override-text place="GitMacheteToolbar"/>
             </action>
         </group>
     </actions>

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.1.17'
+  PLUGIN_VERSION = '0.1.18'
 }


### PR DESCRIPTION
Actually, #104 is already resolved for some time, in favor of `Git Machete` (Title Case, as recommended in https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_configuration_file.html)