### PR TITLE
Provide a distiction of pre-release versions for non-master builds and release versions for master builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Other coding conventions include:
 
 ## Rebuild the CI base image
 
-To push the rebuilt image, you need write access to [`gitmachete` organization on Docker Hub](https://hub.docker.com/orgs/gitmachete).
+To push the rebuilt image, you need a write access to [`gitmachete` organization on Docker Hub](https://hub.docker.com/orgs/gitmachete).
 
 ```
 DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build -t gitmachete/intellij-plugin-ci .
@@ -45,13 +45,23 @@ We follow [Semantic versioning](semver.org):
 
 * MAJOR version must be bumped for each plugin release that stops supporting any IDEA build (typically when `sinceBuild` is increased). <br/>
   This does not apply to 0->1 major version transition, which is going to happen when the plugin's compatibility range is considered stable.
-* MINOR version must be bumped for each plugin release that either adds a new user-facing feature,
+* MINOR version must be bumped for each plugin release that either adds a new user-facing feature
   or starts supporting a new quarterly (`year.number`) IDEA build (typically when `untilBuild` is increased).
 * PATCH version must be bumped for each plugin release that adds no new user-facing features
   and doesn't change the range of supported IDEA builds.
-* Pre-release version (`d` in `a.b.c-d`) is bumped for each PR merged to `develop` (see PRs & releases below). <br/>
-  Released plugin versions must **never** have a pre-release version indicator (are always of the form `a.b.c`). <br/>
+* Pre-release version (`d` in `a.b.c-d`) must be bumped for each PR merged to `develop` (see PRs & releases below). <br/>
+  Released plugin versions must **never** have a pre-release version indicator (must be of the form `a.b.c`). <br/>
   Non-released plugin versions must **always** have a pre-release version indicator.
+
+### Sample sequence of versions between releases
+
+After a release e.g. `1.0.3`, we might have the following sequence of versions:
+* `1.0.4-1` - note that pre-release identifiers start with one, not zero
+* `1.0.4-2`
+* `1.0.4-3`
+* `1.1.0-1` - coz we've just adding new feature, the new release won't be a PATCH-level anymore, but MINOR-level one
+* `1.1.0-2`
+* `1.1.0` - finally releasing as minor release; as a consequence, `1.0.4` never actually gets released
 
 
 ## PRs & releases
@@ -60,7 +70,7 @@ Each PR must bump the version (see [version.gradle](version.gradle)) comparing t
 
 Each regular (non-hotfix, non-release) PR is ultimately merged to `develop` and must have a non-empty pre-release version. <br/>
 Stacked PRs (Y -> X -> `develop`) are never merged until their base is finally changed to `develop`.
-They're must instead be retargeted to its base's base once their base branch is merged itself (Y -> X -> `develop` => X gets merged => Y -> `develop`).
+They must instead be retargeted to its base's base once their base branch is merged itself (Y -> X -> `develop` => X gets merged => Y -> `develop`).
 
 Each release PR (from `develop` to `master`) must not have a pre-release version.
 Once the release PR is merged, `master` is built. <br/>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,4 +82,3 @@ They are likely going to require us to allow either of:
   (during a release, `develop` gets merged to the hotfixed `master` instead of `master` getting FFed to match `develop`) OR
 * rebasing the `develop` history since the latest release over the hotfixed `master`
   (so that `develop` commit remains a descendant of hotfixed `master`, and thus `master` can be FFed to match `develop` during a release)
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,15 @@ ln -s ../../scripts/run-pre-build-checks .git/hooks/pre-commit
 Most non-standard/project-specific conventions are enforced by:
 
 * [pre-commit hook](scripts/run-pre-build-checks)
-* [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle) for Java code formatting ([config](config/spotless/formatting-rules.xml))
-* [Checkstyle](https://checkstyle.sourceforge.io/) for code style/detecting basic smells ([config](config/checkstyle/checkstyle.xml))
-* [Checker Framework](https://checkerframework.org/manual/) for formal correctness, esp. wrt. null safety and UI thread handling (most config in [build.gradle](build.gradle), stubs in [config/checker/](config/checker))
+* [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle) for Java code formatting (see [Eclipse-compatible config](config/spotless/formatting-rules.xml))
+* [Checkstyle](https://checkstyle.sourceforge.io/) for code style/detecting basic smells (see [top-level config](config/checkstyle/checkstyle.xml))
+* [Checker Framework](https://checkerframework.org/manual/) for formal correctness, esp. wrt. null safety and UI thread handling
+  (most config in [build.gradle](build.gradle), stubs in [config/checker/](config/checker))
 
 Other coding conventions include:
 
-* Don't write nullary lambdas in `receiver::method` notation, use explicit `() -> receiver.method()` notation instead.
-  `::` notation is confusing when applied to parameterless lambdas, it suggests a unary lambda.
+* Don't write nullary lambdas in `receiver::method` notation, use explicit `() -> receiver.method()` notation instead. <br/>
+  `::` notation is confusing when applied to parameterless lambdas, as it suggests a unary lambda.
 
 
 ## Rebuild the CI base image
@@ -36,3 +37,39 @@ To push the rebuilt image, you need write access to [`gitmachete` organization o
 DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build -t gitmachete/intellij-plugin-ci .
 docker push gitmachete/intellij-plugin-ci
 ```
+
+
+## Versioning
+
+We follow [Semantic versioning](semver.org):
+
+* MAJOR version must be bumped for each plugin release that stops supporting any IDEA build (typically when `sinceBuild` is increased). <br/>
+  This does not apply to 0->1 major version transition, which is going to happen when the plugin's compatibility range is considered stable.
+* MINOR version must be bumped for each plugin release that either adds a new user-facing feature,
+  or starts supporting a new quarterly (`year.number`) IDEA build (typically when `untilBuild` is increased).
+* PATCH version must be bumped for each plugin release that adds no new user-facing features
+  and doesn't change the range of supported IDEA builds.
+* Pre-release version (`d` in `a.b.c-d`) is bumped for each PR merged to `develop` (see PRs & releases below). <br/>
+  Released plugin versions must **never** have a pre-release version indicator (are always of the form `a.b.c`). <br/>
+  Non-released plugin versions must **always** have a pre-release version indicator.
+
+
+## PRs & releases
+
+Each PR must bump the version (see [version.gradle](version.gradle)) comparing to its base.
+
+Each regular (non-hotfix, non-release) PR is ultimately merged to `develop` and must have a non-empty pre-release version. <br/>
+Stacked PRs (Y -> X -> `develop`) are never merged until their base is finally changed to `develop`.
+They're must instead be retargeted to its base's base once their base branch is merged itself (Y -> X -> `develop` => X gets merged => Y -> `develop`).
+
+Each release PR (from `develop` to `master`) must not have a pre-release version.
+Once the release PR is merged, `master` is built. <br/>
+**TODO (#261): ** After a manual approval, the `master` build publishes the plugin to JetBrains marketplace.
+
+TBD: flow for hotfix PRs (PRs to `master` but NOT from `develop`).
+They are likely going to require us to allow either of:
+* non-linear history on `master`
+  (during a release, `develop` gets merged to the hotfixed `master` instead of `master` getting FFed to match `develop`) OR
+* rebasing the `develop` history since the latest release over the hotfixed `master`
+  (so that `develop` commit remains a descendant of hotfixed `master`, and thus `master` can be FFed to match `develop` during a release)
+

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ SLF4J logging in this plugin has the following categories:
 * `frontendUiTable`
 * `gitCore`
 
-By default, IntelliJ logs everything with level `INFO` and above into `idea.log` file.
+By default, IntelliJ logs everything with level `INFO` and above into `idea.log` file. <br/>
 The exact location depends on IntelliJ version and OS, check `Help` -> `Show Log in Files` to find out.
 
-To enable logging in `DEBUG` level, add selected categories to list in `Help` -> `Diagnostic Tools` -> `Debug Log Settings`.
+To enable logging in `DEBUG` level, add selected categories to list in `Help` -> `Diagnostic Tools` -> `Debug Log Settings`. <br/>
 The standard practice in Java logging is to use fully-qualified name of each class as category;
 in our case, however, we're only ever using the categories provided above.
 
@@ -35,10 +35,11 @@ in our case, however, we're only ever using the categories provided above.
 * IntelliJ 2019.3+ Community Edition/Ultimate
 
   * Install [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok/)
-  * Enable annotation processing (for Lombok): `File` -> `Settings` -> `Build`, `Execution`, `Deployment` -> `Compiler` -> `Annotation Processors` -> `Enable Annotation Processing`
+  * Enable annotation processing (for Lombok):
+    `File` -> `Settings` -> `Build`, `Execution`, `Deployment` -> `Compiler` -> `Annotation Processors` -> `Enable Annotation Processing`
   * Set Project SDK to JDK 11: `Project Structure` -> `Project`
 
-Consider increasing maximum heap size for the IDE (the default value is 2048 MB). Go to `Help` -> `Change Memory Settings` for this.
+Consider increasing maximum heap size for the IDE (the default value is 2048 MB) under `Help` -> `Change Memory Settings`.
 
 
 ## Run & debug
@@ -55,7 +56,7 @@ The resulting file will be available under `build/distributions/`.
 
 ## Install snapshot build of the plugin from CI
 
-Download the zip file from the artifacts of the given build in [CircleCI](https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin).
+Download the zip file from the artifacts of the given build in [CircleCI](https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin). <br/>
 Go to `File` -> `Settings` -> `Plugins` -> `(gear icon)` -> `Install Plugin from Disk...`, select the zip and restart IDE.
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ if (System.getenv('CI') == 'true') {
 import org.ajoberstar.grgit.Grgit
 
 allprojects {
-  apply plugin:'org.ajoberstar.grgit'
-  def git = Grgit.open(currentDir: project.rootDir)
+  apply plugin: 'org.ajoberstar.grgit'
+  def git = Grgit.open(currentDir: rootDir)
   def maybeSnapshot = System.getenv('CIRCLE_BRANCH') == 'master' ? '' : '-SNAPSHOT'
   def shortCommitHash = "+git.${git.head().abbreviatedId}"
   def maybeDirty = git.status().clean ? '' : '-dirty'

--- a/scripts/enforce-pre-release-version-correct-use
+++ b/scripts/enforce-pre-release-version-correct-use
@@ -18,10 +18,9 @@ if [[ ${CI_PULL_REQUEST-} ]]; then
   fi
 
 elif [[ ${CIRCLE_BRANCH-} ]]; then
-  if [[ $CIRCLE_BRANCH == master && $head_pre_release ]]; then
-    die 'Pre-release version is not allowed on master branch tip'
+  if [[ ( $CIRCLE_BRANCH == master || $CIRCLE_BRANCH == release/* || $CIRCLE_BRANCH == hotfix/* ) && $head_pre_release ]]; then
+    die 'Pre-release version is not allowed on master/release/hotfix branch tip'
   elif [[ $CIRCLE_BRANCH != master && -z $head_pre_release ]]; then
-    # This case won't occur as for now since we don't build anything but master branch and PRs.
-    die 'Non-master branch tip must have a pre-release version (a.b.c-d, not a.b.c)'
+    die 'Non-master/release/hotfix branch tip must have a pre-release version (a.b.c-d, not a.b.c)'
   fi
 fi

--- a/scripts/enforce-pre-release-version-correct-use
+++ b/scripts/enforce-pre-release-version-correct-use
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
+source "$self_dir"/utils.sh
+
+parse_version_from_current_wd head
+
+if [[ ${CI_PULL_REQUEST-} ]]; then
+  # In case of a PR build, CI_PULL_REQUEST should be a link of the form https://github.com/VirtusLab/git-machete-intellij-plugin/pull/123
+  pr_num=${CI_PULL_REQUEST##*/}
+  base_branch=$(hub pr show --format=%B "$pr_num")
+  if [[ $base_branch == master && $head_pre_release ]]; then
+    die 'Pre-release version is not allowed on a PR to master'
+  elif [[ $base_branch != master && -z $head_pre_release ]]; then
+    die "A PR to $base_branch (!= master) must have a pre-release version (a.b.c-d, not a.b.c)"
+  fi
+
+elif [[ ${CIRCLE_BRANCH-} ]]; then
+  if [[ $CIRCLE_BRANCH == master && $head_pre_release ]]; then
+    die 'Pre-release version is not allowed on master branch tip'
+  elif [[ $CIRCLE_BRANCH != master && -z $head_pre_release ]]; then
+    # This case won't occur as for now since we don't build anything but master branch and PRs.
+    die 'Non-master branch tip must have a pre-release version (a.b.c-d, not a.b.c)'
+  fi
+fi

--- a/scripts/enforce-version-bump
+++ b/scripts/enforce-version-bump
@@ -46,6 +46,18 @@ parse_version_from_git_revision base "$base_commit_short_hash"
   die "Minor version $head_minor must not be lower than $base_minor in $base_desc"
 
 [[ $head_patch -gt $base_patch ]] && exit 0
-[[ $head_patch -eq $base_patch ]] && \
-  die "Version must not be identical as in $base_desc" || \
-  die "Patch version $head_patch must be higher than $base_patch in $base_desc"
+[[ $head_patch -eq $base_patch ]] || \
+  die "Patch version $head_patch must not be lower than $base_patch in $base_desc"
+
+# According to semver spec, a missing pre-release version is considered higher than any defined pre-release version (1.2.3 is higher than 1.2.3-rc999).
+head_pre_release_cmp=${head_pre_release:-999999}
+base_pre_release_cmp=${base_pre_release:-999999}
+[[ $head_pre_release_cmp -gt $base_pre_release_cmp ]] && exit 0
+
+if [[ $head_pre_release -eq $base_pre_release ]]; then
+  die "Version must not be identical as in $base_desc"
+elif ! [[ $base_pre_release ]]; then
+  die "Unreleased version $head_version cannot follow a released version $base_version in $base_desc"
+else
+  die "Pre-release version $head_pre_release must not be lower than $base_pre_release in $base_desc"
+fi

--- a/scripts/enforce-version-bump
+++ b/scripts/enforce-version-bump
@@ -5,29 +5,44 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/utils.sh
 
+function local_base_revision_fallback() {
+  current_branch=$(git symbolic-ref --quiet --short HEAD)
+  if [[ $current_branch == develop || $current_branch == release/* || $current_branch == hotfix/* ]]; then
+    echo master
+  else
+    echo develop
+  fi
+}
+
 if [[ ${CI_PULL_REQUEST-} ]]; then
   # In case of a PR build, CI_PULL_REQUEST should be a link of the form https://github.com/VirtusLab/git-machete-intellij-plugin/pull/123
   pr_num=${CI_PULL_REQUEST##*/}
-  base_branch=$(hub pr show --format=%B "$pr_num")
-  git fetch --quiet origin "$base_branch"
-  base_revision="origin/$base_branch"
+  # CircleCI fetches all the branches from the repo in the Checkout step (but only into refs/remotes, not into refs/heads)
+  base_revision="origin/$(hub pr show --format=%B "$pr_num")"
+
+elif [[ ${CIRCLE_BRANCH-} == develop || ${CIRCLE_BRANCH-} == release/* || ${CIRCLE_BRANCH-} == hotfix/* ]]; then
+  # Develop, hotfix or release build on CI, let's compare to master.
+  base_revision=origin/master
 
 elif [[ ${CIRCLE_BRANCH-} == master ]]; then
   # Master build on CI, no version check needed.
-  # Note: we don't run builds other than for PRs and for master branch (e.g. pre-PR branch builds).
   exit 0
+
+elif [[ ${CIRCLE_BRANCH-} ]]; then
+  # Non-PR, non-master/develop, non-release/hotfix branch build on CI, let's compare to develop.
+  base_revision=origin/develop
 
 elif git machete show up &>/dev/null; then
   # A local run.
   base_revision=$(git machete show up 2>/dev/null)
 
 elif command -v hub &>/dev/null; then
-  # A local run. Fall back to master if no PR is open for the current branch.
-  base_revision=$(hub pr show --format=%B 2>/dev/null || echo master)
+  # A local run.
+  base_revision=$(hub pr show --format=%B 2>/dev/null || local_base_revision_fallback)
 
 else
   # A local run.
-  base_revision=origin/master
+  base_revision=$(local_base_revision_fallback)
 fi
 
 

--- a/scripts/git-hooks/machete-pre-rebase
+++ b/scripts/git-hooks/machete-pre-rebase
@@ -12,12 +12,24 @@ if [ $# -eq 3 ]; then
   parse_version_from_git_revision base "$new_base"
   parse_version_from_git_revision head "$current_branch"
 
-  if [[ $head_patch -ne 0 ]]; then
-    target_version="$base_major.$base_minor.$((base_patch + 1))"
-  elif [[ $head_minor -ne 0 ]]; then
-    target_version="$base_major.$((base_minor + 1)).0"
+  if [[ $head_pre_release ]]; then
+    if [[ $head_pre_release -ne 1 ]]; then
+      target_version="$base_major.$base_minor.$base_patch-$((${base_pre_release:-0} + 1))"
+    elif [[ $head_patch -ne 0 ]]; then
+      target_version="$base_major.$base_minor.$((base_patch + 1))-1"
+    elif [[ $head_minor -ne 0 ]]; then
+      target_version="$base_major.$((base_minor + 1)).0-1"
+    else
+      target_version="$((base_major + 1)).0.0-1"
+    fi
   else
-    target_version="$((base_major + 1)).0.0"
+    if [[ $head_patch -ne 0 ]]; then
+      target_version="$base_major.$base_minor.$((base_patch + 1))"
+    elif [[ $head_minor -ne 0 ]]; then
+      target_version="$base_major.$((base_minor + 1)).0"
+    else
+      target_version="$((base_major + 1)).0.0"
+    fi
   fi
 
   if [[ $head_version != "$target_version" ]]; then

--- a/scripts/git-hooks/machete-status-branch
+++ b/scripts/git-hooks/machete-status-branch
@@ -13,4 +13,4 @@ function ansi_esc {
 dim=$(ansi_esc '\033[2m')
 endc=$(ansi_esc '\033[0m')
 
-echo -ne "${dim}v$(extract_version_from_git_revision "$branch" | sed 's/[-+].*//' || echo '???')${endc}"
+echo -ne "${dim}v$(extract_version_from_git_revision "$branch" || echo '???')${endc}"

--- a/scripts/run-pre-build-checks
+++ b/scripts/run-pre-build-checks
@@ -10,6 +10,7 @@ x_option=${-//[^x]/}
 ./scripts/enforce-indent-two-spaces-outside-java
 ./scripts/enforce-issue-number-for-todos
 ./scripts/enforce-newline-at-eof
-bash ${x_option:+-x} ./scripts/enforce-version-bump # pass -x option if this script is run with -x option itself
+bash ${x_option:+-x} ./scripts/enforce-pre-release-version-correct-use  # pass -x option if this script is run with -x option itself
+bash ${x_option:+-x} ./scripts/enforce-version-bump
 ./scripts/prohibit-tab-character
 ./scripts/prohibit-trailing-whitespace

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -33,10 +33,10 @@ function extract_version_from_git_revision() {
 function parse_version() {
   [[ $# -eq 2 ]] || die "${FUNCNAME[0]}: expecting 2 arguments (<var_prefix> <version>), aborting"
   local var_prefix=$1
-  local version=${2//[-+]*/} # remove pre-release indicator/build metadata; note that this is glob, not regex - so `*` here means the same as `.*` in regex
+  local version=$2
 
   declare -g "$var_prefix"_version="$version"
-  IFS=. read -r ${var_prefix}_major ${var_prefix}_minor ${var_prefix}_patch <<< "$version"
+  IFS=.- read -r ${var_prefix}_major ${var_prefix}_minor ${var_prefix}_patch ${var_prefix}_pre_release <<< "$version"
 }
 
 function parse_version_from_current_wd() {

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.3.1'
+  PLUGIN_VERSION = '0.3.2-1'
 }


### PR DESCRIPTION
Step towards https://github.com/VirtusLab/git-machete-intellij-plugin/issues/261, still missing the actual publish step