### PR TITLE
Feat/delete branch on slide out

### DIFF
--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
@@ -129,9 +129,8 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
           LOG.warn("Skipping local branch deletion because it is equal to current branch");
         }
 
-        var branchesToContainingRepositories = java.util.Collections.<String, java.util.List<? extends GitRepository>>singletonMap(
-            branchName,
-            selectedVcsRepository.toJavaList());
+        java.util.Map<String, java.util.List<? extends GitRepository>> branchesToContainingRepositories = java.util.Collections
+            .singletonMap(branchName, selectedVcsRepository.toJavaList());
         GitBrancher.getInstance(project).deleteBranches(branchesToContainingRepositories,
             () -> getGraphTable(anActionEvent).queueRepositoryUpdateAndModelRefresh());
         isRefreshScheduled = true;

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
@@ -29,7 +29,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
       IExpectsKeyGitMacheteRepository,
       IExpectsKeyProject {
 
-  private static final String DELETE_LOCAL_BRANCH_ON_SLIDE_OUT_GIT_CONFIG_KEY = "machete.slideout.deletelocalbranch";
+  private static final String DELETE_LOCAL_BRANCH_ON_SLIDE_OUT_GIT_CONFIG_KEY = "machete.slideOut.deleteLocalBranch";
 
   @Override
   public IEnhancedLambdaLogger log() {
@@ -155,7 +155,8 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
       }
       return result;
     } catch (VcsException e) {
-      // ignore
+      LOG.info(
+          "Attempt to get '${DELETE_LOCAL_BRANCH_ON_SLIDE_OUT_GIT_CONFIG_KEY}' git config value failed: key may not exist");
     }
 
     return false;

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.5.0-41'
+  PLUGIN_VERSION = '0.5.0-42'
 }


### PR DESCRIPTION
This minor improvement introduces a ~registry~ git config key which then decides whether slid out local branch should be deleted. 
key name: `machete.slideout.deletelocalbranch`
turn it on: `git config --global --add machete.slideout.deletelocalbranch true`
