### PR TITLE
Highlighting of invalid indentation

### DIFF
--- a/frontendFile/src/main/grammar/Machete.bnf
+++ b/frontendFile/src/main/grammar/Machete.bnf
@@ -15,7 +15,7 @@
 
 simpleFile ::= item_*
 
-// Even if we don't have comments in our machete file this element must be here - language parser definition
+// Even if we don't have comments in our machete file, the COMMENT element must be here - language parser definition
 // (in file MacheteParserDefinition) enforces us to define element that represent comments
 private item_ ::= (entry|COMMENT|(INDENTATION? EOL))
 

--- a/frontendFile/src/main/grammar/Machete.bnf
+++ b/frontendFile/src/main/grammar/Machete.bnf
@@ -17,7 +17,7 @@ simpleFile ::= item_*
 
 // Even if we don't have comments in our machete file this element must be here - language parser definition
 // (in file MacheteParserDefinition) enforces us to define element that represent comments
-private item_ ::= (entry|COMMENT|EOL)
+private item_ ::= (entry|COMMENT|(INDENTATION? EOL))
 
 entry ::= INDENTATION? branch CUSTOM_ANNOTATION?
 

--- a/frontendFile/src/main/grammar/Machete.flex
+++ b/frontendFile/src/main/grammar/Machete.flex
@@ -14,13 +14,40 @@ import com.intellij.psi.TokenType;
 %eof{  return;
 %eof}
 
+%{
+    Character indentationChar = null;
+    int singleIndentWidth = 0;
+    int currentIndentLevel = 0;
+
+    private boolean checkIndentation(char indentType, int processedIndentWidth) {
+        if (indentationChar == null)
+            indentationChar = indentType;
+        else if (!indentationChar.equals(indentType))
+            return false;
+
+        if (singleIndentWidth == 0) {
+            singleIndentWidth = processedIndentWidth;
+            currentIndentLevel = 1;
+        } else if (processedIndentWidth % singleIndentWidth != 0) {
+            return false;
+        } else {
+            int level = processedIndentWidth / singleIndentWidth;
+            if (level < currentIndentLevel - 1 || level > currentIndentLevel + 1)
+                return false;
+            currentIndentLevel = level;
+        }
+
+        return true;
+    }
+%}
 
 // End Of Line
 EOL=[\r\n]+
 // For sake of distinguishablility WHITESPACE and INDENTATION are two separated entries
 // even if they are the same for now
 WHITESPACE=[\ \t]+
-INDENTATION=[\ \t]+
+SPACE_INDENTATION=\ +
+TAB_INDENTATION=\t+
 // Probably all characters allowed in branch name
 // (https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html)
 // \w is standard regex abbreviation of [a-zA-Z0-9_]
