### PR TITLE
Rework test setups so that they lead to different results under 2.14.0 vs 2.15.2 `git machete discover`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ Other coding conventions include:
   `::` notation is confusing when applied to parameterless lambdas, as it suggests a unary lambda.
 * Use `get...` method names for pure methods that only return the value without doing any heavy workload like accessing git repository.
   Use `derive...` method names for methods that actually compute their result and/or can return a different value every time when accessed.
+* Non-obvious method params that have values like `false`, `true`, `0`, `1`, `null`, `""` should be preceded with a `/* comment */ `
+  containing the name of the param.
+
 
 ## Check dependency updates
 

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
@@ -159,7 +159,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           .mapValues(pairsOfCommitHashAndBranchName -> pairsOfCommitHashAndBranchName
               .map(commitHashAndBranchName -> commitHashAndBranchName._2));
 
-      LOG.debug(() -> "Derived the map of branches containing given commit in reflog:");
+      LOG.debug("Derived the map of branches containing given commit in reflog:");
       LOG.debug(() -> result.toList().map(kv -> kv._1 + " -> " + kv._2.mkString(", "))
           .sorted().mkString(System.lineSeparator()));
       branchesContainingGivenCommitInReflog = result;

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/IntegrationTestUtils.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/IntegrationTestUtils.java
@@ -1,0 +1,25 @@
+package com.virtuslab.gitmachete.backend.integration;
+
+import java.util.concurrent.TimeUnit;
+
+import lombok.SneakyThrows;
+import org.junit.Assert;
+
+class IntegrationTestUtils {
+
+  @SneakyThrows
+  static void ensureCliVersionIs(String cliReferenceVersion) {
+    var process = new ProcessBuilder().command("git", "machete", "--version").start();
+    process.waitFor(1, TimeUnit.SECONDS);
+    var exitValue = process.exitValue();
+    if (exitValue != 0) {
+      Assert.fail("git-machete CLI is not installed");
+    }
+    var version = new String(process.getInputStream().readAllBytes())
+        .stripTrailing()
+        .replace("git-machete version ", "");
+    if (!version.equals(cliReferenceVersion)) {
+      Assert.fail("git-machete is expected in version ${cliReferenceVersion}, found ${version}");
+    }
+  }
+}

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
@@ -7,12 +7,11 @@ import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Relation.D
 import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Relation.InSyncToRemote;
 import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Relation.NoRemotes;
 import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Relation.Untracked;
+import static com.virtuslab.gitmachete.backend.integration.IntegrationTestUtils.ensureCliVersionIs;
 import static io.vavr.API.$;
 import static io.vavr.API.Case;
 import static io.vavr.API.Match;
 import static org.junit.runners.Parameterized.Parameters;
-
-import java.util.concurrent.TimeUnit;
 
 import io.vavr.collection.List;
 import io.vavr.collection.Set;
@@ -37,12 +36,10 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRootBranch;
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 import com.virtuslab.gitmachete.backend.impl.GitMacheteRepositoryCache;
-import com.virtuslab.gitmachete.testcommon.BaseGitRepositoryBackedTestSuite;
+import com.virtuslab.gitmachete.testcommon.BaseGitRepositoryBackedIntegrationTestSuite;
 
 @RunWith(Parameterized.class)
