### PR TITLE
Use parent/child naming for branch layout instead of upstream/subentry

### DIFF
--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
@@ -22,7 +22,7 @@ public class BranchLayout implements IBranchLayout {
   }
 
   private static List<IBranchLayoutEntry> collectEntriesRecursively(IBranchLayoutEntry entry) {
-    return entry.getSubentries().flatMap(BranchLayout::collectEntriesRecursively).prepend(entry);
+    return entry.getChildren().flatMap(BranchLayout::collectEntriesRecursively).prepend(entry);
   }
 
   @Override
@@ -44,11 +44,11 @@ public class BranchLayout implements IBranchLayout {
 
   @SuppressWarnings("interning:not.interned") // to allow for `entry == entryToSlideOut`
   private List<IBranchLayoutEntry> slideOut(IBranchLayoutEntry entry, IBranchLayoutEntry entryToSlideOut) {
-    var subentries = entry.getSubentries();
+    var children = entry.getChildren();
     if (entry == entryToSlideOut) {
-      return subentries;
+      return children;
     } else {
-      return List.of(entry.withSubentries(subentries.flatMap(subentry -> slideOut(subentry, entryToSlideOut))));
+      return List.of(entry.withChildren(children.flatMap(child -> slideOut(child, entryToSlideOut))));
     }
   }
 }

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/IBranchLayoutEntry.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/IBranchLayoutEntry.java
@@ -9,9 +9,9 @@ import io.vavr.control.Option;
 public interface IBranchLayoutEntry {
   String getName();
 
-  List<IBranchLayoutEntry> getSubentries();
+  List<IBranchLayoutEntry> getChildren();
 
-  IBranchLayoutEntry withSubentries(List<IBranchLayoutEntry> newSubentry);
+  IBranchLayoutEntry withChildren(List<IBranchLayoutEntry> newChildren);
 
   Option<String> getCustomAnnotation();
 }

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/BranchLayoutEntry.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/BranchLayoutEntry.java
@@ -12,7 +12,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import com.virtuslab.branchlayout.api.IBranchLayoutEntry;
 
 @AllArgsConstructor
