### PR TITLE
Prevent against resetting to an outdated commit of remote tracking branch

### DIFF
--- a/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRemoteBranch.java
+++ b/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRemoteBranch.java
@@ -1,5 +1,7 @@
 package com.virtuslab.gitmachete.backend.api;
 
 public interface IGitMacheteRemoteBranch {
+  String getName();
+
   IGitMacheteCommit getPointedCommit();
 }

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRemoteBranch.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRemoteBranch.java
@@ -7,5 +7,6 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRemoteBranch;
 
 @Data
 public class GitMacheteRemoteBranch implements IGitMacheteRemoteBranch {
+  private final String name;
   private final IGitMacheteCommit pointedCommit;
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -146,7 +146,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
   }
 
   protected void doResetToRemoteWithKeep(Project project, GitRepository gitRepository, String branchName,
-      IGitMacheteRepositorySnapshot macheteRepository, AnActionEvent anActionEvent) {
+      IGitMacheteRepositorySnapshot macheteRepositorySnapshot, AnActionEvent anActionEvent) {
 
     new Task.Backgroundable(project,
         getString("action.GitMachete.BaseResetBranchToRemoteAction.task-title"),
@@ -160,11 +160,11 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
           GitLineHandler resetHandler = new GitLineHandler(project, gitRepository.getRoot(), GitCommand.RESET);
           resetHandler.addParameters("--keep");
 
-          var branchOption = macheteRepository.getManagedBranchByName(branchName);
+          var branchOption = macheteRepositorySnapshot.getManagedBranchByName(branchName);
           assert branchOption.isDefined() : "Can't get branch '${branchName}' from Git Machete repository";
           var remoteTrackingBranchOption = branchOption.get().getRemoteTrackingBranch();
           if (remoteTrackingBranchOption.isDefined()) {
-            resetHandler.addParameters(remoteTrackingBranchOption.get().getPointedCommit().getHash());
+            resetHandler.addParameters(remoteTrackingBranchOption.get().getName());
           } else {
             String message = "Branch '${branchName}' doesn't have remote tracking branch, so cannot be reset";
             log().warn(message);
@@ -177,7 +177,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
 
           resetHandler.endOptions();
 
-          // Check if branch to reset is not current branch - if isn't then checkout
+          // Check if branch to reset is the current branch - if it isn't, then checkout
           var currentBranchOption = getCurrentBranchNameIfManagedWithLoggingOnEmpty(anActionEvent);
           if (currentBranchOption.isEmpty() || !currentBranchOption.get().equals(branchName)) {
             log().debug(() -> "Checkout to branch '${branchName}' is needed");

--- a/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/repository/IRepositoryGraphCache.java
+++ b/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/repository/IRepositoryGraphCache.java
@@ -6,5 +6,5 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 
 public interface IRepositoryGraphCache {
   @UIEffect
-  IRepositoryGraph getRepositoryGraph(IGitMacheteRepositorySnapshot givenRepository, boolean isListingCommits);
+  IRepositoryGraph getRepositoryGraph(IGitMacheteRepositorySnapshot givenRepositorySnapshot, boolean isListingCommits);
 }

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphBuilder.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphBuilder.java
@@ -46,7 +46,7 @@ import com.virtuslab.gitmachete.frontend.graph.impl.items.CommitItem;
 public class RepositoryGraphBuilder {
 
   @Setter
-  private IGitMacheteRepositorySnapshot repository = NullGitMacheteRepositorySnapshot.getInstance();
+  private IGitMacheteRepositorySnapshot repositorySnapshot = NullGitMacheteRepositorySnapshot.getInstance();
 
   @Setter
   private IBranchGetCommitsStrategy branchGetCommitsStrategy = DEFAULT_GET_COMMITS;
@@ -65,7 +65,7 @@ public class RepositoryGraphBuilder {
   }
 
   private Tuple2<List<IGraphItem>, List<List<Integer>>> deriveGraphItemsAndPositionsOfVisibleEdges() {
-    List<IGitMacheteRootBranch> rootBranches = repository.getRootBranches();
+    List<IGitMacheteRootBranch> rootBranches = repositorySnapshot.getRootBranches();
 
     java.util.List<IGraphItem> graphItems = new ArrayList<>();
     java.util.List<java.util.List<Integer>> positionsOfVisibleEdges = new ArrayList<>();
@@ -194,7 +194,7 @@ public class RepositoryGraphBuilder {
       GraphItemColor graphItemColor,
       @NonNegative int indentLevel) {
     SyncToRemoteStatus syncToRemoteStatus = branch.getSyncToRemoteStatus();
-    Option<IGitMacheteBranch> currentBranch = repository.getCurrentBranchIfManaged();
+    Option<IGitMacheteBranch> currentBranch = repositorySnapshot.getCurrentBranchIfManaged();
     boolean isCurrentBranch = currentBranch.isDefined() && currentBranch.get().equals(branch);
     boolean hasChildItem = !branch.getChildBranches().isEmpty();
 

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphCache.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphCache.java
@@ -10,18 +10,18 @@ public class RepositoryGraphCache implements IRepositoryGraphCache {
 
   private @MonotonicNonNull IRepositoryGraph repositoryGraphWithCommits = null;
   private @MonotonicNonNull IRepositoryGraph repositoryGraphWithoutCommits = null;
-  private @MonotonicNonNull IGitMacheteRepositorySnapshot repository = null;
+  private @MonotonicNonNull IGitMacheteRepositorySnapshot repositorySnapshot = null;
 
   @Override
-  // to allow for `synchronized` and for `givenRepository != this.repository`
+  // to allow for `synchronized` and for `givenRepositorySnapshot != this.repositorySnapshot`
   @SuppressWarnings({"regexp", "interning:not.interned"})
-  public synchronized IRepositoryGraph getRepositoryGraph(IGitMacheteRepositorySnapshot givenRepository,
+  public synchronized IRepositoryGraph getRepositoryGraph(IGitMacheteRepositorySnapshot givenRepositorySnapshot,
       boolean isListingCommits) {
-    if (givenRepository != this.repository || repositoryGraphWithCommits == null
+    if (givenRepositorySnapshot != this.repositorySnapshot || repositoryGraphWithCommits == null
         || repositoryGraphWithoutCommits == null) {
 
-      this.repository = givenRepository;
-      RepositoryGraphBuilder repositoryGraphBuilder = new RepositoryGraphBuilder().repository(givenRepository);
+      this.repositorySnapshot = givenRepositorySnapshot;
+      RepositoryGraphBuilder repositoryGraphBuilder = new RepositoryGraphBuilder().repositorySnapshot(givenRepositorySnapshot);
       repositoryGraphWithCommits = repositoryGraphBuilder
           .branchGetCommitsStrategy(RepositoryGraphBuilder.DEFAULT_GET_COMMITS).build();
       repositoryGraphWithoutCommits = repositoryGraphBuilder

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteGraphTable.java
@@ -239,8 +239,8 @@ public final class GitMacheteGraphTable extends BaseGraphTable implements DataPr
           return;
         }
 
-        @UI Consumer<Option<IGitMacheteRepositorySnapshot>> doRefreshModel = newGitMacheteRepository -> {
-          this.gitMacheteRepositorySnapshot = newGitMacheteRepository.getOrNull();
+        @UI Consumer<Option<IGitMacheteRepositorySnapshot>> doRefreshModel = newGitMacheteRepositorySnapshot -> {
+          this.gitMacheteRepositorySnapshot = newGitMacheteRepositorySnapshot.getOrNull();
           refreshModel(gitRepository,
               this.gitMacheteRepositorySnapshot != null
                   ? this.gitMacheteRepositorySnapshot.getSkippedBranchNames()


### PR DESCRIPTION
This was relatively hard to come across since the bug only manifested itself when a `git fetch` happened between the latest graph table refresh and running the reset action.