### PR TITLE
Prevent 'Already disposed' race conditions in UITestSuite's @BeforeClass method

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,21 +7,16 @@ assignees: ''
 
 ---
 
-### Bug description
-A clear and concise description of what the bug is.
+## Bug description
+Please include steps to reproduce (like `go to...`/`click on...` etc.) + expected and actual behavior.
 
-### Steps to reproduce
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+For more non-trivial issues, we would also appreciate if you included the following details:
 
-### Expected behavior
-Description of what you expected to happen.
-
-### Current behavior
-Describe what is actually happening.
+### Running environment
+ - Git Machete plugin version
+ - IDE type [e.g. IntelliJ, PyCharm]
+ - IDE version [e.g. 2020.1.4]
+ - Operating system [e.g. Windows]
 
 ### Logs
 Enable logging on debug level for this plugin by adding
@@ -35,9 +30,9 @@ gitmachete.frontend.externalsystem
 gitmachete.frontend.graph
 gitmachete.frontend.ui
 ```
-to list under `Help` -> `Diagnostic Tools` -> `Debug Log Settings`.
-Then reproduce a bug and attach logs here.
-To find IntelliJ log file go to `Help` -> `Show Log in Files`.
+to list under `Help` -> `Diagnostic Tools` -> `Debug Log Settings`.<br/>
+Then reproduce a bug and attach the logs to the issue.<br/>
+To find IntelliJ log file, go to `Help` -> `Show Log in Files`.
 
 Consider placing the logs within the `details` (aka "spoiler") tags as the may be very extensive.
 
@@ -47,12 +42,5 @@ Logs go here
 </details>
 
 ### Screenshots
-If applicable, add screenshots to help explain your problem.
-
-### Running environment
- - Operating system [e.g. Windows]
- - IDE type [e.g. IntelliJ, PyCharm]
- - IDE version [e.g. 2020.1.4]
-
-### Additional context
-Add any other context about the problem here.
+If applicable, add screenshots (or screen recordings, see [Peek](https://github.com/phw/peek#peek---an-animated-gif-recorder) on Linux)
+to help explain your problem.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,6 +143,8 @@ Other coding conventions include:
   Use `derive...` method names for methods that actually compute their result and/or can return a different value every time when accessed.
 * Non-obvious method params that have values like `false`, `true`, `0`, `1`, `null`, `""` should be preceded with a `/* comment */ `
   containing the name of the param.
+* Avoid running code outside of IDE-managed threads.
+  Use either UI thread (for lightweight operations) or `Task.Backgroundable` (for heavyweight operations).
 
 
 ## Rebuild the CI base image

--- a/config/checkstyle/tree_walker_module_directives.xml
+++ b/config/checkstyle/tree_walker_module_directives.xml
@@ -45,7 +45,7 @@
 <module name="MissingSwitchDefault"/>
 <module name="MultipleStringLiterals">
     <property name="allowedDuplicates" value="3"/>
-    <!-- Allow for more than 3 occurrences of an empty string, a single-space string or  ", " string in the given file -->
+    <!-- Allow for more than 3 occurrences of an empty string, a single-space string or ", " string in the given file -->
     <property name="ignoreStringsRegexp" value="^&quot;(| |, )&quot;$"/>
 </module>
 <module name="MultipleVariableDeclarations"/>
@@ -79,12 +79,14 @@
 <module name="Regexp">
     <property name="illegalPattern" value="true"/>
     <property name="ignoreComments" value="true"/>
+    <!-- (?<!... ) is a negative lookbehind -->
     <property name="format" value="(?&lt;!Error) extends [A-Za-z0-9]*Error\b"/>
     <property name="message" value="Classes extending errors must have the 'Error' suffix"/>
 </module>
 <module name="Regexp">
     <property name="illegalPattern" value="true"/>
     <property name="ignoreComments" value="true"/>
+    <!-- (?<!... ) is a negative lookbehind -->
     <property name="format" value="(?&lt;!Exception) extends [A-Za-z0-9]*Exception\b"/>
     <property name="message" value="Classes extending exceptions must have the 'Exception' suffix"/>
 </module>

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/graphtable/DiscoverAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/graphtable/DiscoverAction.java
@@ -40,6 +40,9 @@ public class DiscoverAction extends DumbAwareAction implements IExpectsKeyProjec
     }
     var mainDirPath = GitVfsUtils.getMainDirectoryPath(selectedRepository).toAbsolutePath();
     var gitDirPath = GitVfsUtils.getGitDirectoryPath(selectedRepository).toAbsolutePath();
+    // Note that we're essentially doing a heavy-ish operation of discoverLayoutAndCreateSnapshot on UI thread here.
+    // This is still acceptable since it simplifies the flow (no background task needed)
+    // and this action is not going to be invoked frequently (probably just once for a given project).
     Try.of(() -> RuntimeBinding.instantiateSoleImplementingClass(IGitMacheteRepositoryCache.class)
         .getInstance(mainDirPath, gitDirPath).discoverLayoutAndCreateSnapshot())
         .onFailure(e -> GuiUtils.invokeLaterIfNeeded(() -> VcsNotifier.getInstance(project)

--- a/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/BaseGraphTable.java
+++ b/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/BaseGraphTable.java
@@ -20,7 +20,8 @@ public abstract class BaseGraphTable extends JBTable {
     super(model);
 
     // Without set autoresize off column will expand to whole table width (will not fit the content size).
-    // This causes the branch tooltips (sync to parent status descriptions) to be displayed on the whole Git Machete panel width instead of just over the text.
+    // This causes the branch tooltips (sync to parent status descriptions)
+    // to be displayed on the whole Git Machete panel width instead of just over the text.
     setAutoResizeMode(JBTable.AUTO_RESIZE_OFF);
   }
 

--- a/uiTests/src/test/java/com/virtuslab/gitmachete/uitest/UITestSuite.java
+++ b/uiTests/src/test/java/com/virtuslab/gitmachete/uitest/UITestSuite.java
@@ -32,10 +32,14 @@ public class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite {
   }
 
   @BeforeClass
-  public static void connectToIde() {
+  public static void connectToIdeAndCloseProjects() {
     remoteRobot = new RemoteRobot("http://127.0.0.1:8080");
     runJs("ide.configure(/* enableDebugLog */ false)");
-    // In case there are any leftovers from the previous runs of IDE for UI tests.
+
+    // Let's close the opened projects first - there may be leftovers from the previous runs of IDE for UI tests.
+    // First, let's make sure IDE actually initialized these projects - otherwise, we might end up with race conditions:
+    //   'Already disposed: Project (name=machete-sandbox, containerState=DISPOSE_COMPLETED, ...)'
+    awaitIdle();
     runJs("ide.closeOpenedProjects()");
   }
 


### PR DESCRIPTION
Like in https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin/3129/workflows/0eca3823-8402-474b-b9fe-fcba7fcb78ec/jobs/3247 (and generally once in a few builds, typically in second execution of UI tests, so 2020.1.4 currently)