-@SuppressWarnings("interning:not.interned") // to allow for `==` comparison in Lombok-generated `withSubentries` method
+@SuppressWarnings("interning:not.interned") // to allow for `==` comparison in Lombok-generated `withChildren` method
 @ToString
 @UsesObjectEquals
 public class BranchLayoutEntry implements IBranchLayoutEntry {
@@ -23,11 +23,11 @@ public class BranchLayoutEntry implements IBranchLayoutEntry {
 
   @Getter
   @With
-  private final List<IBranchLayoutEntry> subentries;
+  private final List<IBranchLayoutEntry> children;
 
-  @ToString.Include(name = "subentries") // avoid recursive `toString` calls on subentries
-  private List<String> getSubentryNames() {
-    return subentries.map(e -> e.getName());
+  @ToString.Include(name = "children") // avoid recursive `toString` calls on children
+  private List<String> getChildNames() {
+    return children.map(e -> e.getName());
   }
 
   @Override

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReader.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReader.java
@@ -36,11 +36,11 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
 
     List<IBranchLayoutEntry> roots = List.empty();
     if (!linesWithoutBlank.isEmpty()) {
-      Array<Tuple2<Integer, Integer>> lineIndexToIndentLevelAndUpstreamLineIndex = parseToArrayRepresentation(path, indentSpec,
+      Array<Tuple2<Integer, Integer>> lineIndexToIndentLevelAndParentLineIndex = parseToArrayRepresentation(path, indentSpec,
           lines);
-      LOG.debug(() -> "lineIndexToIndentLevelAndUpstreamLineIndex = ${lineIndexToIndentLevelAndUpstreamLineIndex}");
+      LOG.debug(() -> "lineIndexToIndentLevelAndParentLineIndex = ${lineIndexToIndentLevelAndParentLineIndex}");
 
-      roots = buildEntriesStructure(linesWithoutBlank, lineIndexToIndentLevelAndUpstreamLineIndex, /* upstreamLineIndex */ -1);
+      roots = buildEntriesStructure(linesWithoutBlank, lineIndexToIndentLevelAndParentLineIndex, /* parentLineIndex */ -1);
     } else {
       LOG.debug("Branch layout file is empty");
     }
@@ -51,33 +51,33 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
   /**
    * @param lines
    *          list of lines read from branch layout file
-   * @param lineIndexToUpstreamLineIndex
+   * @param lineIndexToParentLineIndex
    *          as it says ({@code lines} metadata containing structure, see {@link #parseToArrayRepresentation})
-   * @param upstreamLineIndex
-   *          index of line whose subentries are to be built
+   * @param parentLineIndex
+   *          index of the line whose children are to be built
    *
-   * @return list of entries with recursively built lists of subentries
+   * @return list of entries with recursively built lists of children
    */
   @SuppressWarnings("index:argument.type.incompatible")
   private List<IBranchLayoutEntry> buildEntriesStructure(
       List<String> lines,
-      Array<Tuple2<Integer, Integer>> lineIndexToUpstreamLineIndex,
-      @GTENegativeOne int upstreamLineIndex) {
+      Array<Tuple2<Integer, Integer>> lineIndexToParentLineIndex,
+      @GTENegativeOne int parentLineIndex) {
 
-    return lineIndexToUpstreamLineIndex
+    return lineIndexToParentLineIndex
         .zipWithIndex()
-        .filter(t -> t._1()._2() == upstreamLineIndex)
+        .filter(t -> t._1()._2() == parentLineIndex)
         .map(t -> createEntry(lines.get(t._2()),
-            buildEntriesStructure(lines, lineIndexToUpstreamLineIndex, t._2())))
+            buildEntriesStructure(lines, lineIndexToParentLineIndex, t._2())))
         .toList();
   }
 
   /**
    * Parses line to {@link BranchLayoutEntry#BranchLayoutEntry} arguments and creates an
-   * entry with the specified {@code subentries}.
+   * entry with the specified {@code children}.
    */
-  private IBranchLayoutEntry createEntry(String line, List<IBranchLayoutEntry> subentries) {
-    LOG.debug(() -> "Entering: line = '${line}', subentries = ${subentries}");
+  private IBranchLayoutEntry createEntry(String line, List<IBranchLayoutEntry> children) {
+    LOG.debug(() -> "Entering: line = '${line}', children = ${children}");
 
     String trimmedLine = line.trim();
     String branchName;
@@ -91,13 +91,13 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
       customAnnotation = null;
     }
 
-    var result = new BranchLayoutEntry(branchName, customAnnotation, subentries);
+    var result = new BranchLayoutEntry(branchName, customAnnotation, children);
     LOG.debug(() -> "Created ${result}");
     return result;
   }
 
   /**
-   * @return an array containing the indent level and upstream entry describing line index which indices correspond to
+   * @return an array containing the indent level and parent entry describing line index which indices correspond to
    *         provided {@code lines} indices. It may be understood as a helper metadata needed to build entries structure
    */
   private Array<Tuple2<Integer, Integer>> parseToArrayRepresentation(Path path, IndentSpec indentSpec, List<String> lines)
@@ -113,9 +113,9 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
           "The initial line of branch layout file (${path.toAbsolutePath()}) must not be indented");
     }
 
-    Array<Tuple2<Integer, Integer>> lineIndexToIndentLevelAndUpstreamLineIndex = Array.fill(linesWithoutBlank.size(),
+    Array<Tuple2<Integer, Integer>> lineIndexToIndentLevelAndParentLineIndex = Array.fill(linesWithoutBlank.size(),
         new Tuple2<>(-1, -1));
-    Array<Integer> levelToPresentUpstream = Array.fill(linesWithoutBlank.size(), -1);
+    Array<Integer> levelToPresentParent = Array.fill(linesWithoutBlank.size(), -1);
 
     int previousLevel = 0;
     int lineIndex = 0;
@@ -142,20 +142,20 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
             "One of branches in branch layout file (${path.toAbsolutePath()}) has incorrect level in relation to its parent branch");
       }
 
-      @SuppressWarnings("index:argument.type.incompatible") Integer upstreamLineIndex = level <= 0
+      @SuppressWarnings("index:argument.type.incompatible") Integer parentLineIndex = level <= 0
           ? -1
-          : levelToPresentUpstream.get(level - 1);
-      Tuple2<Integer, Integer> levelAndUpstreamLineIndex = new Tuple2<>(level, upstreamLineIndex);
+          : levelToPresentParent.get(level - 1);
+      Tuple2<Integer, Integer> levelAndParentLineIndex = new Tuple2<>(level, parentLineIndex);
 
-      lineIndexToIndentLevelAndUpstreamLineIndex = lineIndexToIndentLevelAndUpstreamLineIndex.update(lineIndex,
-          levelAndUpstreamLineIndex);
-      levelToPresentUpstream = levelToPresentUpstream.update(level, lineIndex);
+      lineIndexToIndentLevelAndParentLineIndex = lineIndexToIndentLevelAndParentLineIndex.update(lineIndex,
+          levelAndParentLineIndex);
+      levelToPresentParent = levelToPresentParent.update(level, lineIndex);
 
       previousLevel = level;
       lineIndex++;
     }
 
