### PR TITLE
Highlighting branch names that are invalid

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           command: ./scripts/verify-binary-compatibility
 
       - run:
-          name: Run UI tests against 2020.1 (earliest supported)
+          name: Run UI tests against 2020.1 (erliest supported)
           command: ./scripts/run-ui-tests 2020.1
       # We can't just store the results once at the end since they get overwritten with each UI test run.
       - store_test_results:

--- a/frontendFile/src/main/grammar/Machete.bnf
+++ b/frontendFile/src/main/grammar/Machete.bnf
@@ -19,4 +19,6 @@ simpleFile ::= item_*
 // (in file MacheteParserDefinition) enforces us to define element that represent comments
 private item_ ::= (entry|COMMENT|EOL)
 
-entry ::= INDENTATION? PREFIX? NAME CUSTOM_ANNOTATION?
+entry ::= INDENTATION? branch CUSTOM_ANNOTATION?
+
+branch ::= PREFIX? NAME

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
@@ -8,25 +8,20 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.TextFieldWithAutoCompletionListProvider;
-import git4idea.repo.GitRepositoryManager;
-import io.vavr.collection.List;
 
 public class MacheteCompletionContributor extends CompletionContributor {
 
   @Override
   public void fillCompletionVariants(CompletionParameters parameters, CompletionResultSet result) {
     PsiFile file = parameters.getOriginalFile();
-    var project = file.getProject();
 
-    var gitRepository = List.ofAll(GitRepositoryManager.getInstance(project).getRepositories())
-        .find(r -> file.getVirtualFile().getPath().startsWith(r.getRoot().getPath()));
+    var branchNamesOption = MacheteFileUtils.getBranchNamesForFile(file);
 
-    if (gitRepository.isEmpty()) {
+    if (branchNamesOption.isEmpty()) {
       return;
     }
 
-    var branchNames = List.ofAll(gitRepository.get().getInfo().getLocalBranchesWithHashes().keySet())
-        .map(localBranch -> localBranch.getName());
+    var branchNames = branchNamesOption.get();
 
     /**
      * {@link CompletionResultSet#stopHere} marks the result set as stopped.

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
@@ -1,0 +1,26 @@
+package com.virtuslab.gitmachete.frontend.file;
+
+import com.intellij.psi.PsiFile;
+import git4idea.repo.GitRepositoryManager;
+import io.vavr.collection.List;
+import io.vavr.control.Option;
+
+public final class MacheteFileUtils {
+  private MacheteFileUtils() {}
+
+  public static Option<List<String>> getBranchNamesForFile(PsiFile psiFile) {
+    var project = psiFile.getProject();
+
+    var gitRepository = List.ofAll(GitRepositoryManager.getInstance(project).getRepositories())
+        .find(r -> psiFile.getVirtualFile().getPath().startsWith(r.getRoot().getPath()));
+
+    if (gitRepository.isEmpty()) {
+      return Option.none();
+    }
+
+    var branchNames = List.ofAll(gitRepository.get().getInfo().getLocalBranchesWithHashes().keySet())
+        .map(localBranch -> localBranch.getName());
+
+    return Option.of(branchNames);
+  }
+}

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -1,0 +1,40 @@
+package com.virtuslab.gitmachete.frontend.file.highlighting;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+
+import com.virtuslab.gitmachete.frontend.file.MacheteFileUtils;
+import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedBranch;
+import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedEntry;
+
+public class MacheteAnnotator implements Annotator {
+  @Override
+  public void annotate(PsiElement element, AnnotationHolder holder) {
+    if (!(element instanceof MacheteGeneratedEntry)) {
+      return;
+    }
+
+    MacheteGeneratedEntry macheteEntry = (MacheteGeneratedEntry) element;
+    MacheteGeneratedBranch branch = macheteEntry.getBranch();
+
+    PsiFile file = macheteEntry.getContainingFile();
+    var branchNamesOption = MacheteFileUtils.getBranchNamesForFile(file);
+
+    if (branchNamesOption.isEmpty()) {
+      // We can probably do something more useful here (some kind of message, etc.)
+      return;
+    }
+
+    var branchNames = branchNamesOption.get();
+
+    var processedBranchName = branch.getText();
+
+    if (!branchNames.contains(processedBranchName)) {
+      holder.newAnnotation(HighlightSeverity.ERROR, "Can't find '${processedBranchName}' branch in git repository")
+          .range(branch).create();
+    }
+  }
+}

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -1,8 +1,11 @@
 package com.virtuslab.gitmachete.frontend.file.highlighting;
 
+import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
 import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.util.BuildNumber;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 
@@ -33,8 +36,18 @@ public class MacheteAnnotator implements Annotator {
     var processedBranchName = branch.getText();
 
     if (!branchNames.contains(processedBranchName)) {
-      holder.newAnnotation(HighlightSeverity.ERROR, "Can't find '${processedBranchName}' branch in git repository")
-          .range(branch).create();
+      var buildNumberSinceAnnotationBuilderIsAvailable = BuildNumber.fromString("201.3803.32");
+      assert buildNumberSinceAnnotationBuilderIsAvailable != null : "Error while parsing build number";
+
+      // Remove this if when we drop support for every IntelliJ version bellow 201.3803.32
+      if (ApplicationInfo.getInstance().getBuild().compareTo(buildNumberSinceAnnotationBuilderIsAvailable) >= 0) {
+        holder.newAnnotation(HighlightSeverity.ERROR, "Can't find '${processedBranchName}' branch in git repository")
+            .range(branch).create();
+      } else {
+        Annotation errorAnnotation = holder.createErrorAnnotation(branch,
+            "Can't find '${processedBranchName}' branch in git repository");
+        errorAnnotation.setTextAttributes(MacheteSyntaxHighlighter.BAD_CHARACTER);
+      }
     }
   }
 }

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -24,7 +24,7 @@ public class MacheteAnnotator implements Annotator {
     var branchNamesOption = MacheteFileUtils.getBranchNamesForFile(file);
 
     if (branchNamesOption.isEmpty()) {
-      // We can probably do something more useful here (some kind of message, etc.)
+      // TODO (#372): We can probably do something more useful here (some kind of message, etc.)
       return;
     }
 
@@ -33,7 +33,7 @@ public class MacheteAnnotator implements Annotator {
     var processedBranchName = branch.getText();
 
     if (!branchNames.contains(processedBranchName)) {
-      holder.newAnnotation(HighlightSeverity.ERROR, "Can't find '${processedBranchName}' branch in git repository")
+      holder.newAnnotation(HighlightSeverity.ERROR, "Can't find local branch '${processedBranchName}' in git repository")
           .range(branch).create();
     }
   }

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -1,11 +1,8 @@
 package com.virtuslab.gitmachete.frontend.file.highlighting;
 
-import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
 import com.intellij.lang.annotation.HighlightSeverity;
-import com.intellij.openapi.application.ApplicationInfo;
-import com.intellij.openapi.util.BuildNumber;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 
@@ -36,18 +33,8 @@ public class MacheteAnnotator implements Annotator {
     var processedBranchName = branch.getText();
 
     if (!branchNames.contains(processedBranchName)) {
-      var buildNumberSinceAnnotationBuilderIsAvailable = BuildNumber.fromString("201.3803.32");
-      assert buildNumberSinceAnnotationBuilderIsAvailable != null : "Error while parsing build number";
-
-      // Remove this if when we drop support for every IntelliJ version bellow 201.3803.32
-      if (ApplicationInfo.getInstance().getBuild().compareTo(buildNumberSinceAnnotationBuilderIsAvailable) >= 0) {
-        holder.newAnnotation(HighlightSeverity.ERROR, "Can't find '${processedBranchName}' branch in git repository")
-            .range(branch).create();
-      } else {
-        Annotation errorAnnotation = holder.createErrorAnnotation(branch,
-            "Can't find '${processedBranchName}' branch in git repository");
-        errorAnnotation.setTextAttributes(MacheteSyntaxHighlighter.BAD_CHARACTER);
-      }
+      holder.newAnnotation(HighlightSeverity.ERROR, "Can't find '${processedBranchName}' branch in git repository")
+          .range(branch).create();
     }
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,6 +40,8 @@
                                        implementationClass="com.virtuslab.gitmachete.frontend.file.highlighting.MacheteSyntaxHighlighterFactory"/>
 
         <colorSettingsPage implementation="com.virtuslab.gitmachete.frontend.file.highlighting.MacheteColorSettingsPane"/>
+
+        <annotator language="Machete" implementationClass="com.virtuslab.gitmachete.frontend.file.highlighting.MacheteAnnotator"/>
     </extensions>
 
     <resource-bundle>actions.ResourceBundle</resource-bundle>

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.5.0-39'
+  PLUGIN_VERSION = '0.5.0-40'
 }


### PR DESCRIPTION
Now while we edit machete file branches that are not present in repository are underlined