### PR TITLE
Bump better-strings to v0.4 (x.toString() generated instead of String.valueOf(x))

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,17 +16,6 @@ jobs:
           name: Check formatting
           command: ./gradlew spotlessCheck
       - run:
-          name: '[TEMP] Publish better-strings annotation processor locally'
-          command: |
-            apt-get update
-            apt-get install -y maven
-
-            git clone https://github.com/PawelLipski/better-strings.git ~/better-strings
-            cd ~/better-strings
-            # https://github.com/antkorwin/better-strings/pull/14/files
-            git checkout 8d419868204fc7810de4d7685e7fd9b0793813f9
-            mvn install
-      - run:
           name: Compile production code
           # Given the RAM limits on CI (4GB), max-workers=2 is necessary to prevent OOMs.
           command: ./gradlew --max-workers=2 compileJava

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,17 @@ jobs:
           name: Check formatting
           command: ./gradlew spotlessCheck
       - run:
+          name: '[TEMP] Publish better-strings annotation processor locally'
+          command: |
+            apt-get update
+            apt-get install -y maven
+
+            git clone https://github.com/PawelLipski/better-strings.git ~/better-strings
+            cd ~/better-strings
+            # https://github.com/antkorwin/better-strings/pull/14/files
+            git checkout 8d419868204fc7810de4d7685e7fd9b0793813f9
+            mvn install
+      - run:
           name: Compile production code
           # Given the RAM limits on CI (4GB), max-workers=2 is necessary to prevent OOMs.
           command: ./gradlew --max-workers=2 compileJava

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ allprojects {
   }
 
   ext {
-    betterStringsVerson = '0.4'
+    betterStringsRevision = '8d419868204fc7810de4d7685e7fd9b0793813f9'
     checkerFrameworkVersion = '3.5.0'
     checkstyleToolVersion = '8.33'
 
@@ -163,11 +163,11 @@ subprojects {
   // if this annotation processor isn't run in any subproject (the strings will be just interpreted verbatim, without interpolation applied).
   // We'd only capture that in CI's post-compile checks by analyzing constants in class files.
   repositories {
-    mavenLocal()
+    maven { url "https://jitpack.io" }
   }
 
   dependencies {
-    def betterStringsArtifact = [ group: 'com.antkorwin', name: 'better-strings', version: betterStringsVerson ]
+    def betterStringsArtifact = [ group: 'com.github.PawelLipski', name: 'better-strings', version: betterStringsRevision ]
     annotationProcessor(betterStringsArtifact)
     testAnnotationProcessor(betterStringsArtifact)
   }

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ allprojects {
   }
 
   ext {
-    betterStringsVerson = '0.3'
+    betterStringsVerson = '0.4'
     checkerFrameworkVersion = '3.5.0'
     checkstyleToolVersion = '8.33'
 
@@ -139,7 +139,6 @@ subprojects {
       "-Astubs=$rootDir/config/checker/",
       '-AsuppressWarnings=allcheckers:type.anno.before.decl.anno,allcheckers:type.anno.before.modifier',
     ]
-
     dependencies {
       compileOnly      group: 'org.checkerframework', name: 'checker-qual', version: checkerFrameworkVersion
       checkerFramework group: 'org.checkerframework', name: 'checker',      version: checkerFrameworkVersion
@@ -163,10 +162,20 @@ subprojects {
   // This needs to be enabled in each subproject by default because there's going to be no warning
   // if this annotation processor isn't run in any subproject (the strings will be just interpreted verbatim, without interpolation applied).
   // We'd only capture that in CI's post-compile checks by analyzing constants in class files.
+  repositories {
+    mavenLocal()
+  }
+
   dependencies {
     def betterStringsArtifact = [ group: 'com.antkorwin', name: 'better-strings', version: betterStringsVerson ]
     annotationProcessor(betterStringsArtifact)
     testAnnotationProcessor(betterStringsArtifact)
+  }
+
+  gradle.projectsEvaluated {
+    tasks.withType(JavaCompile) {
+      options.compilerArgs += '-AcallToStringExplicitlyInInterpolations'
+    }
   }
 
 


### PR DESCRIPTION
Extracted from PR #329 so that it isn't blocked on v0.4 being published