### PR TITLE
Limit remote branches whose reflogs are scanned in fork-point algorithm to the counterparts of local branches

### DIFF
--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteNonRootBranch.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteNonRootBranch.java
@@ -24,8 +24,7 @@ import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 @ToString(callSuper = true)
 public final class GitMacheteNonRootBranch extends BaseGitMacheteBranch implements IGitMacheteNonRootBranch {
 
-  @MonotonicNonNull
-  private IGitMacheteBranch upstreamBranch = null;
+  private @MonotonicNonNull IGitMacheteBranch upstreamBranch = null;
   private final @Nullable IGitMacheteForkPointCommit forkPoint;
   private final List<IGitMacheteCommit> commits;
   private final SyncToParentStatus syncToParentStatus;

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
@@ -58,7 +58,7 @@ public abstract class BaseFastForwardParentToMatchBranchAction extends BaseGitMa
       if (anActionEvent.getPlace().equals(ActionPlaces.ACTION_PLACE_TOOLBAR)) {
         presentation.setEnabled(false);
         presentation.setDescription("Root branch '${branchName.get()}' cannot be fast-forwarded");
-      } else { //contextmenu
+      } else { // contextmenu
         // in case of root branch we do not want to show this option at all
         presentation.setEnabledAndVisible(false);
       }

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphCache.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphCache.java
@@ -8,12 +8,9 @@ import com.virtuslab.gitmachete.frontend.graph.api.repository.IRepositoryGraphCa
 
 public class RepositoryGraphCache implements IRepositoryGraphCache {
 
-  @MonotonicNonNull
-  private IRepositoryGraph repositoryGraphWithCommits = null;
-  @MonotonicNonNull
-  private IRepositoryGraph repositoryGraphWithoutCommits = null;
-  @MonotonicNonNull
-  private IGitMacheteRepository repository = null;
+  private @MonotonicNonNull IRepositoryGraph repositoryGraphWithCommits = null;
+  private @MonotonicNonNull IRepositoryGraph repositoryGraphWithoutCommits = null;
+  private @MonotonicNonNull IGitMacheteRepository repository = null;
 
   @Override
   @SuppressWarnings("regexp") // to allow `synchronized`

--- a/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/BaseGitCoreBranch.java
+++ b/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/BaseGitCoreBranch.java
@@ -3,7 +3,6 @@ package com.virtuslab.gitcore.impl.jgit;
 import io.vavr.Lazy;
 import io.vavr.collection.List;
 import io.vavr.control.Either;
-import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -12,7 +11,6 @@ import com.virtuslab.gitcore.api.GitCoreException;
 import com.virtuslab.gitcore.api.IGitCoreBranch;
 import com.virtuslab.gitcore.api.IGitCoreReflogEntry;
 
-@CustomLog
 @RequiredArgsConstructor
 public abstract class BaseGitCoreBranch implements IGitCoreBranch {
 

--- a/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreLocalBranch.java
+++ b/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreLocalBranch.java
@@ -4,7 +4,6 @@ import io.vavr.Lazy;
 import io.vavr.collection.List;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
-import lombok.CustomLog;
 import org.eclipse.jgit.annotations.Nullable;
 
 import com.virtuslab.gitcore.api.GitCoreException;
@@ -12,7 +11,6 @@ import com.virtuslab.gitcore.api.IGitCoreLocalBranch;
 import com.virtuslab.gitcore.api.IGitCoreReflogEntry;
 import com.virtuslab.gitcore.api.IGitCoreRemoteBranch;
 
-@CustomLog
 public class GitCoreLocalBranch extends BaseGitCoreBranch implements IGitCoreLocalBranch {
 
   private @Nullable final IGitCoreRemoteBranch remoteBranch;

--- a/scripts/prohibit-unused-custom-log
+++ b/scripts/prohibit-unused-custom-log
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
+source "$self_dir"/utils.sh
+
+if git grep --files-with-matches '^@CustomLog$' -- '*.java' | xargs git grep --files-without-match '\bLOG\b'; then
+  die 'The above Java sources contain @CustomLog, but LOG is never referenced'
+fi

--- a/scripts/run-pre-build-checks
+++ b/scripts/run-pre-build-checks
@@ -13,7 +13,9 @@ x_option=${-//[^x]/}
 bash ${x_option:+-x} ./scripts/enforce-pre-release-version-correct-use  # pass -x option if this script is run with -x option itself
 ./scripts/enforce-to-string-call-super-in-subclasses
 bash ${x_option:+-x} ./scripts/enforce-version-bump
+
 ./scripts/prohibit-class-name-hardcode-in-strings
 ./scripts/prohibit-non-ascii-characters
 ./scripts/prohibit-tab-character
 ./scripts/prohibit-trailing-whitespace
+./scripts/prohibit-unused-custom-log

--- a/scripts/run-ui-tests
+++ b/scripts/run-ui-tests
@@ -28,13 +28,18 @@ function is_ide_running() {
 # but we still need to kill the IDE instance in case that test was not successful AND the IDE is still running.
 function finish() {
   if is_ide_running; then
-    kill $ide_pid
+    kill -TERM $ide_pid || true  # ignoring exit code in case the process just terminated between `is_ide_running` and `kill`
   fi
   # Let's wait until IDE process is terminated to avoid any risk of race conditions
   # when another UI test is to be run right after this script completes.
+  local count=0
   while is_ide_running; do
-    sleep 0.5
+    # Rather unlikely, IDE process tends to shut down quickly on receiving SIGTERM.
+    if [[ $((count++)) -eq 10 ]]; then
+      kill -KILL $ide_pid || true
+    fi
     echo 'Waiting for IDE process to shut down...'
+    sleep 1.0
   done
 }
 trap finish EXIT

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.5.0-44'
+  PLUGIN_VERSION = '0.5.0-45'
 }


### PR DESCRIPTION
As in, previously **reflogs of all remote branches** were scanned, which was:
1. inconsistent with CLI
1. an unnecessary waste of time

Also, refactor fork-point algorithm a bit to make it more useful for upstream inference