### PR TITLE
Bugfix/reset with uncommitted

### DIFF
--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -9,6 +9,7 @@ import com.intellij.dvcs.DvcsUtil;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.AccessToken;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
@@ -138,6 +139,8 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
       }
     }
 
+    FileDocumentManager.getInstance().saveAllDocuments();
+
     doResetToRemoteWithKeep(project, gitRepository.get(), branchName.get(), macheteRepository.get(), anActionEvent);
   }
 
@@ -199,8 +202,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
           if (result.success()) {
             VcsNotifier.getInstance(project)
                 .notifySuccess(
-                    format(getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.success"),
-                        branchName));
+                    format(getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.success"), branchName));
             log().debug(() -> "Branch '${branchName}' reset to its remote tracking branch");
 
           } else if (localChangesDetector.wasMessageDetected()) {
@@ -211,8 +213,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
 
           } else {
             log().error(result.getErrorOutputAsJoinedString());
-            VcsNotifier.getInstance(project).notifyError(VCS_NOTIFIER_TITLE,
-                result.getErrorOutputAsHtmlString());
+            VcsNotifier.getInstance(project).notifyError(VCS_NOTIFIER_TITLE, result.getErrorOutputAsHtmlString());
           }
         }
       }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -139,6 +139,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
       }
     }
 
+    // Required to avoid reset with uncommitted changes and file cache conflicts
     FileDocumentManager.getInstance().saveAllDocuments();
 
     doResetToRemoteWithKeep(project, gitRepository.get(), branchName.get(), macheteRepository.get(), anActionEvent);
@@ -203,7 +204,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
             VcsNotifier.getInstance(project)
                 .notifySuccess(
                     format(getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.success"), branchName));
-            log().debug(() -> "Branch '${branchName}' reset to its remote tracking branch");
+            log().debug(() -> "Branch '${branchName}' has been reset to its remote tracking branch");
 
           } else if (localChangesDetector.wasMessageDetected()) {
             LocalChangesWouldBeOverwrittenHelper.showErrorNotification(project,

--- a/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
@@ -65,11 +65,9 @@ action.GitMachete.BaseResetBranchToRemoteAction.description-action-name=Reset to
 action.GitMachete.BaseResetBranchToRemoteAction.info-dialog.dont-show-again=Don't Show Again
 action.GitMachete.BaseResetBranchToRemoteAction.info-dialog.title=Git Machete Reset Info
 action.GitMachete.BaseResetBranchToRemoteAction.info-dialog.ok-text=_Reset
-# TODO (#444): prohibit reset on conflicts with uncommitted
 action.GitMachete.BaseResetBranchToRemoteAction.info-dialog.message=\
   <html>\
     Git Machete Reset performs <b>git reset --keep</b>.<br>\
-    In case of uncommitted changes you will be asked to resolve File Cache Conflicts.<br>\
     Local branch <b>{0}</b> will point to the same commit as its remote branch.<br>\
     Use <b>git reflog</b> to see the history of commits pointed by the branch.\
   </html>

--- a/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
@@ -71,7 +71,7 @@ action.GitMachete.BaseResetBranchToRemoteAction.info-dialog.message=\
     Local branch <b>{0}</b> will point to the same commit as its remote branch.<br>\
     Use <b>git reflog</b> to see the history of commits pointed by the branch.\
   </html>
-action.GitMachete.BaseResetBranchToRemoteAction.notification.success=Branch <b>{0}</b> reset to remote
+action.GitMachete.BaseResetBranchToRemoteAction.notification.success=Branch <b>{0}</b> has been reset to remote
 action.GitMachete.BaseResetBranchToRemoteAction.notification.title=Resetting
 action.GitMachete.BaseResetBranchToRemoteAction.task-title=Resetting...
 


### PR DESCRIPTION
- prohibit reset with uncommitted changes
- save all documents before reset
![image](https://user-images.githubusercontent.com/19799111/88389430-ce790100-cdb6-11ea-91c1-eb6468a695a2.png)

In the scope of "indeterministic" reset behavior, it turned out that saving all documents (from intellij vfs, cache) to disk was required.