### PR TITLE
Request building all develop (not only master & PR) commits on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,11 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - build
+      - build:
+          filters:
+            # This filter does not deal with pull requests, all PR commits all built regardless of base/head branch.
+            branches:
+              only: [ develop, master ]
       - hold: # A job that will require manual approval in the CircleCI web application.
           type: approval
           requires: [build]

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.3.1-3'
+  PLUGIN_VERSION = '0.3.1-4'
 }


### PR DESCRIPTION
~Required config updates:~
~* GitHub: change default branch from master to develop~
~* CircleCI: build all (subject to filters!) branch commits, not just the ones coming from PRs~

**EDIT: whoops, not possible now:** https://ideas.circleci.com/ideas/CCI-I-215

Let's leave master as default branch then. The only (minor) nuisance will be that develop commits will never be built (unless a PR from develop is made)