-    return lineIndexToIndentLevelAndUpstreamLineIndex;
+    return lineIndexToIndentLevelAndParentLineIndex;
   }
 
   private @NonNegative int getIndentLevel(Path path, IndentSpec indentSpec, @NonNegative int indent,

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileWriter.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileWriter.java
@@ -25,7 +25,7 @@ public class BranchLayoutFileWriter implements IBranchLayoutWriter {
     LOG.debug(() -> "Entering: path = ${path}, branchLayout = ${branchLayout}, backupOldFile = ${backupOldFile}");
     var indentSpec = BranchLayoutFileUtils.deriveIndentSpec(path);
 
-    var lines = printBranchesOntoStringList(branchLayout.getRootEntries(), indentSpec, /* level */ 0);
+    var lines = printEntriesOntoStringList(branchLayout.getRootEntries(), indentSpec, /* level */ 0);
 
     if (backupOldFile && path.toFile().isFile()) {
       Path parentDir = path.getParent();
@@ -44,8 +44,11 @@ public class BranchLayoutFileWriter implements IBranchLayoutWriter {
         .getOrElseThrow(e -> new BranchLayoutException("Unable to write new branch layout file to ${path}", e));
   }
 
-  private List<String> printBranchesOntoStringList(List<IBranchLayoutEntry> entries, IndentSpec indentSpec,
+  private List<String> printEntriesOntoStringList(
+      List<IBranchLayoutEntry> entries,
+      IndentSpec indentSpec,
       @NonNegative int level) {
+
     List<String> stringList = List.empty();
     for (var entry : entries) {
       var sb = new StringBuilder();
@@ -56,8 +59,8 @@ public class BranchLayoutFileWriter implements IBranchLayoutWriter {
         sb.append(" ").append(customAnnotation.get());
       }
 
-      List<String> resultForSubentries = printBranchesOntoStringList(entry.getSubentries(), indentSpec, level + 1);
-      stringList = stringList.append(sb.toString()).appendAll(resultForSubentries);
+      List<String> resultForChildren = printEntriesOntoStringList(entry.getChildren(), indentSpec, level + 1);
+      stringList = stringList.append(sb.toString()).appendAll(resultForChildren);
     }
     return stringList;
   }

--- a/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutFileReaderTestSuite.java
+++ b/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutFileReaderTestSuite.java
@@ -115,14 +115,14 @@ public class BranchLayoutFileReaderTestSuite {
     // when
     BranchLayoutException exception = assertThrows(BranchLayoutException.class, () -> reader.read(path));
 
-    System.out.println(exception);
+    System.out.println(exception.getMessage());
     // then
     int i = exception.getErrorLine().get();
     assertEquals(4, i);
   }
 
   @Test
-  public void read_givenFileWithSubentryIndentGreaterThanOneToParent_throwsException() {
+  public void read_givenFileWithChildIndentGreaterThanOneToParent_throwsException() {
     // given
     List<String> linesToReturn = List.of(" ", "A", "", "  B", "      C");
     BranchLayoutFileReader reader = getBranchLayoutFileReaderForLines(linesToReturn, /* indentWidth */ 2);

--- a/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutTestSuite.java
+++ b/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutTestSuite.java
@@ -67,9 +67,9 @@ public class BranchLayoutTestSuite {
     // then
     assertEquals(result.getRootEntries().size(), 1);
     assertEquals(result.getRootEntries().get(0).getName(), rootName);
-    var subentries = result.getRootEntries().get(0).getSubentries();
-    assertEquals(subentries.size(), 2);
-    assertEquals(subentries.get(0).getName(), childName0);
-    assertEquals(subentries.get(1).getName(), childName1);
+    var children = result.getRootEntries().get(0).getChildren();
+    assertEquals(children.size(), 2);
+    assertEquals(children.get(0).getName(), childName0);
+    assertEquals(children.get(1).getName(), childName1);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
@@ -37,7 +37,7 @@ public class ToggleListingCommitsAction extends BaseGitMacheteRepositoryReadyAct
     var branchLayout = getBranchLayout(anActionEvent);
     if (branchLayout.isDefined()) {
       boolean anyChildBranchExists = branchLayout.get().getRootEntries()
-          .exists(rootBranch -> rootBranch.getSubentries().nonEmpty());
+          .exists(rootBranch -> rootBranch.getChildren().nonEmpty());
       if (anyChildBranchExists) {
         presentation.setEnabled(true);
         presentation.setDescription("Toggle listing commits");


### PR DESCRIPTION
Not _upstream_/_downstream_: to provide distinction from the naming in backend.
Not _subentry_: to avoid _superentry_ which would be weird.