-public class GitMacheteStatusTestSuite extends BaseGitRepositoryBackedTestSuite {
-
-  public static final String CLI_REFERENCE_VERSION = "2.14.0";
+public class StatusAndDiscoverIntegrationTestSuite extends BaseGitRepositoryBackedIntegrationTestSuite {
 
   private final IBranchLayoutReader branchLayoutReader = RuntimeBinding
       .instantiateSoleImplementingClass(IBranchLayoutReader.class);
@@ -51,20 +48,8 @@ public class GitMacheteStatusTestSuite extends BaseGitRepositoryBackedTestSuite 
   private IGitMacheteRepositorySnapshot gitMacheteRepositorySnapshot;
 
   @BeforeClass
-  @SneakyThrows
-  public static void verifyCliVersion() {
-    var process = new ProcessBuilder().command("git", "machete", "--version").start();
-    process.waitFor(1, TimeUnit.SECONDS);
-    var exitValue = process.exitValue();
-    if (exitValue != 0) {
-      Assert.fail("git-machete CLI is not installed");
-    }
-    var version = new String(process.getInputStream().readAllBytes())
-        .stripTrailing()
-        .replace("git-machete version ", "");
-    if (!version.equals(CLI_REFERENCE_VERSION)) {
-      Assert.fail("git-machete is expected in version ${CLI_REFERENCE_VERSION}, found ${version}");
-    }
+  public static void ensureExpectedCliVersion() {
+    ensureCliVersionIs("2.14.0");
   }
 
   @Parameters(name = "{0} (#{index})")
@@ -80,7 +65,7 @@ public class GitMacheteStatusTestSuite extends BaseGitRepositoryBackedTestSuite 
   }
 
   @SneakyThrows
-  public GitMacheteStatusTestSuite(String scriptName) {
+  public StatusAndDiscoverIntegrationTestSuite(String scriptName) {
     super(scriptName);
     gitMacheteRepository = gitMacheteRepositoryCache.getInstance(repositoryMainDir, repositoryGitDir);
   }

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/UpstreamInferenceIntegrationTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/UpstreamInferenceIntegrationTestSuite.java
@@ -1,9 +1,11 @@
 package com.virtuslab.gitmachete.backend.integration;
 
+import static com.virtuslab.gitmachete.backend.integration.IntegrationTestUtils.ensureCliVersionIs;
 import static org.junit.runners.Parameterized.Parameters;
 
 import lombok.SneakyThrows;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -16,10 +18,10 @@ import com.virtuslab.branchlayout.api.readwrite.IBranchLayoutReader;
 import com.virtuslab.gitmachete.backend.api.IGitMacheteRepository;
 import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 import com.virtuslab.gitmachete.backend.impl.GitMacheteRepositoryCache;
-import com.virtuslab.gitmachete.testcommon.BaseGitRepositoryBackedTestSuite;
+import com.virtuslab.gitmachete.testcommon.BaseGitRepositoryBackedIntegrationTestSuite;
 
 @RunWith(Parameterized.class)
-public class GitMacheteUpstreamInferenceTestSuite extends BaseGitRepositoryBackedTestSuite {
+public class UpstreamInferenceIntegrationTestSuite extends BaseGitRepositoryBackedIntegrationTestSuite {
 
   private final GitMacheteRepositoryCache gitMacheteRepositoryCache = new GitMacheteRepositoryCache();
   private final IGitMacheteRepository gitMacheteRepository;
@@ -27,6 +29,11 @@ public class GitMacheteUpstreamInferenceTestSuite extends BaseGitRepositoryBacke
 
   private final String forBranch;
   private final String expectedUpstream;
+
+  @BeforeClass
+  public static void ensureExpectedCliVersion() {
+    ensureCliVersionIs("2.14.0");
+  }
 
   @Parameters(name = "{0}: inferred upstream of {1} should be {2} (#{index})")
   public static String[][] getTestData() {
@@ -40,7 +47,7 @@ public class GitMacheteUpstreamInferenceTestSuite extends BaseGitRepositoryBacke
   }
 
   @SneakyThrows
-  public GitMacheteUpstreamInferenceTestSuite(String scriptName, String forBranch, String expectedUpstream) {
+  public UpstreamInferenceIntegrationTestSuite(String scriptName, String forBranch, String expectedUpstream) {
     super(scriptName);
     this.forBranch = forBranch;
     this.expectedUpstream = expectedUpstream;

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTestSuite.java
@@ -13,7 +13,7 @@ import com.virtuslab.gitmachete.backend.impl.GitMacheteRepository;
 import com.virtuslab.gitmachete.backend.impl.hooks.PreRebaseHookExecutor;
 import com.virtuslab.gitmachete.backend.impl.hooks.StatusBranchHookExecutor;
 
-public class BaseGitMacheteRepositoryTestSuite {
+public class BaseGitMacheteRepositoryUnitTestSuite {
 
   private static final Class<?> AUX_CLASS = getAuxClass();
 

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveParentAwareForkPointUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveParentAwareForkPointUnitTestSuite.java
@@ -1,7 +1,7 @@
 package com.virtuslab.gitmachete.backend.unit;
 
-import static com.virtuslab.gitmachete.backend.unit.TestUtils.createGitCoreCommit;
-import static com.virtuslab.gitmachete.backend.unit.TestUtils.createGitCoreLocalBranch;
+import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.createGitCoreCommit;
+import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.createGitCoreLocalBranch;
 import static org.mockito.ArgumentMatchers.any;
 
 import io.vavr.collection.Stream;
@@ -16,7 +16,7 @@ import com.virtuslab.gitcore.api.IGitCoreCommit;
 import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitmachete.backend.impl.GitMacheteForkPointCommit;
 
-public class GitMacheteRepository_deriveParentAwareForkPointTestSuite extends BaseGitMacheteRepositoryTestSuite {
+public class GitMacheteRepository_deriveParentAwareForkPointUnitTestSuite extends BaseGitMacheteRepositoryUnitTestSuite {
 
   @SneakyThrows
   private Option<IGitCoreCommit> invokeDeriveParentAwareForkPoint(

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToParentStatusUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToParentStatusUnitTestSuite.java
@@ -1,8 +1,8 @@
 package com.virtuslab.gitmachete.backend.unit;
 
-import static com.virtuslab.gitmachete.backend.unit.TestUtils.TestGitCoreReflogEntry;
-import static com.virtuslab.gitmachete.backend.unit.TestUtils.createGitCoreCommit;
-import static com.virtuslab.gitmachete.backend.unit.TestUtils.createGitCoreLocalBranch;
+import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.TestGitCoreReflogEntry;
+import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.createGitCoreCommit;
+import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.createGitCoreLocalBranch;
 
 import io.vavr.collection.List;
 import lombok.SneakyThrows;
@@ -16,7 +16,7 @@ import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.backend.impl.GitMacheteForkPointCommit;
 
-public class GitMacheteRepository_deriveSyncToParentStatusTestSuite extends BaseGitMacheteRepositoryTestSuite {
+public class GitMacheteRepository_deriveSyncToParentStatusUnitTestSuite extends BaseGitMacheteRepositoryUnitTestSuite {
 
   private static final IGitCoreCommit MISSING_FORK_POINT = createGitCoreCommit();
 

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite.java
@@ -17,7 +17,7 @@ import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitcore.api.IGitCoreRemoteBranchSnapshot;
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 
-public class GitMacheteRepository_deriveSyncToRemoteStatusTestSuite extends BaseGitMacheteRepositoryTestSuite {
+public class GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite extends BaseGitMacheteRepositoryUnitTestSuite {
 
   private static final String ORIGIN = "origin";
 

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/UnitTestUtils.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/UnitTestUtils.java
@@ -17,7 +17,7 @@ import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitcore.api.IGitCorePersonIdentity;
 import com.virtuslab.gitcore.api.IGitCoreReflogEntry;
 
-public class TestUtils {
+class UnitTestUtils {
 
   static TestGitCoreCommit createGitCoreCommit() {
     return new TestGitCoreCommit();

--- a/scripts/git-hooks/machete-pre-rebase
+++ b/scripts/git-hooks/machete-pre-rebase
@@ -2,9 +2,10 @@
 
 set -e -o pipefail -u
 
-source "$(git rev-parse --show-toplevel)"/scripts/utils.sh
+# As per git hook spec, we can rely on this script being executed in the main repository dir.
+source scripts/utils.sh
 
-if [ $# -eq 3 ]; then
+if (( $# == 3 )); then
   new_base=$1
   fork_point=$2
   current_branch=$3
@@ -22,7 +23,7 @@ if [ $# -eq 3 ]; then
     do_rewrite=false
   elif (( $base_patch > $head_patch )); then
     do_rewrite=true
-  else  # $base_patch < $head_patch
+  else  # $base_patch <= $head_patch
     do_rewrite=false
   fi
 
@@ -34,7 +35,7 @@ if [ $# -eq 3 ]; then
     export FILTER_BRANCH_SQUELCH_WARNING=1
     git filter-branch -f --tree-filter "$self_path $base_version" "$fork_point".."$current_branch"
   fi
-elif [ $# -eq 1 ]; then
+elif (( $# == 1 )); then
   target_version=$1
 
   # Using `-i.bak` and not just `-i` to retain compatibility with both Linux (GNU) sed and OS X (BSD) sed.

--- a/scripts/git-hooks/machete-status-branch
+++ b/scripts/git-hooks/machete-status-branch
@@ -2,7 +2,8 @@
 
 set -e -o pipefail -u
 
-source "$(git rev-parse --show-toplevel)"/scripts/utils.sh
+# As per git hook spec, we can rely on this script being executed in the main repository dir.
+source scripts/utils.sh
 
 [[ ${1-} ]] || die "usage: $(basename "$0") <branch-name>"
 branch=$1

--- a/scripts/run-ui-tests
+++ b/scripts/run-ui-tests
@@ -9,6 +9,8 @@ source "$self_dir"/utils.sh
 intellij_version=${1-} # can be skipped; the same IntelliJ version that the plugin has been built against will be assumed
 
 ide_log=build/idea-sandbox/system/log/idea.log
+# idea.log is not automatically cleared before each `runIde(forUiTests)`
+# and we don't want to print the potential logs from the previous runs.
 ide_log_last_line=$(cat $ide_log 2>/dev/null | wc -l || true)  # will be 0 if $ide_log doesn't exist yet
 
 function ide_logs_from_this_run() {

--- a/testCommon/src/test/java/com/virtuslab/gitmachete/testcommon/BaseGitRepositoryBackedIntegrationTestSuite.java
+++ b/testCommon/src/test/java/com/virtuslab/gitmachete/testcommon/BaseGitRepositoryBackedIntegrationTestSuite.java
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
 import org.junit.Assert;
 
-public abstract class BaseGitRepositoryBackedTestSuite {
+public abstract class BaseGitRepositoryBackedIntegrationTestSuite {
 
   protected final static String SETUP_FOR_NO_REMOTES = "setup-with-no-remotes.sh";
   protected final static String SETUP_WITH_SINGLE_REMOTE = "setup-with-single-remote.sh";
@@ -25,7 +25,7 @@ public abstract class BaseGitRepositoryBackedTestSuite {
   protected final Path repositoryGitDir;
 
   @SneakyThrows
-  protected BaseGitRepositoryBackedTestSuite(String scriptName) {
+  protected BaseGitRepositoryBackedIntegrationTestSuite(String scriptName) {
     parentDir = Files.createTempDirectory("machete-tests-");
     repositoryMainDir = parentDir.resolve("machete-sandbox");
     repositoryGitDir = repositoryMainDir.resolve(".git");

--- a/testCommon/src/test/resources/common.sh
+++ b/testCommon/src/test/resources/common.sh
@@ -61,7 +61,7 @@ function commit() {
   fi
 
   local b=$(git symbolic-ref --short HEAD)
-  local f=${b/\//-}-$(sed 's/ /-/g' <<< "$@").txt
+  local f=${b//\//-}-$(sed 's/[ /]/-/g' <<< "$@").txt
   touch $f
   git add $f
   git commit -m "$*"

--- a/testCommon/src/test/resources/setup-for-diverged-and-older-than.sh
+++ b/testCommon/src/test/resources/setup-for-diverged-and-older-than.sh
@@ -31,10 +31,12 @@ create_repo machete-sandbox
     commit Call web service
     commit 1st round of fixes
     push
-  create_branch drop-constraint # not added to definition file
-    commit Drop unneeded SQL constraints
   git checkout call-ws
     commit 2nd round of fixes
+  git checkout develop
+    # call-ws is merged to develop, and would have no downstream branches in the discovered layout,
+    # so it should be skipped from the discovered layout
+    git merge --ff-only call-ws
 
   git checkout root
   create_branch master

--- a/testCommon/src/test/resources/setup-with-multiple-remotes.sh
+++ b/testCommon/src/test/resources/setup-with-multiple-remotes.sh
@@ -33,7 +33,7 @@ create_repo machete-sandbox
     commit 1st round of fixes
     push remote1
     git branch --unset-upstream  # let's remove tracking config
-  create_branch drop-constraint # not added to definition file
+  create_branch drop-constraint  # not added to definition file
     commit Drop unneeded SQL constraints
   git checkout call-ws
     commit 2nd round of fixes

--- a/testCommon/src/test/resources/setup-with-no-remotes.sh
+++ b/testCommon/src/test/resources/setup-with-no-remotes.sh
@@ -8,6 +8,8 @@ source "$self_dir"/common.sh
 create_repo machete-sandbox
 (
   cd machete-sandbox
+  # Let's add more than 10 branches so that some of them (the least recently checked out ones)
+  # should be skipped from the discovered layout
   create_branch root
     commit Root
   create_branch develop
@@ -27,8 +29,20 @@ create_repo machete-sandbox
     commit Drop unneeded SQL constraints
   git checkout call-ws
     commit 2nd round of fixes
-
-  git branch -d root
+  create_branch evict-deps
+    commit Evict conflicting dependencies
+  create_branch fix/component-labels
+    commit Fix component labels
+  create_branch global-context
+    commit Introduce global context
+  create_branch interop-scala-python
+    commit Enable Scala/Python interoperability
+  create_branch java-11-enforce
+    commit Enforce the use of Java 11
+  git checkout allow-ownership-link
+  create_branch kill-process
+    commit Kill the process after 10 seconds
+  git checkout develop
 
   machete_file='
   develop

--- a/uiTests/src/test/java/com/virtuslab/gitmachete/uitest/UiTestSuite.java
+++ b/uiTests/src/test/java/com/virtuslab/gitmachete/uitest/UiTestSuite.java
@@ -11,9 +11,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.virtuslab.gitmachete.testcommon.BaseGitRepositoryBackedTestSuite;
+import com.virtuslab.gitmachete.testcommon.BaseGitRepositoryBackedIntegrationTestSuite;
 
-public class UiTestSuite extends BaseGitRepositoryBackedTestSuite {
+public class UiTestSuite extends BaseGitRepositoryBackedIntegrationTestSuite {
 
   private final static String script = loadScript();
 


### PR DESCRIPTION
We're now compatible with 2.14.0 and not with 2.15.2 (which skips some useless branches from the result) - and the purpose of this PR is to provide "red" test cases for TDD of migration to 2.15.2.