@@ -30,12 +57,39 @@ NAME_WITH_SLASH=[\w\-.!@#$%&()+={}\];'\",.<>|`\/]+
 SLASH="\/"
 ANNOTATION=[^\r\n]+
 
-%state AFTER_PREFIX AFTER_NAME CUSTOM_ANNOTATION
+%state AFTER_INDENTATION AFTER_PREFIX AFTER_NAME CUSTOM_ANNOTATION
 
 %%
 
 <YYINITIAL> {
-    {INDENTATION}                        { return MacheteGeneratedElementTypes.INDENTATION; }
+    {SPACE_INDENTATION}                  {
+                                            yybegin(AFTER_INDENTATION);
+                                            if (!checkIndentation(' ', yytext().length()))
+                                                return TokenType.BAD_CHARACTER;
+                                            return MacheteGeneratedElementTypes.INDENTATION;
+                                         }
+    {TAB_INDENTATION}                    {
+                                            yybegin(AFTER_INDENTATION);
+                                            if (!checkIndentation('\t', yytext().length()))
+                                                return TokenType.BAD_CHARACTER;
+                                            return MacheteGeneratedElementTypes.INDENTATION;
+                                         }
+    {NAME_WITHOUT_SLASH}{SLASH}          {
+                                            yybegin(AFTER_PREFIX);
+                                            currentIndentLevel = 0;
+                                            return MacheteGeneratedElementTypes.PREFIX;
+                                         }
+    {NAME_WITHOUT_SLASH}                 {
+                                            yybegin(AFTER_NAME);
+                                            currentIndentLevel = 0;
+                                            return MacheteGeneratedElementTypes.NAME;
+                                         }
+    {EOL}                                {
+                                            return MacheteGeneratedElementTypes.EOL;
+                                         }
+}
+
+<AFTER_INDENTATION> {
     {NAME_WITHOUT_SLASH}{SLASH}          { yybegin(AFTER_PREFIX); return MacheteGeneratedElementTypes.PREFIX; }
     {NAME_WITHOUT_SLASH}                 { yybegin(AFTER_NAME); return MacheteGeneratedElementTypes.NAME; }
     {EOL}                                { return MacheteGeneratedElementTypes.EOL; }

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -1,23 +1,31 @@
 package com.virtuslab.gitmachete.frontend.file.highlighting;
 
+import com.intellij.lang.ASTNode;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import io.vavr.control.Option;
+import lombok.Data;
 
 import com.virtuslab.gitmachete.frontend.file.MacheteFileUtils;
+import com.virtuslab.gitmachete.frontend.file.grammar.MacheteFile;
 import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedBranch;
+import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedElementTypes;
 import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedEntry;
 
 public class MacheteAnnotator implements Annotator {
   @Override
   public void annotate(PsiElement element, AnnotationHolder holder) {
-    if (!(element instanceof MacheteGeneratedEntry)) {
-      return;
+    if (element instanceof MacheteGeneratedEntry) {
+      processMacheteGeneratedEntry((MacheteGeneratedEntry) element, holder);
+    } else if (element.getNode().getElementType().equals(MacheteGeneratedElementTypes.INDENTATION)) {
+      processIndentationElement(element, holder);
     }
+  }
 
-    MacheteGeneratedEntry macheteEntry = (MacheteGeneratedEntry) element;
+  private void processMacheteGeneratedEntry(MacheteGeneratedEntry macheteEntry, AnnotationHolder holder) {
     MacheteGeneratedBranch branch = macheteEntry.getBranch();
 
     PsiFile file = macheteEntry.getContainingFile();
@@ -36,5 +44,128 @@ public class MacheteAnnotator implements Annotator {
       holder.newAnnotation(HighlightSeverity.ERROR, "Can't find local branch '${processedBranchName}' in git repository")
           .range(branch).create();
     }
+  }
+
+  private void processIndentationElement(PsiElement element, AnnotationHolder holder) {
+    PsiElement parent = element.getParent();
+    assert parent != null : "Element has not parent";
+
+    if (parent instanceof MacheteFile) {
+      return;
+    }
+
+    var prevMacheteGeneratedEntryOption = getPrevSiblingMacheteGeneratedEntry(parent);
+    if (prevMacheteGeneratedEntryOption.isEmpty()) {
+      holder.newAnnotation(HighlightSeverity.ERROR, "First entry cannot be indented").range(element).create();
+      return;
+    }
+
+    int prevLevel;
+    int thisLevel;
+    boolean hasPrevLevelCorrectWidth;
+
+    IndentationParameters indentationParameters = findIndentationParameters(element);
+
+    var prevIndentationNodeOption = getIndentationNodeFromMacheteGeneratedEntry(prevMacheteGeneratedEntryOption.get());
+    if (prevIndentationNodeOption.isEmpty()) {
+      prevLevel = 0;
+      hasPrevLevelCorrectWidth = true;
+    } else {
+      var prevIndentationText = prevIndentationNodeOption.get().getText();
+      hasPrevLevelCorrectWidth = prevIndentationText.length() % indentationParameters.indentationWidth == 0;
+      prevLevel = prevIndentationText.length() / indentationParameters.indentationWidth;
+    }
+
+    var thisIndentationText = element.getText();
+
+    if (thisIndentationText.chars().filter(c -> c != indentationParameters.indentationCharacter).count() > 0) {
+      holder.newAnnotation(HighlightSeverity.ERROR, "Indentation character does not match the first indented line")
+          .range(element).create();
+      return;
+    }
+
+    if (thisIndentationText.length() % indentationParameters.indentationWidth != 0) {
+      holder.newAnnotation(HighlightSeverity.ERROR,
+          "Indentation width is not multiple of ${indentationParameters.indentationWidth}" +
+              " as first indented line suggests")
+          .range(element).create();
+    }
+
+    thisLevel = thisIndentationText.length() / indentationParameters.indentationWidth;
+
+    if (hasPrevLevelCorrectWidth && thisLevel > prevLevel + 1) {
+      holder.newAnnotation(HighlightSeverity.ERROR, "Indentation level does not math")
+          .range(element).create();
+    }
+  }
+
+  private IndentationParameters findIndentationParameters(PsiElement currentElement) {
+    var element = getFirstMacheteGeneratedEntry(currentElement);
+    while (element.isDefined() && getIndentationNodeFromMacheteGeneratedEntry(element.get()).isEmpty()) {
+      element = getNextSiblingMacheteGeneratedEntry(element.get());
+    }
+
+    if (element.isEmpty()) {
+      // Default - theoretically this should never happen
+      return new IndentationParameters(' ', 4);
+    }
+
+    var indentationNodeOption = getIndentationNodeFromMacheteGeneratedEntry(element.get());
+    if (indentationNodeOption.isEmpty()) {
+      // Default - this also theoretically should never happen
+      return new IndentationParameters(' ', 4);
+    }
+
+    var indentationText = indentationNodeOption.get().getText();
+
+    char indentationChar = indentationText.charAt(0);
+    int indentationWidth = indentationText.length();
+
+    return new IndentationParameters(indentationChar, indentationWidth);
+  }
+
+  private Option<ASTNode> getIndentationNodeFromMacheteGeneratedEntry(MacheteGeneratedEntry macheteEntry) {
+    return Option.of(macheteEntry.getNode().findChildByType(MacheteGeneratedElementTypes.INDENTATION));
+  }
+
+  private Option<MacheteGeneratedEntry> getFirstMacheteGeneratedEntry(PsiElement currentElement) {
+    PsiElement root = currentElement;
+    while (root.getParent() != null) {
+      root = root.getParent();
+    }
+
+    return getNextSiblingMacheteGeneratedEntry(root.getFirstChild());
+  }
+
+  private Option<MacheteGeneratedEntry> getNextSiblingMacheteGeneratedEntry(PsiElement currentElement) {
+    PsiElement nextSiblingMacheteGeneratedEntry = currentElement.getNextSibling();
+    while (nextSiblingMacheteGeneratedEntry != null && !(nextSiblingMacheteGeneratedEntry instanceof MacheteGeneratedEntry)) {
+      nextSiblingMacheteGeneratedEntry = nextSiblingMacheteGeneratedEntry.getNextSibling();
+    }
+
+    if (nextSiblingMacheteGeneratedEntry == null || !(nextSiblingMacheteGeneratedEntry instanceof MacheteGeneratedEntry)) {
+      return Option.none();
+    }
+
+    return Option.of((MacheteGeneratedEntry) nextSiblingMacheteGeneratedEntry);
+  }
+
+  private Option<MacheteGeneratedEntry> getPrevSiblingMacheteGeneratedEntry(PsiElement currentElement) {
+    PsiElement prevSiblingMacheteGeneratedEntry = currentElement.getPrevSibling();
+    while (prevSiblingMacheteGeneratedEntry != null && !(prevSiblingMacheteGeneratedEntry instanceof MacheteGeneratedEntry)) {
+      prevSiblingMacheteGeneratedEntry = prevSiblingMacheteGeneratedEntry.getPrevSibling();
+    }
+
+    if (prevSiblingMacheteGeneratedEntry == null || !(prevSiblingMacheteGeneratedEntry instanceof MacheteGeneratedEntry)) {
+      return Option.none();
+    }
+
+    return Option.of((MacheteGeneratedEntry) prevSiblingMacheteGeneratedEntry);
+  }
+
+  @Data
+  private class IndentationParameters {
+    private final char indentationCharacter;
+    private final int indentationWidth;
   }
 }

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -118,6 +118,8 @@ public class MacheteAnnotator implements Annotator {
 
     var indentationText = indentationNodeOption.get().getText();
 
+    @SuppressWarnings("index")
+    // Indentation text is never empty (otherwise element does not exist)
     char indentationChar = indentationText.charAt(0);
     int indentationWidth = indentationText.length();
 

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.5.0-42'
+  PLUGIN_VERSION = '0.5.0-43'
 }


### PR DESCRIPTION
Maybe not the simplest and clearest one but it is: implementation of invalid indentation highlighting based on Machete Annotator class.
Probably better solution would be use a flexer to do this but something went wrong wen I try using it and I have no idea how to assign custom tooltip error text when mouse is hovered on selected error (see the first commit in this PR)