### PR TITLE
Fast forward action without remote tracking information

### DIFF
--- a/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteBranch.java
+++ b/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteBranch.java
@@ -30,6 +30,8 @@ public interface IGitMacheteBranch {
 
   String getName();
 
+  String getFullName();
+
   IGitMacheteCommit getPointedCommit();
 
   List<? extends IGitMacheteNonRootBranch> getChildBranches();

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/BaseGitMacheteBranch.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/BaseGitMacheteBranch.java
@@ -2,7 +2,9 @@ package com.virtuslab.gitmachete.backend.impl;
 
 import io.vavr.collection.List;
 import io.vavr.control.Option;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -15,35 +17,20 @@ import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 @Getter
 @ToString
 @UsesObjectEquals
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class BaseGitMacheteBranch implements IGitMacheteBranch {
   private final String name;
+  private final String fullName;
   private final List<GitMacheteNonRootBranch> childBranches;
   private final IGitMacheteCommit pointedCommit;
-  private final SyncToRemoteStatus syncToRemoteStatus;
   private final @Nullable IGitMacheteRemoteBranch remoteTrackingBranch;
+  private final SyncToRemoteStatus syncToRemoteStatus;
   private final @Nullable String customAnnotation;
   private final @Nullable String statusHookOutput;
 
   @ToString.Include(name = "childBranches") // avoid recursive `toString` calls on child branches
   private List<String> getChildBranchNames() {
     return childBranches.map(e -> e.getName());
-  }
-
-  protected BaseGitMacheteBranch(
-      String name,
-      List<GitMacheteNonRootBranch> childBranches,
-      IGitMacheteCommit pointedCommit,
-      @Nullable IGitMacheteRemoteBranch remoteTrackingBranch,
-      SyncToRemoteStatus syncToRemoteStatus,
-      @Nullable String customAnnotation,
-      @Nullable String statusHookOutput) {
-    this.name = name;
-    this.childBranches = childBranches;
-    this.pointedCommit = pointedCommit;
-    this.syncToRemoteStatus = syncToRemoteStatus;
-    this.remoteTrackingBranch = remoteTrackingBranch;
-    this.customAnnotation = customAnnotation;
-    this.statusHookOutput = statusHookOutput;
   }
 
   /**

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteNonRootBranch.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteNonRootBranch.java
@@ -36,6 +36,7 @@ public final class GitMacheteNonRootBranch extends BaseGitMacheteBranch implemen
 
   public GitMacheteNonRootBranch(
       String name,
+      String fullName,
       List<GitMacheteNonRootBranch> childBranches,
       IGitMacheteCommit pointedCommit,
       @Nullable IGitMacheteRemoteBranch remoteTrackingBranch,
@@ -45,7 +46,7 @@ public final class GitMacheteNonRootBranch extends BaseGitMacheteBranch implemen
       @Nullable IGitMacheteForkPointCommit forkPoint,
       List<IGitMacheteCommit> commits,
       SyncToParentStatus syncToParentStatus) {
-    super(name, childBranches, pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
+    super(name, fullName, childBranches, pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
 
     this.forkPoint = forkPoint;
     this.commits = commits;

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteNonRootBranch.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteNonRootBranch.java
@@ -46,7 +46,8 @@ public final class GitMacheteNonRootBranch extends BaseGitMacheteBranch implemen
       @Nullable IGitMacheteForkPointCommit forkPoint,
       List<IGitMacheteCommit> commits,
       SyncToParentStatus syncToParentStatus) {
-    super(name, fullName, childBranches, pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
+    super(name, fullName, childBranches, pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation,
+        statusHookOutput);
 
     this.forkPoint = forkPoint;
     this.commits = commits;

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
@@ -364,7 +364,9 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       var remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
       var statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit).getOrNull();
 
-      GitMacheteRootBranch createdRootBranch = new GitMacheteRootBranch(branchName, branchFullName, childBranches.getCreatedBranches(), pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
+      GitMacheteRootBranch createdRootBranch = new GitMacheteRootBranch(branchName, branchFullName,
+          childBranches.getCreatedBranches(), pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation,
+          statusHookOutput);
       return RootCreatedBranchAndSkippedBranches.of(createdRootBranch, childBranches.getSkippedBranchNames());
     }
 
@@ -408,7 +410,9 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       var remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
       var statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit).getOrNull();
 
-      var result = new GitMacheteNonRootBranch(branchName, branchFullName, childBranches.getCreatedBranches(), pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput, forkPoint, commits.map(GitMacheteCommit::new), syncToParentStatus);
+      var result = new GitMacheteNonRootBranch(branchName, branchFullName, childBranches.getCreatedBranches(), pointedCommit,
+          remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput, forkPoint,
+          commits.map(GitMacheteCommit::new), syncToParentStatus);
       return NonRootCreatedAndSkippedBranches.of(result, childBranches.getSkippedBranchNames());
     }
 

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
@@ -353,6 +353,8 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       IGitCoreLocalBranchSnapshot coreLocalBranch = localBranchByName.get(branchName)
           .getOrElseThrow(() -> new GitMacheteException("Branch '${branchName}' not found in the repository"));
 
+      var branchFullName = coreLocalBranch.getFullName();
+
       IGitCoreCommit corePointedCommit = coreLocalBranch.getPointedCommit();
 
       var pointedCommit = new GitMacheteCommit(corePointedCommit);
@@ -362,8 +364,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       var remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
       var statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit).getOrNull();
 
-      GitMacheteRootBranch createdRootBranch = new GitMacheteRootBranch(branchName, childBranches.getCreatedBranches(),
-          pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
+      GitMacheteRootBranch createdRootBranch = new GitMacheteRootBranch(branchName, branchFullName, childBranches.getCreatedBranches(), pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
       return RootCreatedBranchAndSkippedBranches.of(createdRootBranch, childBranches.getSkippedBranchNames());
     }
 
@@ -378,6 +379,8 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         NonRootCreatedAndSkippedBranches childResult = deriveChildBranches(parentCoreLocalBranch, entry.getChildren());
         return childResult.withExtraSkippedBranch(branchName);
       }
+
+      var branchFullName = coreLocalBranch.getFullName();
 
       IGitCoreCommit corePointedCommit = coreLocalBranch.getPointedCommit();
 
@@ -405,9 +408,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       var remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
       var statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit).getOrNull();
 
-      var result = new GitMacheteNonRootBranch(branchName, childBranches.getCreatedBranches(), pointedCommit,
-          remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput, forkPoint,
-          commits.map(GitMacheteCommit::new), syncToParentStatus);
+      var result = new GitMacheteNonRootBranch(branchName, branchFullName, childBranches.getCreatedBranches(), pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput, forkPoint, commits.map(GitMacheteCommit::new), syncToParentStatus);
       return NonRootCreatedAndSkippedBranches.of(result, childBranches.getSkippedBranchNames());
     }
 

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRootBranch.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRootBranch.java
@@ -23,7 +23,8 @@ public final class GitMacheteRootBranch extends BaseGitMacheteBranch implements 
       SyncToRemoteStatus syncToRemoteStatus,
       @Nullable String customAnnotation,
       @Nullable String statusHookOutput) {
-    super(name, fullName, childBranches, pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
+    super(name, fullName, childBranches, pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation,
+        statusHookOutput);
 
     LOG.debug("Creating ${this}");
 

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRootBranch.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRootBranch.java
@@ -16,13 +16,14 @@ public final class GitMacheteRootBranch extends BaseGitMacheteBranch implements 
 
   public GitMacheteRootBranch(
       String name,
+      String fullName,
       List<GitMacheteNonRootBranch> childBranches,
       IGitMacheteCommit pointedCommit,
       @Nullable IGitMacheteRemoteBranch remoteTrackingBranch,
       SyncToRemoteStatus syncToRemoteStatus,
       @Nullable String customAnnotation,
       @Nullable String statusHookOutput) {
-    super(name, childBranches, pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
+    super(name, fullName, childBranches, pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput);
 
     LOG.debug("Creating ${this}");
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
@@ -120,19 +120,8 @@ public abstract class BaseFastForwardParentToMatchBranchAction extends BaseGitMa
   private void doFastForward(Project project,
       GitRepository gitRepository,
       IGitMacheteNonRootBranch gitMacheteNonRootBranch) {
-    var trackingInfo = gitRepository.getBranchTrackInfo(gitMacheteNonRootBranch.getName());
-    var parentTrackingInfo = gitRepository.getBranchTrackInfo(gitMacheteNonRootBranch.getParentBranch().getName());
-
-    if (trackingInfo == null) {
-      log().warn("No branch tracking info for branch ${gitMacheteNonRootBranch.getName()}");
-      return;
-    } else if (parentTrackingInfo == null) {
-      log().warn("No branch tracking info for parent branch ${gitMacheteNonRootBranch.getParentBranch().getName()}");
-      return;
-    }
-
-    var localFullName = trackingInfo.getLocalBranch().getFullName();
-    var parentLocalFullName = parentTrackingInfo.getLocalBranch().getFullName();
+    var localFullName = gitMacheteNonRootBranch.getFullName();
+    var parentLocalFullName = gitMacheteNonRootBranch.getParentBranch().getFullName();
     var refspecChildParent = "${localFullName}:${parentLocalFullName}";
 
     // Remote set to '.' (dot) is just the local repository.

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
@@ -37,6 +37,7 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
     var fp = new FpCommit("Fork point commit");
     NonRoot[] nonRoots = {
         new NonRoot(/* name */ "allow-ownership-link",
+            /* fullName */ "refs/heads/allow-ownership-link",
             /* customAnnotation */ "# Gray edge: branch is merged to its parent branch",
             nullPointedCommit,
             /* fork point */ null,
@@ -44,6 +45,7 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
             /* commits */ List.empty(),
             SyncToParentStatus.MergedToParent),
         new NonRoot(/* name */ "build-chain",
+            /* fullName */ "refs/heads/build-chain",
             /* customAnnotation */ "# Green edge: branch is in sync with its parent branch",
             nullPointedCommit,
             /* fork point */ null,
@@ -52,6 +54,7 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
                 new Commit("First commit of build-chain")),
             SyncToParentStatus.InSync),
         new NonRoot(/* name */ "call-ws",
+            /* fullName */ "refs/heads/call-ws",
             /* customAnnotation */ "# Yellow edge: Branch is in sync with its parent branch but the fork point is NOT equal to parent branch",
             nullPointedCommit,
             /* fork point */ fp,
@@ -59,6 +62,7 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
             /* commits */ List.of(fp),
             SyncToParentStatus.InSyncButForkPointOff),
         new NonRoot(/* name */ "remove-ff",
+            /* fullName */ "refs/heads/remove-ff",
             /* customAnnotation */ "# Red edge: branch is out of sync to its parent branch",
             nullPointedCommit,
             /* fork point */ null,
@@ -68,6 +72,7 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
     };
 
     var root = new Root(/* name */ "develop",
+        /* fullName */ "refs/heads/develop",
         /* customAnnotation */ "# This is a root branch, the underline indicates that it is the currently checked out branch",
         nullPointedCommit,
         /* childBranches */ List.of(nonRoots));
@@ -174,6 +179,7 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
   @AllArgsConstructor
   private static final class Root implements IGitMacheteRootBranch {
     private final String name;
+    private final String fullName;
     private final String customAnnotation;
     private final Commit pointedCommit;
     private final SyncToRemoteStatus syncToRemoteStatus = getSTRSofRelation(SyncToRemoteStatus.Relation.InSyncToRemote);
@@ -199,6 +205,7 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
   @RequiredArgsConstructor
   private static final class NonRoot implements IGitMacheteNonRootBranch {
     private final String name;
+    private final String fullName;
     private final String customAnnotation;
     private final Commit pointedCommit;
     private final @Nullable IGitMacheteForkPointCommit forkPoint;


### PR DESCRIPTION
* `getFullName` method was added to `IGitMacheteBranch` interface (and implemented in its implementations)
* `BaseFastForwardParentToMatchBranchAction` was revamped to use `getFullName` method instead of tracking branch information