### PR TITLE
[DO NOT MERGE] [BUG DEMO] Checker allows to unsoundly override a @SafeEffect method as @UIEffect

### DIFF
--- a/config/checker/com.intellij.astub
+++ b/config/checker/com.intellij.astub
@@ -136,6 +136,13 @@ interface Application {
 @UIPackage package com.intellij.openapi.paths;
 
 
+package com.intellij.openapi.progress;
+
+interface Progressive {
+  @SafeEffect void run(ProgressIndicator indicator);
+}
+
+
 package com.intellij.openapi.project;
 
 @UI class DumbAwareToggleAction {}

--- a/frontendUiTableImpl/src/main/java/bugdemo/IBaseInterface.java
+++ b/frontendUiTableImpl/src/main/java/bugdemo/IBaseInterface.java
@@ -1,0 +1,5 @@
+package bugdemo;
+
+public interface IBaseInterface {
+  void run();
+}

--- a/frontendUiTableImpl/src/main/java/bugdemo/IDerivedInterface.java
+++ b/frontendUiTableImpl/src/main/java/bugdemo/IDerivedInterface.java
@@ -1,0 +1,5 @@
+package bugdemo;
+
+interface IDerivedInterface extends IBaseInterface { // this could as well be class, same effect can be observed
+  // void run(); // will unsuppress the (expected) compilation error in ConcreteClass if uncommented
+}

--- a/frontendUiTableImpl/src/main/java/bugdemo/ImplementingClass.java
+++ b/frontendUiTableImpl/src/main/java/bugdemo/ImplementingClass.java
@@ -1,0 +1,15 @@
+package bugdemo;
+
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+
+public class ImplementingClass implements IDerivedInterface {
+  @Override
+  // This should cause a compilation error
+  // `error: [[all, guieffect]:override.effect.invalid] A method override may only be @UI if it overrides an @UI method.`
+  // but it doesn't...
+  @UIEffect
+  public void run() {}
+  // Now try either extending BaseInterface directly instead of via DerivedInterface,
+  // or adding a no-op override (`void run();`) to DerivedInterface -
+  // and you'll get the compilation error, as expected.
+}

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.2.0'
+  PLUGIN_VERSION = '0.2.1'
 }


### PR DESCRIPTION
....if the method is inherited via another class/interface

A demo for Checker maintainers (https://github.com/typetools/checker-framework/issues/3287), can be extracted to a separate project if needed