### PR TITLE
Fix ASCII-printing of repository in tests in case the last child of any branch has a child itself

### DIFF
--- a/testCommon/src/test/resources/setup-with-no-remotes.sh
+++ b/testCommon/src/test/resources/setup-with-no-remotes.sh
@@ -23,7 +23,7 @@ newrepo machete-sandbox
   newb call-ws
     cmt Call web service
     cmt 1st round of fixes
-  newb drop-constraint # not added to definition file
+  newb drop-constraint
     cmt Drop unneeded SQL constraints
   git checkout call-ws
     cmt 2nd round of fixes
@@ -35,6 +35,7 @@ newrepo machete-sandbox
       allow-ownership-link PR #123
           build-chain PR #124
       call-ws
+          drop-constraint
   '
   sed 's/^  //' <<< "$machete_file" > .git/machete
 )

--- a/version.gradle
+++ b/version.gradle
@@ -1,3 +1,3 @@
 ext {
-  PLUGIN_VERSION = '0.5.2-4'
+  PLUGIN_VERSION = '0.5.2-5'
 }


### PR DESCRIPTION
See `call-ws`/`drop-constraint` here:

```
develop  Tue Jun 30 10:43:12 2020 +0200
|
| Allow ownership links
| 1st round of fixes
x-allow-ownership-link  PR #123  Tue Jun 30 10:43:12 2020 +0200
| |
| | Build arbitrarily long chains
| x-build-chain  PR #124  Tue Jun 30 10:43:12 2020 +0200
|
| Call web service
| 1st round of fixes
| 2nd round of fixes
o-call-ws *  Tue Jun 30 10:43:12 2020 +0200
| |
| | Drop unneeded SQL constraints
| x-drop-constraint  Tue Jun 30 10:43:12 2020 +0200
```