### PR TITLE
Statically ensure that RevCommit instances are never leaked (aka "aliased" in Checker terms)

### DIFF
--- a/binding/src/main/java/com/virtuslab/binding/RuntimeBinding.java
+++ b/binding/src/main/java/com/virtuslab/binding/RuntimeBinding.java
@@ -2,7 +2,6 @@ package com.virtuslab.binding;
 
 import static lombok.Lombok.sneakyThrow;
 
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.reflections.Reflections;
@@ -31,7 +30,7 @@ public final class RuntimeBinding {
    */
   public static <T> T instantiateSoleImplementingClass(Class<T> interfaze) {
     try {
-      Set<Class<? extends T>> classes = reflectionsInstance.getSubTypesOf(interfaze).stream()
+      java.util.Set<Class<? extends T>> classes = reflectionsInstance.getSubTypesOf(interfaze).stream()
           .filter(c -> !c.isInterface() && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
           .collect(Collectors.toSet());
       if (classes.isEmpty()) {

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReader.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReader.java
@@ -171,8 +171,9 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
             "One of branches in branch layout file (${path.toAbsolutePath()}) has incorrect level in relation to its parent branch");
       }
 
-      @SuppressWarnings("index:argument.type.incompatible")
-      Integer upstreamLineIndex = level <= 0 ? -1 : levelToPresentUpstream.get(level - 1);
+      @SuppressWarnings("index:argument.type.incompatible") Integer upstreamLineIndex = level <= 0
+          ? -1
+          : levelToPresentUpstream.get(level - 1);
       Tuple2<Integer, Integer> levelAndUpstreamLineIndex = new Tuple2<>(level, upstreamLineIndex);
 
       // Can't use lambda because `realLineNumber` and `lineIndex` are not effectively final

--- a/build.gradle
+++ b/build.gradle
@@ -105,8 +105,10 @@ subprojects {
 
   gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
-      // Treat each compiler warning (esp. the ones coming from Checker Framework) as an error.
-      options.compilerArgs << '-Werror'
+      options.compilerArgs += [
+        '-Werror', // Treat each compiler warning (esp. the ones coming from Checker Framework) as an error.
+        '-Xlint:unchecked', // Warn of type-unsafe operations on generics.
+      ]
       if (System.getenv('CI') != 'true') {
         def jvmArgsEnvVar = System.getenv('GRADLE_COMPILE_JAVA_JVM_ARGS')
         options.forkOptions.jvmArgs += jvmArgsEnvVar ? jvmArgsEnvVar.tokenize(' ') : ['-Xmx6g', '-XX:+HeapDumpOnOutOfMemoryError']

--- a/build.gradle
+++ b/build.gradle
@@ -274,6 +274,12 @@ subprojects {
       }
     }
 
+    applyAliasingChecker = { ->
+      checkerFramework {
+        checkers += 'org.checkerframework.common.aliasing.AliasingChecker'
+      }
+    }
+
     applySubtypingChecker = { ->
       dependencies {
         implementation project(':qual')

--- a/config/checker/javax.swing.astub
+++ b/config/checker/javax.swing.astub
@@ -1,5 +1,6 @@
 
 import org.checkerframework.checker.guieffect.qual.SafeEffect;
+import org.checkerframework.checker.guieffect.qual.UI;
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -17,6 +18,8 @@ class JComponent {
 }
 
 class JTable {
+  void setDefaultRenderer(Class<?> columnClass, @UI TableCellRenderer renderer);
+
   // `this` in all the below methods is @UnknownInitialization since all these methods are called from JTable's c'tor
   void setColumnModel(@UnknownInitialization JTable this, TableColumnModel columnModel);
 

--- a/config/checker/org.eclipse.jgit.astub
+++ b/config/checker/org.eclipse.jgit.astub
@@ -1,0 +1,14 @@
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.common.aliasing.qual.NonLeaked;
+import org.checkerframework.common.aliasing.qual.Unique;
+
+package org.eclipse.jgit.revwalk;
+
+class RevWalk {
+  void markStart(@NonLeaked RevCommit c);
+
+  @Unique RevCommit next();
+
+  @NonNull @Unique RevCommit parseCommit(org.eclipse.jgit.lib.AnyObjectId id);
+}

--- a/config/checkstyle/tree_walker_module_directives.xml
+++ b/config/checkstyle/tree_walker_module_directives.xml
@@ -23,13 +23,15 @@
 <module name="HideUtilityClassConstructor"/>
 <module name="IllegalCatch"/>
 <module name="IllegalImport">
+    <!-- Avoid mutable collections; if really needed, qualify their class names explicitly. -->
+    <property name="illegalClasses" value="java.util.Deque, java.util.List, java.util.Map, java.util.Queue, java.util.Set, java.util.Stack, java.util.Vector"/>
     <!-- Use string interpolation instead (com.antkorwin:better-strings). -->
     <property name="illegalClasses" value="java.text.MessageFormat"/>
     <!-- Use io.vavr.control.Option instead. -->
     <property name="illegalClasses" value="java.util.Optional"/>
     <!-- Use org.checkerframework.checker.nullness.qual.Nullable instead. -->
     <property name="illegalClasses" value="javax.annotation.Nonnull, javax.annotation.Nullable"/>
-    <property name="illegalClasses" value="org.jetbrains.annotations.Nullable, org.jetbrains.annotations.NotNull"/>
+    <property name="illegalClasses" value="org.jetbrains.annotations.NotNull, org.jetbrains.annotations.Nullable"/>
 </module>
 <module name="IllegalThrows"/>
 <module name="IllegalType"/>

--- a/config/checkstyle/tree_walker_module_directives.xml
+++ b/config/checkstyle/tree_walker_module_directives.xml
@@ -140,6 +140,12 @@
 <module name="Regexp">
     <property name="illegalPattern" value="true"/>
     <property name="ignoreComments" value="true"/>
+    <property name="format" value="^.*(?&lt;!@Unique |@NonLeaked |import org\.eclipse\.jgit\.revwalk\.)\bRevCommit\b"/>
+    <property name="message" value="RevCommit is mutable and thus unsafe when leaked; always mark RevCommits as @org.checkerframework.common.aliasing.qual.Unique"/>
+</module>
+<module name="Regexp">
+    <property name="illegalPattern" value="true"/>
+    <property name="ignoreComments" value="true"/>
     <property name="format" value="\bupdateUI\b"/>
     <property name="message" value="Probably unintended updateUI() usage. See docs and consider repaint() and revalidate()"/>
 </module>

--- a/config/spotless/formatting-rules.xml
+++ b/config/spotless/formatting-rules.xml
@@ -108,7 +108,7 @@
         <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/BasePushBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/BasePushBranchAction.java
@@ -109,8 +109,7 @@ public abstract class BasePushBranchAction extends GitMacheteRepositoryReadyActi
 
   @UIEffect
   private void doPush(Project project, GitRepository preselectedRepository, String branchName) {
-    @Nullable
-    GitLocalBranch localBranch = preselectedRepository.getBranches().findLocalBranch(branchName);
+    @Nullable GitLocalBranch localBranch = preselectedRepository.getBranches().findLocalBranch(branchName);
 
     if (localBranch != null) {
       java.util.List<GitRepository> selectedRepositories = Collections.singletonList(preselectedRepository);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/BaseRebaseBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/BaseRebaseBranchOntoParentAction.java
@@ -7,8 +7,6 @@ import static io.vavr.API.$;
 import static io.vavr.API.Case;
 import static io.vavr.API.Match;
 
-import java.util.List;
-
 import com.intellij.dvcs.repo.Repository;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -142,7 +140,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends GitMacheteReposit
                   "until ${gitRebaseParameters.getForkPointCommit().getHash()} commit " +
                   "onto ${gitRebaseParameters.getNewBaseCommit().getHash()}");
 
-              GitRebaseUtils.rebase(project, List.of(gitRepository), params, indicator);
+              GitRebaseUtils.rebase(project, java.util.List.of(gitRepository), params, indicator);
             }
 
             // TODO (#95): on success, refresh only sync statuses (not the whole repository). Keep in mind potential

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/GitFetchSupportImpl.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/GitFetchSupportImpl.java
@@ -353,8 +353,8 @@ public final class GitFetchSupportImpl implements GitFetchSupport {
      * repositories have two remotes, and then fetch succeeds for the first remote in both repos, and fails for the second
      * remote in both repos. Such cases are rare, and can be handled when actual problem is reported.
      */
-    private MultiMessage multiRemoteMessage(boolean remoteInPrefix) {
-      return new MultiMessage(results.keySet().toJavaSet(),
+    private MultiMessage<GitRemote> multiRemoteMessage(boolean remoteInPrefix) {
+      return new MultiMessage<GitRemote>(results.keySet().toJavaSet(),
           (Function1<GitRemote, String>) GitRemote::getName,
           (Function1<GitRemote, String>) GitRemote::getName,
           remoteInPrefix,

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
@@ -5,8 +5,6 @@ import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.getPr
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.getSelectedBranchName;
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.getSelectedVcsRepository;
 
-import java.util.List;
-
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -83,7 +81,7 @@ public class CheckoutSelectedBranchAction extends GitMacheteRepositoryReadyActio
           LOG.info("Checking out branch '${selectedBranchName.get()}'");
           GitBranchUiHandlerImpl uiHandler = new GitBranchUiHandlerImpl(project, Git.getInstance(), indicator);
           new GitBranchWorker(project, Git.getInstance(), uiHandler)
-              .checkout(selectedBranchName.get(), /* detach */ false, List.of(gitRepository.get()));
+              .checkout(selectedBranchName.get(), /* detach */ false, java.util.List.of(gitRepository.get()));
         }
         // TODO (#95): on success, refresh only indication of the current branch
       }.queue();

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraph.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraph.java
@@ -36,8 +36,7 @@ public class RepositoryGraph implements IRepositoryGraph {
    */
   public List<GraphEdge> getAdjacentEdges(@NonNegative int itemIndex) {
     java.util.List<GraphEdge> adjacentEdges = new SmartList<>();
-    @SuppressWarnings("upperbound:argument.type.incompatible")
-    IGraphItem currentItem = items.get(itemIndex);
+    @SuppressWarnings("upperbound:argument.type.incompatible") IGraphItem currentItem = items.get(itemIndex);
 
     if (itemIndex > 0) {
       int upNodeIndex = currentItem.getPrevSiblingItemIndex();

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphFactory.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphFactory.java
@@ -1,6 +1,5 @@
 package com.virtuslab.gitmachete.frontend.graph.impl.repository;
 
-import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import com.virtuslab.gitmachete.backend.api.IGitMacheteRepository;
@@ -17,10 +16,8 @@ public class RepositoryGraphFactory implements IRepositoryGraphFactory {
   private IGitMacheteRepository repository = null;
 
   @Override
-  // Not the most beautiful solution, but let's enforce that this method is only ever called from UI thread
-  // to prevent race conditions on mutable fields.
-  @UIEffect
-  public IRepositoryGraph getRepositoryGraph(IGitMacheteRepository givenRepository, boolean isListingCommits) {
+  @SuppressWarnings("regexp") // to allow `synchronized`
+  public synchronized IRepositoryGraph getRepositoryGraph(IGitMacheteRepository givenRepository, boolean isListingCommits) {
     if (givenRepository != this.repository || repositoryGraphWithCommits == null
         || repositoryGraphWithoutCommits == null) {
 

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
@@ -37,7 +37,7 @@ import git4idea.repo.GitRepositoryChangeListener;
 import io.vavr.control.Option;
 import lombok.Getter;
 import lombok.Setter;
-import org.checkerframework.checker.guieffect.qual.AlwaysSafe;
+import org.checkerframework.checker.guieffect.qual.UI;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -99,8 +99,7 @@ public final class GitMacheteGraphTable extends BaseGraphTable implements DataPr
 
     initColumns();
 
-    @SuppressWarnings("guieffect:assignment.type.incompatible") @AlwaysSafe BranchOrCommitCellRenderer branchOrCommitCellRenderer = new BranchOrCommitCellRenderer(
-        /* table */ this, graphCellPainter);
+    @UI BranchOrCommitCellRenderer branchOrCommitCellRenderer = new BranchOrCommitCellRenderer(this, graphCellPainter);
     setDefaultRenderer(BranchOrCommitCell.class, branchOrCommitCellRenderer);
 
     setCellSelectionEnabled(false);

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
@@ -99,9 +99,8 @@ public final class GitMacheteGraphTable extends BaseGraphTable implements DataPr
 
     initColumns();
 
-    @SuppressWarnings("guieffect:assignment.type.incompatible")
-    @AlwaysSafe
-    BranchOrCommitCellRenderer branchOrCommitCellRenderer = new BranchOrCommitCellRenderer(/* table */ this, graphCellPainter);
+    @SuppressWarnings("guieffect:assignment.type.incompatible") @AlwaysSafe BranchOrCommitCellRenderer branchOrCommitCellRenderer = new BranchOrCommitCellRenderer(
+        /* table */ this, graphCellPainter);
     setDefaultRenderer(BranchOrCommitCell.class, branchOrCommitCellRenderer);
 
     setCellSelectionEnabled(false);

--- a/gitCoreJGit/build.gradle
+++ b/gitCoreJGit/build.gradle
@@ -1,6 +1,8 @@
 jgit()
 vavr()
 
+applyAliasingChecker()
+
 dependencies {
   implementation project(':logging')
 

--- a/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommit.java
+++ b/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommit.java
@@ -3,6 +3,7 @@ package com.virtuslab.gitcore.impl.jgit;
 import java.time.Instant;
 
 import lombok.Getter;
+import org.checkerframework.common.aliasing.qual.NonLeaked;
 import org.eclipse.jgit.revwalk.RevCommit;
 
 import com.virtuslab.gitcore.api.BaseGitCoreCommit;
@@ -18,12 +19,12 @@ public class GitCoreCommit extends BaseGitCoreCommit {
   private final String stringValue;
 
   @SuppressWarnings("index:argument.type.incompatible")
-  public GitCoreCommit(RevCommit commit) {
+  public GitCoreCommit(@NonLeaked RevCommit commit) {
     this.message = commit.getFullMessage();
     this.author = new GitCorePersonIdentity(commit.getAuthorIdent());
     this.committer = new GitCorePersonIdentity(commit.getCommitterIdent());
     this.commitTime = Instant.ofEpochSecond(commit.getCommitTime());
-    this.hash = GitCoreCommitHash.of(commit);
+    this.hash = new GitCoreCommitHash(commit.getId().getName());
     this.stringValue = commit.getId().getName().substring(0, 7) + ": " + commit.getShortMessage();
   }
 

--- a/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommitHash.java
+++ b/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommitHash.java
@@ -3,7 +3,6 @@ package com.virtuslab.gitcore.impl.jgit;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
-import org.eclipse.jgit.revwalk.RevCommit;
 
 import com.virtuslab.gitcore.api.BaseGitCoreCommitHash;
 
@@ -12,8 +11,4 @@ import com.virtuslab.gitcore.api.BaseGitCoreCommitHash;
 @ToString
 public class GitCoreCommitHash extends BaseGitCoreCommitHash {
   private final String hashString;
-
-  public static GitCoreCommitHash of(RevCommit jgitCommit) {
-    return new GitCoreCommitHash(jgitCommit.getId().getName());
-  }
 }

--- a/logging/src/main/java/com/virtuslab/logger/PrefixedLambdaLogger.java
+++ b/logging/src/main/java/com/virtuslab/logger/PrefixedLambdaLogger.java
@@ -17,8 +17,7 @@ public class PrefixedLambdaLogger implements IPrefixedLambdaLogger {
     // #1: com.virtuslab.logger.MacheteLogger#<init>
     // #2: com.virtuslab.logger.MacheteLoggerFactory#getLogger
     // #3: method from which MacheteLoggerFactory#getLogger was called
-    @SuppressWarnings("upperbound")
-    StackTraceElement element = Thread.currentThread().getStackTrace()[3];
+    @SuppressWarnings("upperbound") StackTraceElement element = Thread.currentThread().getStackTrace()[3];
     String[] classPath = element.getClassName().split("\\.");
     className = classPath[classPath.length - 1];
   }
@@ -32,8 +31,7 @@ public class PrefixedLambdaLogger implements IPrefixedLambdaLogger {
     // #4: kr.pe.kwonnam.slf4jlambda.LambdaLogger#debug
     // #5: com.virtuslab.logger.MacheteLogger#debug
     // #6: method from which IMacheteLogger.<logMethod> was called;
-    @SuppressWarnings("upperbound")
-    StackTraceElement element = Thread.currentThread().getStackTrace()[6];
+    @SuppressWarnings("upperbound") StackTraceElement element = Thread.currentThread().getStackTrace()[6];
     return className + "#" + element.getMethodName() + ": ";
   }
 

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.3.2-7'
+  PLUGIN_VERSION = '0.3.2-8'
 }


### PR DESCRIPTION
A follow-up for #282 