### PR TITLE
Rectify test repo setup scripts + add fake commit/reflog entry date setup

### DIFF
--- a/scripts/setup-multiroot-sandbox
+++ b/scripts/setup-multiroot-sandbox
@@ -4,11 +4,11 @@ set -e
 
 sandboxDir=machete-sandbox
 
-newb() {
+create_branch() {
   git checkout -b $1
 }
 
-cmt() {
+commit() {
   b=$(git symbolic-ref --short HEAD)
   f=${b/\//-}-${1}-${2}.txt
   touch $f
@@ -16,7 +16,7 @@ cmt() {
   git commit -m "$*"
 }
 
-newrepo() {
+create_repo() {
   dir=$sandboxDir/$1
   mkdir ~/$dir
   cd ~/$dir
@@ -45,38 +45,38 @@ init() {
 init
 
 newremote filter-service
-newrepo filter-service
+create_repo filter-service
 git remote add origin ~/$sandboxDir/filter-service-remote
 
-newb root
-  cmt Root
-newb develop
-  cmt Develop commit
-newb allow-ownership-link
-  cmt Allow ownership links
+create_branch root
+  commit Root
+create_branch develop
+  commit Develop commit
+create_branch allow-ownership-link
+  commit Allow ownership links
   push
-newb build-chain
-  cmt Build arbitrarily long chains
+create_branch build-chain
+  commit Build arbitrarily long chains
 git checkout allow-ownership-link
-  cmt 1st round of fixes
+  commit 1st round of fixes
 git checkout develop
-  cmt Other develop commit
+  commit Other develop commit
   push
-newb call-ws
-  cmt Call web service
-  cmt 1st round of fixes
+create_branch call-ws
+  commit Call web service
+  commit 1st round of fixes
   push
-newb drop-constraint # not added to definition file
-  cmt Drop unneeded SQL constraints
+create_branch drop-constraint # not added to definition file
+  commit Drop unneeded SQL constraints
 git checkout call-ws
-  cmt 2nd round of fixes
+  commit 2nd round of fixes
 
 git checkout root
-newb master
-  cmt Master commit
+create_branch master
+  commit Master commit
   push
-newb hotfix/add-trigger
-  cmt HOTFIX Add the trigger
+create_branch hotfix/add-trigger
+  commit HOTFIX Add the trigger
   push
   git commit --amend -m 'HOTFIX Add the trigger (amended)'
 
@@ -98,57 +98,57 @@ echo
 echo
 
 newremote generator-service
-newrepo generator-service
+create_repo generator-service
 git remote add origin ~/$sandboxDir/generator-service-remote
 
-newb root
-  cmt Root
-newb develop
-  cmt 'Develop commit (probably empty)'
-newb forbid-ownership-link
-  cmt Forbid ownership links
+create_branch root
+  commit Root
+create_branch develop
+  commit 'Develop commit (probably empty)'
+create_branch forbid-ownership-link
+  commit Forbid ownership links
   push
-newb destroy-chain
-  cmt Destroy arbitrarily long chains
+create_branch destroy-chain
+  commit Destroy arbitrarily long chains
 git checkout forbid-ownership-link
-  cmt n-th round of fixes
+  commit n-th round of fixes
 git checkout develop
-  cmt Other develop commit - this one too
+  commit Other develop commit - this one too
   push
-newb send-a-pigeon-for-ws
-  cmt Send a pigeon for web service
-  cmt 1st round of bugs
-  push
-git checkout forbid-ownership-link
-newb toggle-rain
-  cmt toggle
-  cmt toggle 2
-  push
-  cmt toggle 3
-newb make-coffee
-  cmt Get water
-  cmt Search for help
+create_branch send-a-pigeon-for-ws
+  commit Send a pigeon for web service
+  commit 1st round of bugs
   push
 git checkout forbid-ownership-link
-newb go-home
-  cmt run
-  cmt ide
+create_branch toggle-rain
+  commit toggle
+  commit toggle 2
+  push
+  commit toggle 3
+create_branch make-coffee
+  commit Get water
+  commit Search for help
   push
 git checkout forbid-ownership-link
-newb add-constraint # not added to definition file
-  cmt Add unneeded SQL constraints
+create_branch go-home
+  commit run
+  commit ide
+  push
+git checkout forbid-ownership-link
+create_branch add-constraint # not added to definition file
+  commit Add unneeded SQL constraints
 git checkout send-a-pigeon-for-ws
-  cmt 2nd round of bugs
+  commit 2nd round of bugs
 
 git checkout root
-newb master
-  cmt 'Master of puppets!!111111oneoneone commit'
+create_branch master
+  commit 'Master of puppets!!111111oneoneone commit'
   push
-newb coldfix/knor
-  cmt pudliszki
+create_branch coldfix/knor
+  commit pudliszki
   push
-newb hotfix/remove-trigger
-  cmt HOTFIX Remove the trigger
+create_branch hotfix/remove-trigger
+  commit HOTFIX Remove the trigger
   push
   git commit --amend -m 'HOTFIX Remove the trigger (amended)'
 

--- a/testCommon/src/test/resources/common.sh
+++ b/testCommon/src/test/resources/common.sh
@@ -10,11 +10,26 @@ EOF
 
 # All functions defined here are guaranteed to preserve the original current working directory.
 
-newrepo() {
+function set_fake_git_date() {
+  if (( $# != 1 )); then
+    echo "${FUNCNAME[0]} <date> needs 1 parameter, $# was given"
+    exit 100
+  fi
+
+  local date=$1
+  # Note that GIT_COMMITTER_DATE is recorded not only into the commits but also into reflog entries.
+  export GIT_COMMITTER_DATE="$date 12:34:56"
+}
+
+commit_day_of_month=1
+
+function create_repo() {
   if (( $# < 1 )); then
     echo "${FUNCNAME[0]} <dir> [<git-init-options>...] needs at least 1 parameter, $# was given"
     exit 100
   fi
+
+  set_fake_git_date 2020-01-$commit_day_of_month
 
   local dir=$1
   mkdir -p $dir
@@ -30,7 +45,7 @@ newrepo() {
   cd -
 }
 
-newb() {
+function create_branch() {
   if (( $# != 1 )); then
     echo "${FUNCNAME[0]} <branch-name> needs 1 parameter, $# was given"
     exit 100
@@ -39,7 +54,7 @@ newb() {
   git checkout -b $1
 }
 
-cmt() {
+function commit() {
   if (( $# < 1 )); then
     echo "${FUNCNAME[0]} <commit-message-words...> needs at least 1 parameter, $# was given"
     exit 100
@@ -50,9 +65,10 @@ cmt() {
   touch $f
   git add $f
   git commit -m "$*"
+  set_fake_git_date 2020-01-$((++commit_day_of_month))
 }
 
-push() {
+function push() {
   local b=$(git symbolic-ref --short HEAD)
   git push -u ${1-origin} $b
 }

--- a/testCommon/src/test/resources/setup-for-diverged-and-older-than.sh
+++ b/testCommon/src/test/resources/setup-for-diverged-and-older-than.sh
@@ -6,42 +6,42 @@ self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/common.sh
 
 
-newrepo machete-sandbox-remote --bare
+create_repo machete-sandbox-remote --bare
 
-newrepo machete-sandbox
+create_repo machete-sandbox
 (
   cd machete-sandbox
   git remote add origin ../machete-sandbox-remote
 
-  newb root
-    cmt Root
-  newb develop
-    cmt Develop commit
-  newb allow-ownership-link
-    cmt Allow ownership links
+  create_branch root
+    commit Root
+  create_branch develop
+    commit Develop commit
+  create_branch allow-ownership-link
+    commit Allow ownership links
     push
-  newb build-chain
-    cmt Build arbitrarily long chains
+  create_branch build-chain
+    commit Build arbitrarily long chains
   git checkout allow-ownership-link
-    cmt 1st round of fixes
+    commit 1st round of fixes
   git checkout develop
-    cmt Other develop commit
+    commit Other develop commit
     push
-  newb call-ws
-    cmt Call web service
-    cmt 1st round of fixes
+  create_branch call-ws
+    commit Call web service
+    commit 1st round of fixes
     push
-  newb drop-constraint # not added to definition file
-    cmt Drop unneeded SQL constraints
+  create_branch drop-constraint # not added to definition file
+    commit Drop unneeded SQL constraints
   git checkout call-ws
-    cmt 2nd round of fixes
+    commit 2nd round of fixes
 
   git checkout root
-  newb master
-    cmt Master commit
+  create_branch master
+    commit Master commit
     push
-  newb hotfix/add-trigger
-    cmt HOTFIX Add the trigger
+  create_branch hotfix/add-trigger
+    commit HOTFIX Add the trigger
     push
     git commit --amend -m 'HOTFIX Add the trigger (amended)'
 
@@ -58,18 +58,18 @@ newrepo machete-sandbox
   sed 's/^  //' <<< "$machete_file" > .git/machete
 )
 
-newrepo machete-sandbox2
+create_repo machete-sandbox2
 (
   cd machete-sandbox2
   git remote add origin ../machete-sandbox-remote
   git fetch
 
   git checkout allow-ownership-link
-  cmt Newer commit
+  commit Newer commit
   push
 
   git checkout master
-  cmt Master newer commit
+  commit Master newer commit
   push
 )
 

--- a/testCommon/src/test/resources/setup-for-overridden-fork-point.sh
+++ b/testCommon/src/test/resources/setup-for-overridden-fork-point.sh
@@ -5,22 +5,22 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/common.sh
 
-newrepo machete-sandbox-remote --bare
+create_repo machete-sandbox-remote --bare
 
-newrepo machete-sandbox
+create_repo machete-sandbox
 (
   cd machete-sandbox
   git remote add origin ../machete-sandbox-remote
 
-  newb root
-    cmt Root
-  newb develop
-    cmt Develop commit
+  create_branch root
+    commit Root
+  create_branch develop
+    commit Develop commit
     push
-  newb allow-ownership-link # not added to definition file
-    cmt Allow ownership links
-  newb build-chain
-    cmt Build arbitrarily long chains
+  create_branch allow-ownership-link # not added to definition file
+    commit Allow ownership links
+  create_branch build-chain
+    commit Build arbitrarily long chains
     push
 
   git branch -d root

--- a/testCommon/src/test/resources/setup-for-yellow-edges.sh
+++ b/testCommon/src/test/resources/setup-for-yellow-edges.sh
@@ -5,37 +5,37 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/common.sh
 
-newrepo machete-sandbox-remote --bare
+create_repo machete-sandbox-remote --bare
 
-newrepo machete-sandbox
+create_repo machete-sandbox
 (
   cd machete-sandbox
   git remote add origin ../machete-sandbox-remote
 
-  newb root
-    cmt Root
-  newb develop
-    cmt Develop commit
-  newb allow-ownership-link # not added to definition file
-    cmt Allow ownership links
+  create_branch root
+    commit Root
+  create_branch develop
+    commit Develop commit
+  create_branch allow-ownership-link # not added to definition file
+    commit Allow ownership links
     push
-  newb build-chain
-    cmt Build arbitrarily long chains
-  newb call-ws
-    cmt Call web service
-    cmt 1st round of fixes
+  create_branch build-chain
+    commit Build arbitrarily long chains
+  create_branch call-ws
+    commit Call web service
+    commit 1st round of fixes
     push
-  newb drop-constraint # not added to definition file
-    cmt Drop unneeded SQL constraints
+  create_branch drop-constraint # not added to definition file
+    commit Drop unneeded SQL constraints
   git checkout call-ws
-    cmt 2nd round of fixes
+    commit 2nd round of fixes
 
   git checkout root
-  newb master
-    cmt Master commit
+  create_branch master
+    commit Master commit
     push
-  newb hotfix/add-trigger
-    cmt HOTFIX Add the trigger
+  create_branch hotfix/add-trigger
+    commit HOTFIX Add the trigger
     push
     git commit --amend -m 'HOTFIX Add the trigger (amended)'
 

--- a/testCommon/src/test/resources/setup-with-multiple-remotes.sh
+++ b/testCommon/src/test/resources/setup-with-multiple-remotes.sh
@@ -5,45 +5,45 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/common.sh
 
-newrepo machete-sandbox-remote1 --bare
-newrepo machete-sandbox-remote2 --bare
+create_repo machete-sandbox-remote1 --bare
+create_repo machete-sandbox-remote2 --bare
 
-newrepo machete-sandbox
+create_repo machete-sandbox
 (
   cd machete-sandbox
   git remote add remote1 ../machete-sandbox-remote1
   git remote add remote2 ../machete-sandbox-remote2
 
-  newb root
-    cmt Root
-  newb develop
-    cmt Develop commit
-  newb allow-ownership-link
-    cmt Allow ownership links
+  create_branch root
+    commit Root
+  create_branch develop
+    commit Develop commit
+  create_branch allow-ownership-link
+    commit Allow ownership links
     push remote1
-  newb build-chain
-    cmt Build arbitrarily long chains
+  create_branch build-chain
+    commit Build arbitrarily long chains
   git checkout allow-ownership-link
-    cmt 1st round of fixes
+    commit 1st round of fixes
   git checkout develop
-    cmt Other develop commit
+    commit Other develop commit
     push remote1
-  newb call-ws
-    cmt Call web service
-    cmt 1st round of fixes
+  create_branch call-ws
+    commit Call web service
+    commit 1st round of fixes
     push remote1
     git branch --unset-upstream  # let's remove tracking config
-  newb drop-constraint # not added to definition file
-    cmt Drop unneeded SQL constraints
+  create_branch drop-constraint # not added to definition file
+    commit Drop unneeded SQL constraints
   git checkout call-ws
-    cmt 2nd round of fixes
+    commit 2nd round of fixes
 
   git checkout root
-  newb master
-    cmt Master commit
+  create_branch master
+    commit Master commit
     push remote2
-  newb hotfix/add-trigger
-    cmt HOTFIX Add the trigger
+  create_branch hotfix/add-trigger
+    commit HOTFIX Add the trigger
     push remote2
     git branch --unset-upstream  # let's remove tracking config
     git commit --amend -m 'HOTFIX Add the trigger (amended)'

--- a/testCommon/src/test/resources/setup-with-no-remotes.sh
+++ b/testCommon/src/test/resources/setup-with-no-remotes.sh
@@ -5,28 +5,28 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/common.sh
 
-newrepo machete-sandbox
+create_repo machete-sandbox
 (
   cd machete-sandbox
-  newb root
-    cmt Root
-  newb develop
-    cmt Develop commit
-  newb allow-ownership-link
-    cmt Allow ownership links
-  newb build-chain
-    cmt Build arbitrarily long chains
+  create_branch root
+    commit Root
+  create_branch develop
+    commit Develop commit
+  create_branch allow-ownership-link
+    commit Allow ownership links
+  create_branch build-chain
+    commit Build arbitrarily long chains
   git checkout allow-ownership-link
-    cmt 1st round of fixes
+    commit 1st round of fixes
   git checkout develop
-    cmt Other develop commit
-  newb call-ws
-    cmt Call web service
-    cmt 1st round of fixes
-  newb drop-constraint
-    cmt Drop unneeded SQL constraints
+    commit Other develop commit
+  create_branch call-ws
+    commit Call web service
+    commit 1st round of fixes
+  create_branch drop-constraint
+    commit Drop unneeded SQL constraints
   git checkout call-ws
-    cmt 2nd round of fixes
+    commit 2nd round of fixes
 
   git branch -d root
 

--- a/testCommon/src/test/resources/setup-with-single-remote.sh
+++ b/testCommon/src/test/resources/setup-with-single-remote.sh
@@ -5,42 +5,42 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/common.sh
 
-newrepo machete-sandbox-remote --bare
+create_repo machete-sandbox-remote --bare
 
-newrepo machete-sandbox
+create_repo machete-sandbox
 (
   cd machete-sandbox
   git remote add origin ../machete-sandbox-remote
 
-  newb root
-    cmt Root
-  newb develop
-    cmt Develop commit
-  newb allow-ownership-link
-    cmt Allow ownership links
+  create_branch root
+    commit Root
+  create_branch develop
+    commit Develop commit
+  create_branch allow-ownership-link
+    commit Allow ownership links
     push
-  newb build-chain
-    cmt Build arbitrarily long chains
+  create_branch build-chain
+    commit Build arbitrarily long chains
   git checkout allow-ownership-link
-    cmt 1st round of fixes
+    commit 1st round of fixes
   git checkout develop
-    cmt Other develop commit
+    commit Other develop commit
     push
-  newb call-ws
-    cmt Call web service
-    cmt 1st round of fixes
+  create_branch call-ws
+    commit Call web service
+    commit 1st round of fixes
     push
-  newb drop-constraint # not added to definition file
-    cmt Drop unneeded SQL constraints
+  create_branch drop-constraint # not added to definition file
+    commit Drop unneeded SQL constraints
   git checkout call-ws
-    cmt 2nd round of fixes
+    commit 2nd round of fixes
 
   git checkout root
-  newb master
-    cmt Master commit
+  create_branch master
+    commit Master commit
     push
-  newb hotfix/add-trigger
-    cmt HOTFIX Add the trigger
+  create_branch hotfix/add-trigger
+    commit HOTFIX Add the trigger
     push
     git commit --amend -m 'HOTFIX Add the trigger (amended)'
 


### PR DESCRIPTION
:100: :100: :100: :100: 
The improved (2.15.0-compatible) implementation of discover relies on reflog timestamps, so it's necessary to spread them over time a bit (so far they were all just landing within the same second/two seconds)