### PR TITLE
Remove "entry-references" from notifications

### DIFF
--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/EntryDoesNotExistException.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/EntryDoesNotExistException.java
@@ -1,0 +1,7 @@
+package com.virtuslab.branchlayout.api;
+
+public class EntryDoesNotExistException extends BranchLayoutException {
+  public EntryDoesNotExistException(String message) {
+    super(message);
+  }
+}

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/EntryIsDescendantOfException.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/EntryIsDescendantOfException.java
@@ -1,0 +1,12 @@
+package com.virtuslab.branchlayout.api;
+
+public class EntryIsDescendantOfException extends BranchLayoutException {
+  private final IBranchLayoutEntry descendant;
+  private final IBranchLayoutEntry ancestor;
+
+  public EntryIsDescendantOfException(String message, IBranchLayoutEntry descendant, IBranchLayoutEntry ancestor) {
+    super(message);
+    this.descendant = descendant;
+    this.ancestor = ancestor;
+  }
+}

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/EntryIsRootException.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/EntryIsRootException.java
@@ -1,0 +1,7 @@
+package com.virtuslab.branchlayout.api;
+
+public class EntryIsRootException extends BranchLayoutException {
+  public EntryIsRootException(String message) {
+    super(message);
+  }
+}

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/IBranchLayout.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/IBranchLayout.java
@@ -8,7 +8,8 @@ public interface IBranchLayout {
 
   Option<IBranchLayoutEntry> findEntryByName(String branchName);
 
-  IBranchLayout slideIn(String parentBranchName, IBranchLayoutEntry entryToSlideIn) throws BranchLayoutException;
+  IBranchLayout slideIn(String parentBranchName, IBranchLayoutEntry entryToSlideIn)
+      throws EntryDoesNotExistException, EntryIsDescendantOfException;
 
-  IBranchLayout slideOut(String branchName) throws BranchLayoutException;
+  IBranchLayout slideOut(String branchName) throws EntryDoesNotExistException, EntryIsRootException;
 }

--- a/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
@@ -86,10 +86,13 @@ action.GitMachete.BaseSlideInBranchBelowAction.dialog.slide-in.ok-button=Slide I
 action.GitMachete.BaseSlideInBranchBelowAction.dialog.slide-in.title=Slide In Branch Below
 action.GitMachete.BaseSlideInBranchBelowAction.dialog.slide-in.error.slide-in-under-itself=Cannot slide in the branch under itself
 action.GitMachete.BaseSlideInBranchBelowAction.dialog.slide-in.error.slide-in-under-its-descendant=Cannot slide in the branch under any of its descendants
-action.GitMachete.BaseSlideInBranchBelowAction.notification.fail=Slide in of branch <b>{0}</b> failed
-action.GitMachete.BaseSlideInBranchBelowAction.notification.fail.branch-layout-write=Writing new branch layout failed
+action.GitMachete.BaseSlideInBranchBelowAction.notification.title.branch-layout-write-fail=Writing new branch layout failed
+action.GitMachete.BaseSlideInBranchBelowAction.notification.title.slide-in-fail=Slide in of branch <b>{0}</b> failed
+action.GitMachete.BaseSlideInBranchBelowAction.notification.message.entry-does-not-exist=Branch <b>{0}</b> does not exist
+action.GitMachete.BaseSlideInBranchBelowAction.notification.message.entry-is-descendant-of=Branch <b>{0}</b> cannot be slid under branch <b>{1}</b> since <b>{0}</b> is already an ancestor of <b>{1}</b>
+action.GitMachete.BaseSlideInBranchBelowAction.notification.message.entry-is-root=Root branch <b>{0}</b> cannot be slid in
 action.GitMachete.BaseSlideInBranchBelowAction.notification.message.slide-in-under-itself-or-its-descendant=Cannot slide in the branch under itself or any of its descendants
-action.GitMachete.BaseSlideInBranchBelowAction.notification.fail.mismatched-names=<b>Slide in canceled:</b> branch name ({0}) and new branch name ({1}) differ
+action.GitMachete.BaseSlideInBranchBelowAction.notification.mismatched-names=<b>Slide in canceled:</b> branch name ({0}) and new branch name ({1}) differ
 action.GitMachete.BaseSlideInBranchBelowAction.task-title=Sliding in
 action.GitMachete.BaseSlideInBranchBelowAction.text.current-branch=Slide _In Branch Below Current Branch
 


### PR DESCRIPTION
- Introduce `(EntryDoesNotExist|EntryIsRoot|EntryIsDescendantOf)Exception`
- Fix and enhance slide in notifications