### PR TITLE
Migrate from 2019.3 to 2020.1 earliest supported version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,12 +53,7 @@ jobs:
           command: ./scripts/verify-binary-compatibility
 
       - run:
-          name: Run UI tests against 2019.3 (earliest supported)
-          command: ./scripts/run-ui-tests 2019.3
-      - store_test_results:
-          path: uiTests/build/test-results/
-      - run:
-          name: Run UI tests against 2020.1
+          name: Run UI tests against 2020.1 (earliest supported)
           command: ./scripts/run-ui-tests 2020.1
       # We can't just store the results once at the end since they get overwritten with each UI test run.
       - store_test_results:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A relatively small amount of `TRACE`-level logs is generated as well.
 ### Prerequisites
 
 * git
-* IntelliJ 2019.3+ Community Edition/Ultimate
+* IntelliJ 2020.1 Community Edition/Ultimate
 
   * Install [Lombok plugin](https://plugins.jetbrains.com/plugin/6317-lombok/)
   * Enable annotation processing (for Lombok):

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ allprojects {
     intellijVersions = [
       earliestSupported: '2020.1',
       // An arbitrary list of versions between earliest supported (excl.) and current (excl.), for binary compatibility checks
-      // inBetweenForCompatibilityChecks: [ '2020.1' ],
+      inBetweenForCompatibilityChecks: [],
       current: '2020.1.2',
     ]
     intellijVersions.buildTarget = intellijVersions.current

--- a/build.gradle
+++ b/build.gradle
@@ -80,9 +80,9 @@ allprojects {
 
     // Update the range of UI-tested versions in .circle/config.yml when any of the below is updated
     intellijVersions = [
-      earliestSupported: '2019.3',
+      earliestSupported: '2020.1',
       // An arbitrary list of versions between earliest supported (excl.) and current (excl.), for binary compatibility checks
-      inBetweenForCompatibilityChecks: [ '2020.1' ],
+      // inBetweenForCompatibilityChecks: [ '2020.1' ],
       current: '2020.1.2',
     ]
     intellijVersions.buildTarget = intellijVersions.current

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/GitFetchSupportImpl.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/GitFetchSupportImpl.java
@@ -56,10 +56,9 @@ import com.virtuslab.gitmachete.frontend.actions.base.BasePullBranchAction;
 import com.virtuslab.gitmachete.frontend.actions.toolbar.FetchAllRemotesAction;
 
 /**
- * TODO (#339): remove (if possible) once 2019.3 is dropped
- *
- * @deprecated This implementation is a workaround to provide features missing in pre-2020.1 versions.
- * The main benefit of it is specific branch update ({@link GitFetchSupportImpl#fetch(GitRepository, GitRemote, String)}).
+ * This implementation is a workaround to provide features missing now.
+ * Since 2020.1 the only missing option is the support for "--update-head-ok" parameter
+ * which allows us to update current branch fast-forward like.
  * We need this class for {@link FetchAllRemotesAction} and {@link BasePullBranchAction}.
  */
 @CustomLog

--- a/frontendActions/src/main/resources/actions/ResourceBundle.properties
+++ b/frontendActions/src/main/resources/actions/ResourceBundle.properties
@@ -1,77 +1,77 @@
 
 # Context menu
 
-action.GitMachete.CheckoutSelectedBranchAction.text=Checkout Selected Branch
+action.GitMachete.CheckoutSelectedBranchAction.text=Git Machete: Checkout Selected Branch
 action.GitMachete.CheckoutSelectedBranchAction.GitMacheteContextMenu.text=_Checkout Branch
 action.GitMachete.CheckoutSelectedBranchAction.description=Checkout this branch
 
-action.GitMachete.RebaseSelectedBranchOntoParentAction.text=Checkout and Rebase Selected Branch Onto Parent
+action.GitMachete.RebaseSelectedBranchOntoParentAction.text=Git Machete: Checkout and Rebase Selected Branch Onto Parent
 action.GitMachete.RebaseSelectedBranchOntoParentAction.GitMacheteContextMenu.text=Checkout and _Rebase Branch Onto Parent
 action.GitMachete.RebaseSelectedBranchOntoParentAction.description=Checkout and rebase this branch onto parent
 
-action.GitMachete.PullSelectedBranchAction.text=Pull Selected Branch
+action.GitMachete.PullSelectedBranchAction.text=Git Machete: Pull Selected Branch
 action.GitMachete.PullSelectedBranchAction.GitMacheteContextMenu.text=P_ull Branch
 action.GitMachete.PullSelectedBranchAction.description=Pull (fast-forward only) this branch
 
-action.GitMachete.PushSelectedBranchAction.text=Push Selected Branch...
+action.GitMachete.PushSelectedBranchAction.text=Git Machete: Push Selected Branch...
 action.GitMachete.PushSelectedBranchAction.GitMacheteContextMenu.text=_Push Branch...
 action.GitMachete.PushSelectedBranchAction.description=Push this branch using push dialog
 
-action.GitMachete.ResetSelectedBranchAction.text=Checkout and Reset Selected Branch to Remote
+action.GitMachete.ResetSelectedBranchAction.text=Git Machete: Checkout and Reset Selected Branch to Remote
 action.GitMachete.ResetSelectedBranchAction.GitMacheteContextMenu.text=Checkout and Re_set Branch to Remote
 action.GitMachete.ResetSelectedBranchAction.description=Checkout and reset this branch to its remote tracking branch
 
-action.GitMachete.FastForwardParentToMatchSelectedBranchAction.text=Fast Forward Parent To Match Selected Branch
+action.GitMachete.FastForwardParentToMatchSelectedBranchAction.text=Git Machete: Fast Forward Parent To Match Selected Branch
 action.GitMachete.FastForwardParentToMatchSelectedBranchAction.GitMacheteContextMenu.text=_Fast Forward Parent To Match Selected Branch
 action.GitMachete.FastForwardParentToMatchSelectedBranchAction.description=Fast forward parent to match selected branch
 
-action.GitMachete.SlideOutSelectedBranchAction.text=Slide Out Selected Branch
+action.GitMachete.SlideOutSelectedBranchAction.text=Git Machete: Slide Out Selected Branch
 action.GitMachete.SlideOutSelectedBranchAction.GitMacheteContextMenu.text=_Slide Out Branch
 action.GitMachete.SlideOutSelectedBranchAction.description=Slide out this branch
 
 
 # Toolbar
 
-action.GitMachete.RefreshStatusAction.text=Refresh Status
+action.GitMachete.RefreshStatusAction.text=Git Machete: Refresh Status
 action.GitMachete.RefreshStatusAction.GitMacheteToolbar.text=Refresh Status
 action.GitMachete.RefreshStatusAction.description=Refresh status
 
-action.GitMachete.ToggleListingCommitsAction.text=Toggle Listing Commits
+action.GitMachete.ToggleListingCommitsAction.text=Git Machete: Toggle Listing Commits
 action.GitMachete.ToggleListingCommitsAction.GitMacheteToolbar.text=Toggle Listing Commits
 action.GitMachete.ToggleListingCommitsAction.description=Toggle listing commits
 
-action.GitMachete.RebaseCurrentBranchOntoParentAction.text=Rebase Current Branch Onto Parent
+action.GitMachete.RebaseCurrentBranchOntoParentAction.text=Git Machete: Rebase Current Branch Onto Parent
 action.GitMachete.RebaseCurrentBranchOntoParentAction.GitMacheteToolbar.text=Rebase Current Branch Onto Parent
 action.GitMachete.RebaseCurrentBranchOntoParentAction.description=Rebase current branch onto parent
 
-action.GitMachete.FetchAllRemotesAction.text=Fetch All Remotes
-action.GitMachete.FetchAllRemotesAction.GitMacheteToolbar.text=Fetch all remotes
+action.GitMachete.FetchAllRemotesAction.text=Git Machete: Fetch All Remotes
+action.GitMachete.FetchAllRemotesAction.GitMacheteToolbar.text=Fetch All Remotes
 action.GitMachete.FetchAllRemotesAction.description=Fetch all remotes
 
-action.GitMachete.PullCurrentBranchAction.text=Pull Current Branch
+action.GitMachete.PullCurrentBranchAction.text=Git Machete: Pull Current Branch
 action.GitMachete.PullCurrentBranchAction.GitMacheteToolbar.text=Pull Current Branch
 action.GitMachete.PullCurrentBranchAction.description=Pull (fast-forward only) current branch
 
-action.GitMachete.PushCurrentBranchAction.text=Push Current Branch...
+action.GitMachete.PushCurrentBranchAction.text=Git Machete: Push Current Branch...
 action.GitMachete.PushCurrentBranchAction.GitMacheteToolbar.text=Push Current Branch...
 action.GitMachete.PushCurrentBranchAction.description=Push current branch using push dialog
 
-action.GitMachete.FastForwardParentToMatchCurrentBranchAction.text=Fast Forward Parent To Match Current Branch
+action.GitMachete.FastForwardParentToMatchCurrentBranchAction.text=Git Machete: Fast Forward Parent To Match Current Branch
 action.GitMachete.FastForwardParentToMatchCurrentBranchAction.GitMacheteToolbar.text=Fast Forward Parent To Match Current Branch
 action.GitMachete.FastForwardParentToMatchCurrentBranchAction.description=Fast forward parent to match current branch
 
-action.GitMachete.OpenMacheteFileAction.text=Open Machete File
+action.GitMachete.OpenMacheteFileAction.text=Git Machete: Open Machete File
 action.GitMachete.OpenMacheteFileAction.GitMacheteToolbar.text=Open Machete File
 action.GitMachete.OpenMacheteFileAction.description=Open machete file
 
-action.GitMachete.ResetCurrentBranchAction.text=Reset Current Branch to Remote
+action.GitMachete.ResetCurrentBranchAction.text=Git Machete: Reset Current Branch to Remote
 action.GitMachete.ResetCurrentBranchAction.GitMacheteToolbar.text=_Reset Current Branch to Remote
 action.GitMachete.ResetCurrentBranchAction.description=Reset current branch to its remote tracking branch
 
-action.GitMachete.SlideOutCurrentBranchAction.text=Slide Out Current Branch
+action.GitMachete.SlideOutCurrentBranchAction.text=Git Machete: Slide Out Current Branch
 action.GitMachete.SlideOutCurrentBranchAction.GitMacheteToolbar.text=Slide Out Current Branch
 action.GitMachete.SlideOutCurrentBranchAction.description=Slide out current branch
 
-action.GitMachete.HelpAction.text=Show Help Window
+action.GitMachete.HelpAction.text=Git Machete: Show Help Window
 action.GitMachete.HelpAction.GitMacheteToolbar.text=Show Help Window
 action.GitMachete.HelpAction.description=Show help window

--- a/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/MacheteIconProvider.java
+++ b/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/MacheteIconProvider.java
@@ -1,16 +1,13 @@
 package com.virtuslab.gitmachete.frontend.externalsystem;
 
-// TODO (#339):  "externalIconProvider" is available since 2020.1. The following lines shall be uncommented after 2019.3 support is dropped.
-// Before this we depend on default refresh icon com.intellij.icons.AllIcons.Actions.BuildAutoReloadChanges.
-//
-//import javax.swing.Icon;
-//
-//import com.intellij.openapi.externalSystem.ui.ExternalSystemIconProvider;
-//import icons.MacheteIcons;
-//
-//public class MacheteIconProvider implements ExternalSystemIconProvider {
-//  @Override
-//  public Icon getReloadIcon() {
-//    return MacheteIcons.MACHETE_LOAD_CHANGES;
-//  }
-//}
+import javax.swing.Icon;
+
+import com.intellij.openapi.externalSystem.ui.ExternalSystemIconProvider;
+import icons.MacheteIcons;
+
+public class MacheteIconProvider implements ExternalSystemIconProvider {
+  @Override
+  public Icon getReloadIcon() {
+    return MacheteIcons.MACHETE_LOAD_CHANGES;
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,8 +27,7 @@
         <completion.contributor language="Machete"
                                 implementationClass="com.virtuslab.gitmachete.frontend.file.MacheteCompletionContributor"/>
         <externalSystemManager implementation="com.virtuslab.gitmachete.frontend.externalsystem.MacheteProjectService"/>
-        <!-- TODO (#339): "externalIconProvider" is available since 2020.1. The following line shall be uncommented after 2019.3 support is dropped. -->
-<!--        <externalIconProvider key="MACHETE" implementationClass="com.virtuslab.gitmachete.frontend.externalsystem.MacheteIconProvider"/>-->
+        <externalIconProvider key="MACHETE" implementationClass="com.virtuslab.gitmachete.frontend.externalsystem.MacheteIconProvider"/>
 
         <!-- See javadoc of com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil.isInProcessMode -->
         <registryKey key="MACHETE.system.in.process" defaultValue="true"
@@ -50,49 +49,43 @@
             <!-- These actions are used in right-click context menu on branches. -->
             <action id="GitMachete.CheckoutSelectedBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.contextmenu.CheckoutSelectedBranchAction">
-                <!-- TODO (#339): "override-text" is available since 2020.1. As long as we support previous versions it cannot be used.
-                    Furthermore, prepending "Git Machete: " to action texts (without defined place) should take place
-                      once we introduce override-text here.
-                    This will distinguish Git Machete actions in "Find Action..." search dialog.
-                    We do not prepend it now to avoid text pollution in the toolbar/context menu.
-                    We assume that those are the most usual ways to execute a Git Machete action. -->
-                <!--                <override-text place="GitMacheteContextMenu"/>-->
+                <override-text place="GitMacheteContextMenu"/>
             </action>
 
             <action id="GitMachete.RebaseSelectedBranchOntoParentAction"
                     class="com.virtuslab.gitmachete.frontend.actions.contextmenu.RebaseSelectedBranchOntoParentAction"
                     icon="MacheteIcons.REBASE">
-                <!--                <override-text place="GitMacheteContextMenu"/>-->
+                <override-text place="GitMacheteContextMenu"/>
             </action>
 
             <action id="GitMachete.PullSelectedBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.contextmenu.PullSelectedBranchAction"
                     icon="MacheteIcons.PULL">
-                <!--                <override-text place="GitMacheteContextMenu"/>-->
+                <override-text place="GitMacheteContextMenu"/>
             </action>
 
             <action id="GitMachete.PushSelectedBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.contextmenu.PushSelectedBranchAction"
                     icon="MacheteIcons.PUSH">
-                <!--                <override-text place="GitMacheteContextMenu"/>-->
+                <override-text place="GitMacheteContextMenu"/>
             </action>
 
             <action id="GitMachete.ResetSelectedBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.contextmenu.ResetSelectedBranchToRemoteAction"
                     icon="MacheteIcons.RESET">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteContextMenu"/>
             </action>
 
             <action id="GitMachete.FastForwardParentToMatchSelectedBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.contextmenu.FastForwardParentToMatchSelectedBranchAction"
                     icon="MacheteIcons.FAST_FORWARD">
-                <!--                <override-text place="GitMacheteContextMenu"/>-->
+                <override-text place="GitMacheteContextMenu"/>
             </action>
 
             <action id="GitMachete.SlideOutSelectedBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.contextmenu.SlideOutSelectedBranchAction"
                     icon="MacheteIcons.SLIDE_OUT">
-                <!--                <override-text place="GitMacheteContextMenu"/>-->
+                <override-text place="GitMacheteContextMenu"/>
             </action>
         </group>
 
@@ -101,19 +94,19 @@
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.RefreshStatusAction"
                     icon="MacheteIcons.REFRESH_STATUS"
                     use-shortcut-of="Refresh">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.ToggleListingCommitsAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.ToggleListingCommitsAction"
                     icon="MacheteIcons.TOGGLE_LISTING_COMMITS">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.OpenMacheteFileAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.OpenMacheteFileAction"
                     icon="MacheteIcons.TEXT_FILE">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <separator/>
@@ -121,43 +114,43 @@
             <action id="GitMachete.RebaseCurrentBranchOntoParentAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.RebaseCurrentBranchOntoParentAction"
                     icon="MacheteIcons.REBASE">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.FetchAllRemotesAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.FetchAllRemotesAction"
                     icon="MacheteIcons.FETCH">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.PullCurrentBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.PullCurrentBranchAction"
                     icon="MacheteIcons.PULL">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.PushCurrentBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.PushCurrentBranchAction"
                     icon="MacheteIcons.PUSH">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.ResetCurrentBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.ResetCurrentBranchToRemoteAction"
                     icon="MacheteIcons.RESET">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.FastForwardParentToMatchCurrentBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.FastForwardParentToMatchCurrentBranchAction"
                     icon="MacheteIcons.FAST_FORWARD">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <action id="GitMachete.SlideOutCurrentBranchAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.SlideOutCurrentBranchAction"
                     icon="MacheteIcons.SLIDE_OUT">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
 
             <separator/>
@@ -165,7 +158,7 @@
             <action id="GitMachete.HelpAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.HelpAction"
                     icon="MacheteIcons.HELP">
-                <!--                <override-text place="GitMacheteToolbar"/>-->
+                <override-text place="GitMacheteToolbar"/>
             </action>
         </group>
     </actions>

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.5.0-37'
+  PLUGIN_VERSION = '0.5.0-38'
 }


### PR DESCRIPTION
- `override-text` enabled
- `externalSystemIconProvider` enabled

**IMPORTANT NOTE - GitFetchSupport**

It turned out that custom `GitFetchSupportImpl` cannot be replaced with the one provided by IntelliJ 2020.1.
The updated one (from 2020.1) does provide the ability to "update" non-current branches indeed.
However, it does not allow us to fetch the current branch. 
The option - `--update-head-ok` required by fetch cannot be delivered to the `git4idea.commands.GitImpl#fetch(...)`.

Because of that, the decision has been made to keep our custom implementation for now.