### PR TITLE
Nonexistent repository log error fix

### DIFF
--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
@@ -58,7 +58,8 @@ public abstract class BaseFastForwardParentToMatchBranchAction extends BaseGitMa
 
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent);
-    var gitMacheteBranch = getNameOfBranchUnderAction(anActionEvent).flatMap(b -> getGitMacheteBranchByName(anActionEvent, b));
+    var gitMacheteBranch = getNameOfBranchUnderActionWithLogging(anActionEvent)
+        .flatMap(b -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, b));
 
     if (gitMacheteBranch.isDefined() && gitRepository.isDefined()) {
       assert gitMacheteBranch.get().isNonRoot() : "Provided machete branch to fast forward is a root";

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
@@ -59,7 +59,7 @@ public abstract class BaseFastForwardParentToMatchBranchAction extends BaseGitMa
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent);
     var gitMacheteBranch = getNameOfBranchUnderActionWithLogging(anActionEvent)
-        .flatMap(b -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, b));
+        .flatMap(b -> getGitMacheteBranchByNameWithLogging(anActionEvent, b));
 
     if (gitMacheteBranch.isDefined() && gitRepository.isDefined()) {
       assert gitMacheteBranch.get().isNonRoot() : "Provided machete branch to fast forward is a root";

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardParentToMatchBranchAction.java
@@ -21,7 +21,7 @@ import com.virtuslab.logger.IEnhancedLambdaLogger;
 @CustomLog
 public abstract class BaseFastForwardParentToMatchBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
+      IBranchNameProviderWithLogging,
       IExpectsKeyProject,
       ISyncToParentStatusDependentAction {
 
@@ -57,7 +57,7 @@ public abstract class BaseFastForwardParentToMatchBranchAction extends BaseGitMa
   public void actionPerformed(AnActionEvent anActionEvent) {
 
     var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent);
     var gitMacheteBranch = getNameOfBranchUnderActionWithLogging(anActionEvent)
         .flatMap(b -> getGitMacheteBranchByNameWithLogging(anActionEvent, b));
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseGitMacheteRepositoryReadyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseGitMacheteRepositoryReadyAction.java
@@ -13,7 +13,7 @@ public abstract class BaseGitMacheteRepositoryReadyAction extends BaseProjectKey
   @Override
   @UIEffect
   public void onUpdate(AnActionEvent anActionEvent) {
-    boolean isEnabled = getGitMacheteRepositorySnapshot(anActionEvent).isDefined();
+    boolean isEnabled = getGitMacheteRepositorySnapshotWithoutLogging(anActionEvent).isDefined();
     anActionEvent.getPresentation().setEnabled(isEnabled);
 
     if (!isEnabled) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
@@ -63,8 +63,8 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
   public void actionPerformed(AnActionEvent anActionEvent) {
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var branchUnderAction = getNameOfBranchUnderAction(anActionEvent);
-    var branch = branchUnderAction.flatMap(pn -> getGitMacheteBranchByName(anActionEvent, pn)).getOrNull();
+    var branchUnderAction = getNameOfBranchUnderActionWithLogging(anActionEvent);
+    var branch = branchUnderAction.flatMap(pn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, pn)).getOrNull();
 
     if (gitRepository == null || branch == null || branch.isRoot()) {
       return;

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
@@ -64,7 +64,7 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
     var branchUnderAction = getNameOfBranchUnderActionWithLogging(anActionEvent);
-    var branch = branchUnderAction.flatMap(pn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, pn)).getOrNull();
+    var branch = branchUnderAction.flatMap(pn -> getGitMacheteBranchByNameWithLogging(anActionEvent, pn)).getOrNull();
 
     if (gitRepository == null || branch == null || branch.isRoot()) {
       return;

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
@@ -27,6 +27,7 @@ import com.virtuslab.qual.guieffect.NotUIThreadSafe;
 @CustomLog
 public abstract class BaseOverrideForkPointAction extends BaseGitMacheteRepositoryReadyAction
     implements
+      IBranchNameProviderWithLogging,
       IExpectsKeyProject,
       IExpectsKeyGitMacheteRepository,
       ISyncToParentStatusDependentAction {
@@ -62,7 +63,7 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
     var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent).getOrNull();
     var branchUnderAction = getNameOfBranchUnderActionWithLogging(anActionEvent);
     var branch = branchUnderAction.flatMap(pn -> getGitMacheteBranchByNameWithLogging(anActionEvent, pn)).getOrNull();
 
@@ -90,7 +91,7 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
 
   @NotUIThreadSafe
   private void overrideForkPoint(AnActionEvent anActionEvent, IManagedBranchSnapshot branch, ICommitOfManagedBranch forkPoint) {
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent);
 
     if (gitRepository.isDefined()) {
       var root = gitRepository.get().getRoot();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseProjectKeyAvailabilityAssuranceAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseProjectKeyAvailabilityAssuranceAction.java
@@ -25,6 +25,8 @@ public abstract class BaseProjectKeyAvailabilityAssuranceAction extends DumbAwar
 
   /**
    * If overridden {@code super.onUpdate(anActionEvent);} should always be called in the first line of overriding method.
+   * In addition, in this method we should use getters WITHOUT logging like
+   * {@code IExpectsKeyGitMacheteRepository#getGitMacheteRepositorySnapshotWithoutLogging}
    *
    * @param anActionEvent an action event
    */

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseProjectKeyAvailabilityAssuranceAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseProjectKeyAvailabilityAssuranceAction.java
@@ -9,7 +9,7 @@ import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyProject
 public abstract class BaseProjectKeyAvailabilityAssuranceAction extends DumbAwareAction {
   @Override
   @UIEffect
-  public void update(AnActionEvent anActionEvent) {
+  public final void update(AnActionEvent anActionEvent) {
     super.update(anActionEvent);
 
     if (this instanceof IExpectsKeyProject) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchFastForwardOnlyAction.java
@@ -23,7 +23,7 @@ import com.virtuslab.logger.IEnhancedLambdaLogger;
 @CustomLog
 public abstract class BasePullBranchFastForwardOnlyAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
+      IBranchNameProviderWithLogging,
       IExpectsKeyGitMacheteRepository,
       IExpectsKeyProject,
       ISyncToRemoteStatusDependentAction {
@@ -63,9 +63,9 @@ public abstract class BasePullBranchFastForwardOnlyAction extends BaseGitMachete
     log().debug("Performing");
 
     var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent).getOrNull();
     var localBranchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
-    var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshot(anActionEvent).getOrNull();
+    var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshotWithLogging(anActionEvent).getOrNull();
 
     if (localBranchName != null && gitRepository != null && gitMacheteRepositorySnapshot != null) {
       var localBranch = gitMacheteRepositorySnapshot.getManagedBranchByName(localBranchName).getOrNull();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchFastForwardOnlyAction.java
@@ -64,7 +64,7 @@ public abstract class BasePullBranchFastForwardOnlyAction extends BaseGitMachete
 
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var localBranchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    var localBranchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshot(anActionEvent).getOrNull();
 
     if (localBranchName != null && gitRepository != null && gitMacheteRepositorySnapshot != null) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
@@ -66,8 +66,8 @@ public abstract class BasePushBranchAction extends BaseGitMacheteRepositoryReady
 
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent);
-    var branchName = getNameOfBranchUnderAction(anActionEvent);
-    var relation = branchName.flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
+    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
+    var relation = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus())
         .map(strs -> strs.getRelation());
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
@@ -67,7 +67,7 @@ public abstract class BasePushBranchAction extends BaseGitMacheteRepositoryReady
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent);
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
-    var relation = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
+    var relation = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus())
         .map(strs -> strs.getRelation());
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
@@ -25,7 +25,7 @@ import com.virtuslab.logger.IEnhancedLambdaLogger;
 @CustomLog
 public abstract class BasePushBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
+      IBranchNameProviderWithLogging,
       IExpectsKeyProject,
       ISyncToRemoteStatusDependentAction {
 
@@ -65,7 +65,7 @@ public abstract class BasePushBranchAction extends BaseGitMacheteRepositoryReady
   public void actionPerformed(AnActionEvent anActionEvent) {
 
     var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent);
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
     var relation = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus())

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
@@ -86,7 +86,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
 
       var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
       var branch = branchName != null
-          ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
+          ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
           : null;
 
       if (branch == null) {
@@ -118,7 +118,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
             branch.getName(), upstream.getName()));
       }
 
-      var isRebasingCurrent = branch != null && getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent)
+      var isRebasingCurrent = branch != null && getCurrentBranchNameIfManagedWithLogging(anActionEvent)
           .map(bn -> bn.equals(branch.getName())).getOrElse(false);
       if (anActionEvent.getPlace().equals(ActionPlaces.ACTION_PLACE_CONTEXT_MENU) && isRebasingCurrent) {
         presentation.setText(getString("action.GitMachete.BaseRebaseBranchOntoParentAction.text"));
@@ -131,7 +131,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
     LOG.debug("Performing");
 
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
-    var branch = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn));
+    var branch = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn));
 
     if (branch.isDefined()) {
       if (branch.get().isNonRoot()) {
@@ -145,7 +145,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
   private void doRebase(AnActionEvent anActionEvent, INonRootManagedBranchSnapshot branchToRebase) {
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent);
-    var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent);
+    var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshotWithLogging(anActionEvent);
 
     if (gitRepository.isDefined() && gitMacheteRepositorySnapshot.isDefined()) {
       doRebase(project, gitRepository.get(), gitMacheteRepositorySnapshot.get(), branchToRebase);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
@@ -84,7 +84,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
           getString("action.GitMachete.BaseRebaseBranchOntoParentAction.description.disabled.repository.status"), stateName));
     } else {
 
-      var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+      var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
       var branch = branchName != null
           ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
           : null;
@@ -118,7 +118,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
             branch.getName(), upstream.getName()));
       }
 
-      var isRebasingCurrent = branch != null && getCurrentBranchNameIfManaged(anActionEvent)
+      var isRebasingCurrent = branch != null && getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent)
           .map(bn -> bn.equals(branch.getName())).getOrElse(false);
       if (anActionEvent.getPlace().equals(ActionPlaces.ACTION_PLACE_CONTEXT_MENU) && isRebasingCurrent) {
         presentation.setText(getString("action.GitMachete.BaseRebaseBranchOntoParentAction.text"));
@@ -130,8 +130,8 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
   public void actionPerformed(AnActionEvent anActionEvent) {
     LOG.debug("Performing");
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent);
-    var branch = branchName.flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn));
+    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
+    var branch = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn));
 
     if (branch.isDefined()) {
       if (branch.get().isNonRoot()) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
@@ -37,7 +37,8 @@ import com.virtuslab.logger.IEnhancedLambdaLogger;
 @CustomLog
 public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
+      IBranchNameProviderWithLogging,
+      IBranchNameProviderWithoutLogging,
       IExpectsKeyProject,
       IExpectsKeyGitMacheteRepository {
   private static final String NL = System.lineSeparator();
@@ -57,7 +58,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
       return;
     }
 
-    var state = getSelectedGitRepository(anActionEvent).map(r -> r.getState());
+    var state = getSelectedGitRepositoryWithoutLogging(anActionEvent).map(r -> r.getState());
 
     if (state.isEmpty()) {
       presentation.setEnabled(false);
@@ -84,9 +85,9 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
           getString("action.GitMachete.BaseRebaseBranchOntoParentAction.description.disabled.repository.status"), stateName));
     } else {
 
-      var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
+      var branchName = getNameOfBranchUnderActionWithoutLogging(anActionEvent).getOrNull();
       var branch = branchName != null
-          ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
+          ? getGitMacheteBranchByNameWithoutLogging(anActionEvent, branchName).getOrNull()
           : null;
 
       if (branch == null) {
@@ -118,7 +119,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
             branch.getName(), upstream.getName()));
       }
 
-      var isRebasingCurrent = branch != null && getCurrentBranchNameIfManagedWithLogging(anActionEvent)
+      var isRebasingCurrent = branch != null && getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
           .map(bn -> bn.equals(branch.getName())).getOrElse(false);
       if (anActionEvent.getPlace().equals(ActionPlaces.ACTION_PLACE_CONTEXT_MENU) && isRebasingCurrent) {
         presentation.setText(getString("action.GitMachete.BaseRebaseBranchOntoParentAction.text"));
@@ -144,7 +145,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
 
   private void doRebase(AnActionEvent anActionEvent, INonRootManagedBranchSnapshot branchToRebase) {
     var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent);
     var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshotWithLogging(anActionEvent);
 
     if (gitRepository.isDefined() && gitMacheteRepositorySnapshot.isDefined()) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -106,7 +106,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
     Project project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent);
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
-    var macheteRepository = getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent);
+    var macheteRepository = getGitMacheteRepositorySnapshotWithLogging(anActionEvent);
 
     if (branchName.isEmpty()) {
       VcsNotifier.getInstance(project).notifyError(VCS_NOTIFIER_TITLE,
@@ -128,7 +128,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
 
     // if key is missing the default value (false) is returned
     if (!PropertiesComponent.getInstance().getBoolean(RESET_INFO_SHOWN)) {
-      var gitMacheteBranch = getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, branchName.get());
+      var gitMacheteBranch = getGitMacheteBranchByNameWithLogging(anActionEvent, branchName.get());
       var remoteBranch = gitMacheteBranch.flatMap(b -> b.getRemoteTrackingBranch()).map(rtb -> rtb.getName())
           .getOrElse("<remote-branch>");
       var currentCommitSha = gitMacheteBranch.map(b -> b.getPointedCommit().getHash()).getOrNull();
@@ -193,7 +193,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
           resetHandler.endOptions();
 
           // Check if branch to reset is the current branch - if it isn't, then checkout
-          var currentBranchOption = getCurrentBranchNameIfManagedWithLoggingOnEmpty(anActionEvent);
+          var currentBranchOption = getCurrentBranchNameIfManagedWithLogging(anActionEvent);
           if (currentBranchOption.isEmpty() || !currentBranchOption.get().equals(branchName)) {
             log().debug(() -> "Checkout to branch '${branchName}' is needed");
             // Checking out given branch

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -25,7 +25,6 @@ import git4idea.commands.GitLocalChangesWouldBeOverwrittenDetector;
 import git4idea.repo.GitRepository;
 import git4idea.util.LocalChangesWouldBeOverwrittenHelper;
 import io.vavr.collection.List;
-import io.vavr.control.Option;
 import lombok.CustomLog;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -42,7 +41,8 @@ import com.virtuslab.logger.IEnhancedLambdaLogger;
 @CustomLog
 public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
+      IBranchNameProviderWithLogging,
+      IBranchNameProviderWithoutLogging,
       IExpectsKeyProject,
       ISyncToRemoteStatusDependentAction {
 
@@ -80,17 +80,15 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
         SyncToRemoteStatus.Relation.DivergedFromAndOlderThanRemote);
   }
 
-  public abstract Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent);
-
   @Override
   @UIEffect
   public void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
     syncToRemoteStatusDependentActionUpdate(anActionEvent);
 
-    var branch = getNameOfBranchUnderAction(anActionEvent);
+    var branch = getNameOfBranchUnderActionWithoutLogging(anActionEvent);
     if (branch.isDefined()) {
-      var isResettingCurrent = getCurrentBranchNameIfManaged(anActionEvent)
+      var isResettingCurrent = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
           .map(bn -> bn.equals(branch.get())).getOrElse(false);
       if (anActionEvent.getPlace().equals(ActionPlaces.ACTION_PLACE_CONTEXT_MENU) && isResettingCurrent) {
         anActionEvent.getPresentation().setText(() -> getActionName());
@@ -104,7 +102,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
     log().debug("Performing");
 
     Project project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent);
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
     var macheteRepository = getGitMacheteRepositorySnapshotWithLogging(anActionEvent);
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -25,6 +25,7 @@ import git4idea.commands.GitLocalChangesWouldBeOverwrittenDetector;
 import git4idea.repo.GitRepository;
 import git4idea.util.LocalChangesWouldBeOverwrittenHelper;
 import io.vavr.collection.List;
+import io.vavr.control.Option;
 import lombok.CustomLog;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -79,6 +80,8 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
         SyncToRemoteStatus.Relation.DivergedFromAndOlderThanRemote);
   }
 
+  public abstract Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent);
+
   @Override
   @UIEffect
   public void onUpdate(AnActionEvent anActionEvent) {
@@ -102,7 +105,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
 
     Project project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent);
-    var branchName = getNameOfBranchUnderAction(anActionEvent);
+    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
     var macheteRepository = getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent);
 
     if (branchName.isEmpty()) {
@@ -125,7 +128,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
 
     // if key is missing the default value (false) is returned
     if (!PropertiesComponent.getInstance().getBoolean(RESET_INFO_SHOWN)) {
-      var gitMacheteBranch = getGitMacheteBranchByName(anActionEvent, branchName.get());
+      var gitMacheteBranch = getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, branchName.get());
       var remoteBranch = gitMacheteBranch.flatMap(b -> b.getRemoteTrackingBranch()).map(rtb -> rtb.getName())
           .getOrElse("<remote-branch>");
       var currentCommitSha = gitMacheteBranch.map(b -> b.getPointedCommit().getHash()).getOrNull();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
@@ -45,8 +45,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
 
   @Override
   @UIEffect
-  public void update(AnActionEvent anActionEvent) {
-    super.update(anActionEvent);
+  public void onUpdate(AnActionEvent anActionEvent) {
+    super.onUpdate(anActionEvent);
 
     Presentation presentation = anActionEvent.getPresentation();
     if (!presentation.isEnabledAndVisible()) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
@@ -53,7 +53,7 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
       return;
     }
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var branch = branchName != null
         ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
         : null;
@@ -76,8 +76,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
   public void actionPerformed(AnActionEvent anActionEvent) {
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var parentName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
-    var branchLayout = getBranchLayout(anActionEvent).getOrNull();
+    var parentName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
+    var branchLayout = getBranchLayoutWithLoggingOnEmpty(anActionEvent).getOrNull();
     var branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
     var notifier = VcsNotifier.getInstance(project);
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
@@ -55,7 +55,7 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
 
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var branch = branchName != null
-        ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
+        ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
         : null;
 
     if (branchName == null) {
@@ -77,7 +77,7 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
     var project = getProject(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
     var parentName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
-    var branchLayout = getBranchLayoutWithLoggingOnEmpty(anActionEvent).getOrNull();
+    var branchLayout = getBranchLayoutWithLogging(anActionEvent).getOrNull();
     var branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
     var notifier = VcsNotifier.getInstance(project);
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
@@ -34,9 +34,10 @@ import com.virtuslab.logger.IEnhancedLambdaLogger;
 @CustomLog
 public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteRepositoryReadyAction
     implements
+      IBranchNameProviderWithLogging,
+      IBranchNameProviderWithoutLogging,
       IExpectsKeyProject,
-      IExpectsKeyGitMacheteRepository,
-      IBranchNameProvider {
+      IExpectsKeyGitMacheteRepository {
 
   @Override
   public IEnhancedLambdaLogger log() {
@@ -53,9 +54,9 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
       return;
     }
 
-    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
+    var branchName = getNameOfBranchUnderActionWithoutLogging(anActionEvent).getOrNull();
     var branch = branchName != null
-        ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
+        ? getGitMacheteBranchByNameWithoutLogging(anActionEvent, branchName).getOrNull()
         : null;
 
     if (branchName == null) {
@@ -75,7 +76,7 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
     var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent).getOrNull();
     var parentName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var branchLayout = getBranchLayoutWithLogging(anActionEvent).getOrNull();
     var branchLayoutWriter = getBranchLayoutWriter(anActionEvent);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
@@ -33,7 +33,8 @@ import com.virtuslab.qual.guieffect.NotUIThreadSafe;
 @CustomLog
 public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
+      IBranchNameProviderWithLogging,
+      IBranchNameProviderWithoutLogging,
       IExpectsKeyGitMacheteRepository,
       IExpectsKeyProject {
 
@@ -54,9 +55,9 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
       return;
     }
 
-    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
+    var branchName = getNameOfBranchUnderActionWithoutLogging(anActionEvent).getOrNull();
     var branch = branchName != null
-        ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
+        ? getGitMacheteBranchByNameWithoutLogging(anActionEvent, branchName).getOrNull()
         : null;
 
     if (branch == null) {
@@ -100,7 +101,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
     String branchName = branchToSlideOut.getName();
     var project = getProject(anActionEvent);
     var branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent).getOrNull();
     var branchLayout = getBranchLayoutWithLogging(anActionEvent).getOrNull();
     if (branchLayout == null || gitRepository == null) {
       return;
@@ -137,7 +138,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
 
   @NotUIThreadSafe
   private void deleteBranchIfRequired(AnActionEvent anActionEvent, String branchName) {
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent);
 
     if (gitRepository.isDefined()) {
       var root = gitRepository.get().getRoot();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
@@ -56,7 +56,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
 
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var branch = branchName != null
-        ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
+        ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
         : null;
 
     if (branch == null) {
@@ -84,7 +84,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
     LOG.debug("Performing");
 
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
-    var branch = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn));
+    var branch = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn));
     if (branch.isDefined()) {
       if (branch.get().isNonRoot()) {
         doSlideOut(anActionEvent, branch.get().asNonRoot());
@@ -101,7 +101,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
     var project = getProject(anActionEvent);
     var branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var branchLayout = getBranchLayoutWithLoggingOnEmpty(anActionEvent).getOrNull();
+    var branchLayout = getBranchLayoutWithLogging(anActionEvent).getOrNull();
     if (branchLayout == null || gitRepository == null) {
       return;
     }
@@ -144,7 +144,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
       var project = getProject(anActionEvent);
       var shallDeleteLocalBranch = getDeleteLocalBranchOnSlideOutGitConfigValue(project, root);
       if (shallDeleteLocalBranch) {
-        var slidOutBranchIsCurrent = getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent)
+        var slidOutBranchIsCurrent = getCurrentBranchNameIfManagedWithLogging(anActionEvent)
             .map(b -> b.equals(branchName))
             .getOrElse(true);
         if (slidOutBranchIsCurrent) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
@@ -54,7 +54,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
       return;
     }
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var branch = branchName != null
         ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
         : null;
@@ -83,8 +83,8 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
   public void actionPerformed(AnActionEvent anActionEvent) {
     LOG.debug("Performing");
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent);
-    var branch = branchName.flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn));
+    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent);
+    var branch = branchName.flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn));
     if (branch.isDefined()) {
       if (branch.get().isNonRoot()) {
         doSlideOut(anActionEvent, branch.get().asNonRoot());
@@ -101,7 +101,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
     var project = getProject(anActionEvent);
     var branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
     var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var branchLayout = getBranchLayout(anActionEvent).getOrNull();
+    var branchLayout = getBranchLayoutWithLoggingOnEmpty(anActionEvent).getOrNull();
     if (branchLayout == null || gitRepository == null) {
       return;
     }
@@ -144,7 +144,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
       var project = getProject(anActionEvent);
       var shallDeleteLocalBranch = getDeleteLocalBranchOnSlideOutGitConfigValue(project, root);
       if (shallDeleteLocalBranch) {
-        var slidOutBranchIsCurrent = getCurrentBranchNameIfManaged(anActionEvent)
+        var slidOutBranchIsCurrent = getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent)
             .map(b -> b.equals(branchName))
             .getOrElse(true);
         if (slidOutBranchIsCurrent) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProvider.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProvider.java
@@ -4,5 +4,5 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
 
 public interface IBranchNameProvider {
-  Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent);
+  Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent);
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProviderWithLogging.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProviderWithLogging.java
@@ -3,6 +3,6 @@ package com.virtuslab.gitmachete.frontend.actions.base;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
 
-public interface IBranchNameProvider {
+public interface IBranchNameProviderWithLogging {
   Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent);
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProviderWithLogging.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProviderWithLogging.java
@@ -4,5 +4,14 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
 
 public interface IBranchNameProviderWithLogging {
+  /**
+   * As a rule of thumb, method {@code getNameOfBranchUnderActionWithLogging} should be used only in `actionPerformed` methods
+   * and definitely NOT in any `update` or `onUpdate` methods.
+   * In `update` and `onUpdate` methods only {@code IBranchNameProviderWithoutLogging#getNameOfBranchUnderActionWithoutLogging}
+   * should be used.
+   *
+   * @param anActionEvent an action event
+   * @return Option of branch name under action
+   */
   Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent);
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProviderWithoutLogging.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProviderWithoutLogging.java
@@ -1,0 +1,8 @@
+package com.virtuslab.gitmachete.frontend.actions.base;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import io.vavr.control.Option;
+
+public interface IBranchNameProviderWithoutLogging {
+  Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent);
+}

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProviderWithoutLogging.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IBranchNameProviderWithoutLogging.java
@@ -4,5 +4,13 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
 
 public interface IBranchNameProviderWithoutLogging {
+  /**
+   * As a rule of thumb, method {@code IBranchNameProviderWithLogging#getNameOfBranchUnderActionWithLogging} should be used
+   * only in `actionPerformed` methods and definitely NOT in any `update` or `onUpdate` methods.
+   * In `update` and `onUpdate` methods only {@code getNameOfBranchUnderActionWithoutLogging} should be used.
+   *
+   * @param anActionEvent an action event
+   * @return Option of branch name under action
+   */
   Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent);
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
@@ -53,7 +53,7 @@ public interface ISyncToParentStatusDependentAction extends IBranchNameProvider,
 
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var gitMacheteBranchByName = branchName != null
-        ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
+        ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
         : null;
 
     if (branchName == null || gitMacheteBranchByName == null) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
@@ -18,14 +18,14 @@ import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
 
-public interface ISyncToParentStatusDependentAction extends IBranchNameProvider, IExpectsKeyGitMacheteRepository {
+public interface ISyncToParentStatusDependentAction extends IBranchNameProviderWithoutLogging, IExpectsKeyGitMacheteRepository {
 
   @I18nFormat({})
   String getActionNameForDisabledDescription();
 
   /**
    * @return a format string for description of action in enabled state
-   *         where {@code {1}} corresponds to branch name as returned by {@link #getNameOfBranchUnderActionWithLogging}
+   *         where {@code {1}} corresponds to branch name as returned by {@link #getNameOfBranchUnderActionWithoutLogging}
    *         and {@code {0}} corresponds to name of its parent branch
    */
   @I18nFormat({GENERAL, GENERAL})
@@ -51,9 +51,9 @@ public interface ISyncToParentStatusDependentAction extends IBranchNameProvider,
       return;
     }
 
-    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
+    var branchName = getNameOfBranchUnderActionWithoutLogging(anActionEvent).getOrNull();
     var gitMacheteBranchByName = branchName != null
-        ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
+        ? getGitMacheteBranchByNameWithoutLogging(anActionEvent, branchName).getOrNull()
         : null;
 
     if (branchName == null || gitMacheteBranchByName == null) {
@@ -63,7 +63,6 @@ public interface ISyncToParentStatusDependentAction extends IBranchNameProvider,
               getActionNameForDisabledDescription(), getQuotedStringOrCurrent(branchName)));
       return;
     } else if (gitMacheteBranchByName.isRoot()) {
-
       if (anActionEvent.getPlace().equals(ActionPlaces.ACTION_PLACE_TOOLBAR)) {
         presentation.setEnabled(false);
         presentation.setDescription(

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
@@ -43,6 +43,11 @@ public interface ISyncToParentStatusDependentAction extends IBranchNameProviderW
    */
   List<SyncToParentStatus> getEligibleStatuses();
 
+  /**
+   * As this method is used in `onUpdate` methods, only `*WithoutLogging` getters should be used here.
+   *
+   * @param anActionEvent an action event
+   */
   @UIEffect
   default void syncToParentStatusDependentActionUpdate(AnActionEvent anActionEvent) {
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
@@ -25,7 +25,7 @@ public interface ISyncToParentStatusDependentAction extends IBranchNameProvider,
 
   /**
    * @return a format string for description of action in enabled state
-   *         where {@code {1}} corresponds to branch name as returned by {@link #getNameOfBranchUnderAction}
+   *         where {@code {1}} corresponds to branch name as returned by {@link #getNameOfBranchUnderActionWithLogging}
    *         and {@code {0}} corresponds to name of its parent branch
    */
   @I18nFormat({GENERAL, GENERAL})
@@ -51,7 +51,7 @@ public interface ISyncToParentStatusDependentAction extends IBranchNameProvider,
       return;
     }
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var gitMacheteBranchByName = branchName != null
         ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
         : null;

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
@@ -17,7 +17,7 @@ import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 
-public interface ISyncToRemoteStatusDependentAction extends IBranchNameProvider, IExpectsKeyGitMacheteRepository {
+public interface ISyncToRemoteStatusDependentAction extends IBranchNameProviderWithoutLogging, IExpectsKeyGitMacheteRepository {
   @I18nFormat({})
   String getActionName();
 
@@ -51,7 +51,7 @@ public interface ISyncToRemoteStatusDependentAction extends IBranchNameProvider,
       return;
     }
 
-    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
+    var branchName = getNameOfBranchUnderActionWithoutLogging(anActionEvent).getOrNull();
     var gitMacheteBranch = branchName != null
         ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
         : null;

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
@@ -53,7 +53,7 @@ public interface ISyncToRemoteStatusDependentAction extends IBranchNameProvider,
 
     var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var gitMacheteBranch = branchName != null
-        ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
+        ? getGitMacheteBranchByNameWithLogging(anActionEvent, branchName).getOrNull()
         : null;
 
     if (branchName == null || gitMacheteBranch == null) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
@@ -43,6 +43,12 @@ public interface ISyncToRemoteStatusDependentAction extends IBranchNameProviderW
    */
   List<SyncToRemoteStatus.Relation> getEligibleRelations();
 
+  /**
+   * As this method is used in `onUpdate` methods, only `*WithoutLogging` getters should be used here.
+   *
+   * @param anActionEvent an action event
+   */
+
   @UIEffect
   default void syncToRemoteStatusDependentActionUpdate(AnActionEvent anActionEvent) {
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
@@ -51,7 +51,7 @@ public interface ISyncToRemoteStatusDependentAction extends IBranchNameProvider,
       return;
     }
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    var branchName = getNameOfBranchUnderActionWithLogging(anActionEvent).getOrNull();
     var gitMacheteBranch = branchName != null
         ? getGitMacheteBranchByName(anActionEvent, branchName).getOrNull()
         : null;

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
@@ -40,7 +40,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
       return;
     }
 
-    var selectedBranchName = getSelectedBranchName(anActionEvent);
+    var selectedBranchName = getSelectedBranchNameWithLogging(anActionEvent);
     // It's very unlikely that selectedBranchName is empty at this point since it's assigned directly before invoking this
     // action in GitMacheteGraphTable.GitMacheteGraphTableMouseAdapter.mouseClicked; still, it's better to be safe.
     if (selectedBranchName.isEmpty()) {
@@ -49,7 +49,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
       return;
     }
 
-    var currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    var currentBranchName = getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
 
     if (currentBranchName.isDefined() && currentBranchName.get().equals(selectedBranchName.get())) {
       presentation.setEnabled(false);
@@ -65,7 +65,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
 
   @Override
   public void actionPerformed(AnActionEvent anActionEvent) {
-    var selectedBranchName = getSelectedBranchName(anActionEvent);
+    var selectedBranchName = getSelectedBranchNameWithLogging(anActionEvent);
     if (selectedBranchName.isEmpty()) {
       return;
     }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
@@ -49,7 +49,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
       return;
     }
 
-    var currentBranchName = getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    var currentBranchName = getCurrentBranchNameIfManagedWithLogging(anActionEvent);
 
     if (currentBranchName.isDefined() && currentBranchName.get().equals(selectedBranchName.get())) {
       presentation.setEnabled(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
@@ -40,7 +40,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
       return;
     }
 
-    var selectedBranchName = getSelectedBranchNameWithLogging(anActionEvent);
+    var selectedBranchName = getSelectedBranchNameWithoutLogging(anActionEvent);
     // It's very unlikely that selectedBranchName is empty at this point since it's assigned directly before invoking this
     // action in GitMacheteGraphTable.GitMacheteGraphTableMouseAdapter.mouseClicked; still, it's better to be safe.
     if (selectedBranchName.isEmpty()) {
@@ -49,7 +49,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
       return;
     }
 
-    var currentBranchName = getCurrentBranchNameIfManagedWithLogging(anActionEvent);
+    var currentBranchName = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
 
     if (currentBranchName.isDefined() && currentBranchName.get().equals(selectedBranchName.get())) {
       presentation.setEnabled(false);
@@ -71,7 +71,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
     }
 
     var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent);
 
     if (gitRepository.isDefined()) {
       log().debug(() -> "Queuing '${selectedBranchName.get()}' branch checkout background task");

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/FastForwardParentToMatchSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/FastForwardParentToMatchSelectedBranchAction.java
@@ -10,7 +10,7 @@ public class FastForwardParentToMatchSelectedBranchAction extends BaseFastForwar
     implements
       IExpectsKeySelectedBranchName {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getSelectedBranchName(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/FastForwardParentToMatchSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/FastForwardParentToMatchSelectedBranchAction.java
@@ -10,6 +10,11 @@ public class FastForwardParentToMatchSelectedBranchAction extends BaseFastForwar
     implements
       IExpectsKeySelectedBranchName {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getSelectedBranchNameWithLogging(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/OverrideForkPointOfSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/OverrideForkPointOfSelectedBranchAction.java
@@ -10,6 +10,11 @@ public class OverrideForkPointOfSelectedBranchAction extends BaseOverrideForkPoi
     implements
       IExpectsKeySelectedBranchName {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getSelectedBranchNameWithLogging(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/OverrideForkPointOfSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/OverrideForkPointOfSelectedBranchAction.java
@@ -10,7 +10,7 @@ public class OverrideForkPointOfSelectedBranchAction extends BaseOverrideForkPoi
     implements
       IExpectsKeySelectedBranchName {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getSelectedBranchName(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/PullSelectedBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/PullSelectedBranchFastForwardOnlyAction.java
@@ -10,7 +10,7 @@ public class PullSelectedBranchFastForwardOnlyAction extends BasePullBranchFastF
     implements
       IExpectsKeySelectedBranchName {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getSelectedBranchName(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/PullSelectedBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/PullSelectedBranchFastForwardOnlyAction.java
@@ -10,6 +10,11 @@ public class PullSelectedBranchFastForwardOnlyAction extends BasePullBranchFastF
     implements
       IExpectsKeySelectedBranchName {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getSelectedBranchNameWithLogging(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/PushSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/PushSelectedBranchAction.java
@@ -8,7 +8,7 @@ import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelecte
 
 public class PushSelectedBranchAction extends BasePushBranchAction implements IExpectsKeySelectedBranchName {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getSelectedBranchName(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/PushSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/PushSelectedBranchAction.java
@@ -8,6 +8,11 @@ import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelecte
 
 public class PushSelectedBranchAction extends BasePushBranchAction implements IExpectsKeySelectedBranchName {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getSelectedBranchNameWithLogging(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/RebaseSelectedBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/RebaseSelectedBranchOntoParentAction.java
@@ -10,7 +10,7 @@ public class RebaseSelectedBranchOntoParentAction extends BaseRebaseBranchOntoPa
     implements
       IExpectsKeySelectedBranchName {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getSelectedBranchName(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/RebaseSelectedBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/RebaseSelectedBranchOntoParentAction.java
@@ -10,6 +10,11 @@ public class RebaseSelectedBranchOntoParentAction extends BaseRebaseBranchOntoPa
     implements
       IExpectsKeySelectedBranchName {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getSelectedBranchNameWithLogging(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/ResetSelectedBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/ResetSelectedBranchToRemoteAction.java
@@ -8,6 +8,11 @@ import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelecte
 
 public class ResetSelectedBranchToRemoteAction extends BaseResetBranchToRemoteAction implements IExpectsKeySelectedBranchName {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
     return getSelectedBranchName(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/ResetSelectedBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/ResetSelectedBranchToRemoteAction.java
@@ -8,12 +8,12 @@ import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelecte
 
 public class ResetSelectedBranchToRemoteAction extends BaseResetBranchToRemoteAction implements IExpectsKeySelectedBranchName {
   @Override
-  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getSelectedBranchNameWithLogging(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithoutLogging(anActionEvent);
   }
 
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getSelectedBranchName(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/SlideInBranchBelowSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/SlideInBranchBelowSelectedBranchAction.java
@@ -10,7 +10,7 @@ public class SlideInBranchBelowSelectedBranchAction extends BaseSlideInBranchBel
     implements
       IExpectsKeySelectedBranchName {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getSelectedBranchName(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/SlideInBranchBelowSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/SlideInBranchBelowSelectedBranchAction.java
@@ -10,6 +10,11 @@ public class SlideInBranchBelowSelectedBranchAction extends BaseSlideInBranchBel
     implements
       IExpectsKeySelectedBranchName {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getSelectedBranchNameWithLogging(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/SlideOutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/SlideOutSelectedBranchAction.java
@@ -8,6 +8,11 @@ import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelecte
 
 public class SlideOutSelectedBranchAction extends BaseSlideOutBranchAction implements IExpectsKeySelectedBranchName {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getSelectedBranchNameWithLogging(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/SlideOutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/SlideOutSelectedBranchAction.java
@@ -8,7 +8,7 @@ import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelecte
 
 public class SlideOutSelectedBranchAction extends BaseSlideOutBranchAction implements IExpectsKeySelectedBranchName {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getSelectedBranchName(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getSelectedBranchNameWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
@@ -13,7 +13,7 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
     return Option.of(anActionEvent.getData(DataKeys.KEY_GIT_MACHETE_REPOSITORY_SNAPSHOT));
   }
 
-  default Option<IGitMacheteRepositorySnapshot> getGitMacheteRepositorySnapshotWithLoggingOnEmpty(AnActionEvent anActionEvent) {
+  default Option<IGitMacheteRepositorySnapshot> getGitMacheteRepositorySnapshotWithLogging(AnActionEvent anActionEvent) {
     var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshot(anActionEvent);
     if (gitMacheteRepositorySnapshot.isEmpty()) {
       log().warn("Git Machete repository snapshot is undefined");
@@ -21,8 +21,8 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
     return gitMacheteRepositorySnapshot;
   }
 
-  default Option<IBranchLayout> getBranchLayoutWithLoggingOnEmpty(AnActionEvent anActionEvent) {
-    var branchLayout = getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent)
+  default Option<IBranchLayout> getBranchLayoutWithLogging(AnActionEvent anActionEvent) {
+    var branchLayout = getGitMacheteRepositorySnapshotWithLogging(anActionEvent)
         .flatMap(repository -> repository.getBranchLayout());
     if (branchLayout.isEmpty()) {
       log().warn("Branch layout is undefined");
@@ -35,30 +35,25 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
         .flatMap(repository -> repository.getCurrentBranchIfManaged());
   }
 
+  default Option<IGitMacheteBranch> getCurrentMacheteBranchIfManagedWithLogging(AnActionEvent anActionEvent) {
+    return getGitMacheteRepositorySnapshotWithLogging(anActionEvent)
+        .flatMap(repository -> repository.getCurrentBranchIfManaged());
+  }
+
   default Option<String> getCurrentBranchNameIfManaged(AnActionEvent anActionEvent) {
     return getCurrentMacheteBranchIfManaged(anActionEvent).map(branch -> branch.getName());
   }
 
-  default Option<IGitMacheteBranch> getCurrentMacheteBranchIfManagedWithLoggingOnEmptyRepository(AnActionEvent anActionEvent) {
-    return getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent)
-        .flatMap(repository -> repository.getCurrentBranchIfManaged());
-  }
-
-  default Option<String> getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(AnActionEvent anActionEvent) {
-    return getCurrentMacheteBranchIfManagedWithLoggingOnEmptyRepository(anActionEvent).map(branch -> branch.getName());
-  }
-
-  default Option<String> getCurrentBranchNameIfManagedWithLoggingOnEmpty(AnActionEvent anActionEvent) {
-    var currentBranchName = getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+  default Option<String> getCurrentBranchNameIfManagedWithLogging(AnActionEvent anActionEvent) {
+    var currentBranchName = getCurrentBranchNameIfManagedWithLogging(anActionEvent);
     if (currentBranchName.isEmpty()) {
       log().warn("Current Git Machete branch name is undefined");
     }
     return currentBranchName;
   }
 
-  default Option<IManagedBranchSnapshot> getGitMacheteBranchByNameWithLoggingOnEmpty(AnActionEvent anActionEvent,
-      String branchName) {
-    var gitMacheteBranch = getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent)
+  default Option<IManagedBranchSnapshot> getGitMacheteBranchByNameWithLogging(AnActionEvent anActionEvent, String branchName) {
+    var gitMacheteBranch = getGitMacheteRepositorySnapshotWithLogging(anActionEvent)
         .flatMap(r -> r.getManagedBranchByName(branchName));
     if (gitMacheteBranch.isEmpty()) {
       log().warn(branchName + " Git Machete branch is undefined");

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
@@ -21,7 +21,7 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
     return gitMacheteRepositorySnapshot;
   }
 
-  default Option<IBranchLayout> getBranchLayout(AnActionEvent anActionEvent) {
+  default Option<IBranchLayout> getBranchLayoutWithLoggingOnEmpty(AnActionEvent anActionEvent) {
     var branchLayout = getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent)
         .flatMap(repository -> repository.getBranchLayout());
     if (branchLayout.isEmpty()) {
@@ -31,7 +31,7 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
   }
 
   default Option<IManagedBranchSnapshot> getCurrentMacheteBranchIfManaged(AnActionEvent anActionEvent) {
-    return getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent)
+    return getGitMacheteRepositorySnapshot(anActionEvent)
         .flatMap(repository -> repository.getCurrentBranchIfManaged());
   }
 
@@ -39,20 +39,34 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
     return getCurrentMacheteBranchIfManaged(anActionEvent).map(branch -> branch.getName());
   }
 
+  default Option<IGitMacheteBranch> getCurrentMacheteBranchIfManagedWithLoggingOnEmptyRepository(AnActionEvent anActionEvent) {
+    return getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent)
+        .flatMap(repository -> repository.getCurrentBranchIfManaged());
+  }
+
+  default Option<String> getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(AnActionEvent anActionEvent) {
+    return getCurrentMacheteBranchIfManagedWithLoggingOnEmptyRepository(anActionEvent).map(branch -> branch.getName());
+  }
+
   default Option<String> getCurrentBranchNameIfManagedWithLoggingOnEmpty(AnActionEvent anActionEvent) {
-    var currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    var currentBranchName = getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
     if (currentBranchName.isEmpty()) {
       log().warn("Current Git Machete branch name is undefined");
     }
     return currentBranchName;
   }
 
-  default Option<IManagedBranchSnapshot> getGitMacheteBranchByName(AnActionEvent anActionEvent, String branchName) {
+  default Option<IManagedBranchSnapshot> getGitMacheteBranchByNameWithLoggingOnEmpty(AnActionEvent anActionEvent,
+      String branchName) {
     var gitMacheteBranch = getGitMacheteRepositorySnapshotWithLoggingOnEmpty(anActionEvent)
         .flatMap(r -> r.getManagedBranchByName(branchName));
     if (gitMacheteBranch.isEmpty()) {
       log().warn(branchName + " Git Machete branch is undefined");
     }
     return gitMacheteBranch;
+  }
+
+  default Option<IGitMacheteBranch> getGitMacheteBranchByName(AnActionEvent anActionEvent, String branchName) {
+    return getGitMacheteRepositorySnapshot(anActionEvent).flatMap(r -> r.getManagedBranchByName(branchName));
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
@@ -8,6 +8,12 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot;
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 
+/**
+ * As a rule of thumb, methods `*WithLogging` should be used only in `actionPerformed` methods and definitely NOT in
+ * any `update` or `onUpdate` methods.
+ * In `update` and `onUpdate` methods only `*WithoutLogging` should be used.
+ */
+
 public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
   default Option<IGitMacheteRepositorySnapshot> getGitMacheteRepositorySnapshotWithoutLogging(AnActionEvent anActionEvent) {
     return Option.of(anActionEvent.getData(DataKeys.KEY_GIT_MACHETE_REPOSITORY_SNAPSHOT));

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
@@ -45,7 +45,7 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
   }
 
   default Option<String> getCurrentBranchNameIfManagedWithLogging(AnActionEvent anActionEvent) {
-    var currentBranchName = getCurrentBranchNameIfManagedWithLogging(anActionEvent);
+    var currentBranchName = getCurrentMacheteBranchIfManagedWithLogging(anActionEvent).map(branch -> branch.getName());
     if (currentBranchName.isEmpty()) {
       log().warn("Current Git Machete branch name is undefined");
     }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
@@ -9,12 +9,12 @@ import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot;
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 
 public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
-  default Option<IGitMacheteRepositorySnapshot> getGitMacheteRepositorySnapshot(AnActionEvent anActionEvent) {
+  default Option<IGitMacheteRepositorySnapshot> getGitMacheteRepositorySnapshotWithoutLogging(AnActionEvent anActionEvent) {
     return Option.of(anActionEvent.getData(DataKeys.KEY_GIT_MACHETE_REPOSITORY_SNAPSHOT));
   }
 
   default Option<IGitMacheteRepositorySnapshot> getGitMacheteRepositorySnapshotWithLogging(AnActionEvent anActionEvent) {
-    var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshot(anActionEvent);
+    var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshotWithoutLogging(anActionEvent);
     if (gitMacheteRepositorySnapshot.isEmpty()) {
       log().warn("Git Machete repository snapshot is undefined");
     }
@@ -30,18 +30,18 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
     return branchLayout;
   }
 
-  default Option<IManagedBranchSnapshot> getCurrentMacheteBranchIfManaged(AnActionEvent anActionEvent) {
-    return getGitMacheteRepositorySnapshot(anActionEvent)
+  default Option<IManagedBranchSnapshot> getCurrentMacheteBranchIfManagedWithoutLogging(AnActionEvent anActionEvent) {
+    return getGitMacheteRepositorySnapshotWithoutLogging(anActionEvent)
         .flatMap(repository -> repository.getCurrentBranchIfManaged());
   }
 
-  default Option<IGitMacheteBranch> getCurrentMacheteBranchIfManagedWithLogging(AnActionEvent anActionEvent) {
+  default Option<IManagedBranchSnapshot> getCurrentMacheteBranchIfManagedWithLogging(AnActionEvent anActionEvent) {
     return getGitMacheteRepositorySnapshotWithLogging(anActionEvent)
         .flatMap(repository -> repository.getCurrentBranchIfManaged());
   }
 
-  default Option<String> getCurrentBranchNameIfManaged(AnActionEvent anActionEvent) {
-    return getCurrentMacheteBranchIfManaged(anActionEvent).map(branch -> branch.getName());
+  default Option<String> getCurrentBranchNameIfManagedWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentMacheteBranchIfManagedWithoutLogging(anActionEvent).map(branch -> branch.getName());
   }
 
   default Option<String> getCurrentBranchNameIfManagedWithLogging(AnActionEvent anActionEvent) {
@@ -52,6 +52,11 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
     return currentBranchName;
   }
 
+  default Option<IManagedBranchSnapshot> getGitMacheteBranchByNameWithoutLogging(AnActionEvent anActionEvent,
+      String branchName) {
+    return getGitMacheteRepositorySnapshotWithoutLogging(anActionEvent).flatMap(r -> r.getManagedBranchByName(branchName));
+  }
+
   default Option<IManagedBranchSnapshot> getGitMacheteBranchByNameWithLogging(AnActionEvent anActionEvent, String branchName) {
     var gitMacheteBranch = getGitMacheteRepositorySnapshotWithLogging(anActionEvent)
         .flatMap(r -> r.getManagedBranchByName(branchName));
@@ -59,9 +64,5 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
       log().warn(branchName + " Git Machete branch is undefined");
     }
     return gitMacheteBranch;
-  }
-
-  default Option<IGitMacheteBranch> getGitMacheteBranchByName(AnActionEvent anActionEvent, String branchName) {
-    return getGitMacheteRepositorySnapshot(anActionEvent).flatMap(r -> r.getManagedBranchByName(branchName));
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyProject.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyProject.java
@@ -11,6 +11,12 @@ import com.virtuslab.gitmachete.frontend.ui.providerservice.BranchLayoutWriterPr
 import com.virtuslab.gitmachete.frontend.ui.providerservice.GraphTableProvider;
 import com.virtuslab.gitmachete.frontend.ui.providerservice.SelectedGitRepositoryProvider;
 
+/**
+ * As a rule of thumb, method {@code getSelectedGitRepositoryWithLogging} should be used only in `actionPerformed` methods
+ * and definitely NOT in any `update` or `onUpdate` methods.
+ * In `update` and `onUpdate` methods only {@code getSelectedGitRepositoryWithoutLogging} should be used.
+ */
+
 public interface IExpectsKeyProject extends IWithLogger {
   default Project getProject(AnActionEvent anActionEvent) {
     var project = anActionEvent.getProject();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyProject.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyProject.java
@@ -30,7 +30,11 @@ public interface IExpectsKeyProject extends IWithLogger {
     return getProject(anActionEvent).getService(GraphTableProvider.class).getGraphTable();
   }
 
-  default Option<GitRepository> getSelectedGitRepository(AnActionEvent anActionEvent) {
+  default Option<GitRepository> getSelectedGitRepositoryWithoutLogging(AnActionEvent anActionEvent) {
+    return getProject(anActionEvent).getService(SelectedGitRepositoryProvider.class).getSelectedGitRepository();
+  }
+
+  default Option<GitRepository> getSelectedGitRepositoryWithLogging(AnActionEvent anActionEvent) {
     var gitRepository = getProject(anActionEvent).getService(SelectedGitRepositoryProvider.class)
         .getSelectedGitRepository();
     if (gitRepository.isEmpty()) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeySelectedBranchName.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeySelectedBranchName.java
@@ -5,6 +5,12 @@ import io.vavr.control.Option;
 
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 
+/**
+ * As a rule of thumb, method {@code getSelectedBranchNameWithLogging} should be used only in `actionPerformed` methods
+ * and definitely NOT in any `update` or `onUpdate` methods.
+ * In `update` and `onUpdate` methods only {@code getSelectedBranchNameWithoutLogging} should be used.
+ */
+
 public interface IExpectsKeySelectedBranchName extends IWithLogger {
   default Option<String> getSelectedBranchNameWithoutLogging(AnActionEvent anActionEvent) {
     return Option.of(anActionEvent.getData(DataKeys.KEY_SELECTED_BRANCH_NAME));

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeySelectedBranchName.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeySelectedBranchName.java
@@ -6,15 +6,15 @@ import io.vavr.control.Option;
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 
 public interface IExpectsKeySelectedBranchName extends IWithLogger {
+  default Option<String> getSelectedBranchNameWithoutLogging(AnActionEvent anActionEvent) {
+    return Option.of(anActionEvent.getData(DataKeys.KEY_SELECTED_BRANCH_NAME));
+  }
+
   default Option<String> getSelectedBranchNameWithLogging(AnActionEvent anActionEvent) {
     var selectedBranchName = Option.of(anActionEvent.getData(DataKeys.KEY_SELECTED_BRANCH_NAME));
     if (selectedBranchName.isEmpty()) {
       log().warn("Selected branch is undefined");
     }
     return selectedBranchName;
-  }
-
-  default Option<String> getSelectedBranchName(AnActionEvent anActionEvent) {
-    return Option.of(anActionEvent.getData(DataKeys.KEY_SELECTED_BRANCH_NAME));
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeySelectedBranchName.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeySelectedBranchName.java
@@ -6,11 +6,15 @@ import io.vavr.control.Option;
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 
 public interface IExpectsKeySelectedBranchName extends IWithLogger {
-  default Option<String> getSelectedBranchName(AnActionEvent anActionEvent) {
+  default Option<String> getSelectedBranchNameWithLogging(AnActionEvent anActionEvent) {
     var selectedBranchName = Option.of(anActionEvent.getData(DataKeys.KEY_SELECTED_BRANCH_NAME));
     if (selectedBranchName.isEmpty()) {
       log().warn("Selected branch is undefined");
     }
     return selectedBranchName;
+  }
+
+  default Option<String> getSelectedBranchName(AnActionEvent anActionEvent) {
+    return Option.of(anActionEvent.getData(DataKeys.KEY_SELECTED_BRANCH_NAME));
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FastForwardParentToMatchCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FastForwardParentToMatchCurrentBranchAction.java
@@ -10,7 +10,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseFastForwardParentToMat
 public class FastForwardParentToMatchCurrentBranchAction extends BaseFastForwardParentToMatchBranchAction {
   @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 
   @Override
@@ -23,7 +23,7 @@ public class FastForwardParentToMatchCurrentBranchAction extends BaseFastForward
     }
 
     var isInSyncToParent = getCurrentBranchNameIfManaged(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
+        .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.InSync)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FastForwardParentToMatchCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FastForwardParentToMatchCurrentBranchAction.java
@@ -9,8 +9,8 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseFastForwardParentToMat
 
 public class FastForwardParentToMatchCurrentBranchAction extends BaseFastForwardParentToMatchBranchAction {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManaged(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
   }
 
   @Override
@@ -22,8 +22,8 @@ public class FastForwardParentToMatchCurrentBranchAction extends BaseFastForward
       return;
     }
 
-    var isInSyncToParent = getNameOfBranchUnderAction(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
+    var isInSyncToParent = getCurrentBranchNameIfManaged(anActionEvent)
+        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.InSync)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FastForwardParentToMatchCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FastForwardParentToMatchCurrentBranchAction.java
@@ -9,6 +9,11 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseFastForwardParentToMat
 
 public class FastForwardParentToMatchCurrentBranchAction extends BaseFastForwardParentToMatchBranchAction {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
@@ -22,7 +27,7 @@ public class FastForwardParentToMatchCurrentBranchAction extends BaseFastForward
       return;
     }
 
-    var isInSyncToParent = getCurrentBranchNameIfManaged(anActionEvent)
+    var isInSyncToParent = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
         .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.InSync)

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
@@ -41,7 +41,7 @@ public class FetchAllRemotesAction extends BaseProjectKeyAvailabilityAssuranceAc
     log().debug("Performing");
 
     var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    var gitRepository = getSelectedGitRepositoryWithLogging(anActionEvent);
 
     String title = getString("action.GitMachete.FetchAllRemotesAction.task-title");
     new Task.Backgroundable(project, title, /* canBeCancelled */ true) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
@@ -35,7 +35,7 @@ public class OpenMacheteFileAction extends DumbAwareAction implements IExpectsKe
 
     // When selected Git repository is empty (due to e.g. unopened Git Machete tab)
     // an attempt to guess current repository based on presently opened file
-    var gitDir = getSelectedGitRepository(anActionEvent)
+    var gitDir = getSelectedGitRepositoryWithLogging(anActionEvent)
         .onEmpty(() -> DvcsUtil.guessCurrentRepositoryQuick(project,
             GitUtil.getRepositoryManager(project),
             GitVcsSettings.getInstance(project).getRecentRootPath()))

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OverrideForkPointOfCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OverrideForkPointOfCurrentBranchAction.java
@@ -9,8 +9,8 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseOverrideForkPointActio
 
 public class OverrideForkPointOfCurrentBranchAction extends BaseOverrideForkPointAction {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManaged(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
   }
 
   @Override
@@ -22,8 +22,8 @@ public class OverrideForkPointOfCurrentBranchAction extends BaseOverrideForkPoin
       return;
     }
 
-    var isInSyncButForkPointOff = getNameOfBranchUnderAction(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
+    var isInSyncButForkPointOff = getCurrentBranchNameIfManaged(anActionEvent)
+        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OverrideForkPointOfCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OverrideForkPointOfCurrentBranchAction.java
@@ -10,7 +10,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseOverrideForkPointActio
 public class OverrideForkPointOfCurrentBranchAction extends BaseOverrideForkPointAction {
   @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 
   @Override
@@ -23,7 +23,7 @@ public class OverrideForkPointOfCurrentBranchAction extends BaseOverrideForkPoin
     }
 
     var isInSyncButForkPointOff = getCurrentBranchNameIfManaged(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
+        .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OverrideForkPointOfCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OverrideForkPointOfCurrentBranchAction.java
@@ -9,6 +9,11 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseOverrideForkPointActio
 
 public class OverrideForkPointOfCurrentBranchAction extends BaseOverrideForkPointAction {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
@@ -22,8 +27,8 @@ public class OverrideForkPointOfCurrentBranchAction extends BaseOverrideForkPoin
       return;
     }
 
-    var isInSyncButForkPointOff = getCurrentBranchNameIfManaged(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
+    var isInSyncButForkPointOff = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
+        .flatMap(bn -> getGitMacheteBranchByNameWithoutLogging(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PullCurrentBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PullCurrentBranchFastForwardOnlyAction.java
@@ -12,8 +12,8 @@ import com.virtuslab.gitmachete.frontend.actions.base.BasePullBranchFastForwardO
 
 public class PullCurrentBranchFastForwardOnlyAction extends BasePullBranchFastForwardOnlyAction {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManaged(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
   }
 
   @Override
@@ -25,8 +25,8 @@ public class PullCurrentBranchFastForwardOnlyAction extends BasePullBranchFastFo
       return;
     }
 
-    var isBehindOrInSyncToRemote = getNameOfBranchUnderAction(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
+    var isBehindOrInSyncToRemote = getCurrentBranchNameIfManaged(anActionEvent)
+        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation())
         .map(strs -> List.of(BehindRemote, InSyncToRemote).contains(strs))
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PullCurrentBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PullCurrentBranchFastForwardOnlyAction.java
@@ -12,6 +12,11 @@ import com.virtuslab.gitmachete.frontend.actions.base.BasePullBranchFastForwardO
 
 public class PullCurrentBranchFastForwardOnlyAction extends BasePullBranchFastForwardOnlyAction {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
@@ -25,7 +30,7 @@ public class PullCurrentBranchFastForwardOnlyAction extends BasePullBranchFastFo
       return;
     }
 
-    var isBehindOrInSyncToRemote = getCurrentBranchNameIfManaged(anActionEvent)
+    var isBehindOrInSyncToRemote = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
         .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation())
         .map(strs -> List.of(BehindRemote, InSyncToRemote).contains(strs))

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PullCurrentBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PullCurrentBranchFastForwardOnlyAction.java
@@ -13,7 +13,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BasePullBranchFastForwardO
 public class PullCurrentBranchFastForwardOnlyAction extends BasePullBranchFastForwardOnlyAction {
   @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 
   @Override
@@ -26,7 +26,7 @@ public class PullCurrentBranchFastForwardOnlyAction extends BasePullBranchFastFo
     }
 
     var isBehindOrInSyncToRemote = getCurrentBranchNameIfManaged(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
+        .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation())
         .map(strs -> List.of(BehindRemote, InSyncToRemote).contains(strs))
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PushCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PushCurrentBranchAction.java
@@ -13,6 +13,11 @@ import com.virtuslab.gitmachete.frontend.actions.base.BasePushBranchAction;
 
 public class PushCurrentBranchAction extends BasePushBranchAction {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
@@ -26,7 +31,7 @@ public class PushCurrentBranchAction extends BasePushBranchAction {
       return;
     }
 
-    var isAheadOrDivergedAndNewerOrUntracked = getCurrentBranchNameIfManaged(anActionEvent)
+    var isAheadOrDivergedAndNewerOrUntracked = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
         .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation())
         .map(strs -> List.of(AheadOfRemote, DivergedFromAndNewerThanRemote, Untracked).contains(strs))

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PushCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PushCurrentBranchAction.java
@@ -13,8 +13,8 @@ import com.virtuslab.gitmachete.frontend.actions.base.BasePushBranchAction;
 
 public class PushCurrentBranchAction extends BasePushBranchAction {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManaged(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
   }
 
   @Override
@@ -26,8 +26,8 @@ public class PushCurrentBranchAction extends BasePushBranchAction {
       return;
     }
 
-    var isAheadOrDivergedAndNewerOrUntracked = getNameOfBranchUnderAction(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
+    var isAheadOrDivergedAndNewerOrUntracked = getCurrentBranchNameIfManaged(anActionEvent)
+        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation())
         .map(strs -> List.of(AheadOfRemote, DivergedFromAndNewerThanRemote, Untracked).contains(strs))
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PushCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PushCurrentBranchAction.java
@@ -14,7 +14,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BasePushBranchAction;
 public class PushCurrentBranchAction extends BasePushBranchAction {
   @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 
   @Override
@@ -27,7 +27,7 @@ public class PushCurrentBranchAction extends BasePushBranchAction {
     }
 
     var isAheadOrDivergedAndNewerOrUntracked = getCurrentBranchNameIfManaged(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
+        .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation())
         .map(strs -> List.of(AheadOfRemote, DivergedFromAndNewerThanRemote, Untracked).contains(strs))
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/RebaseCurrentBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/RebaseCurrentBranchOntoParentAction.java
@@ -8,8 +8,8 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseRebaseBranchOntoParent
 
 public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoParentAction {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManaged(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
   }
 
   @Override
@@ -21,8 +21,8 @@ public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoPar
       return;
     }
 
-    var isNonRootBranch = getNameOfBranchUnderAction(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
+    var isNonRootBranch = getCurrentBranchNameIfManaged(anActionEvent)
+        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
         .map(b -> b.isNonRoot())
         .getOrElse(false);
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/RebaseCurrentBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/RebaseCurrentBranchOntoParentAction.java
@@ -8,6 +8,11 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseRebaseBranchOntoParent
 
 public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoParentAction {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
@@ -21,7 +26,7 @@ public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoPar
       return;
     }
 
-    var isNonRootBranch = getCurrentBranchNameIfManaged(anActionEvent)
+    var isNonRootBranch = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
         .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .map(b -> b.isNonRoot())
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/RebaseCurrentBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/RebaseCurrentBranchOntoParentAction.java
@@ -9,7 +9,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseRebaseBranchOntoParent
 public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoParentAction {
   @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 
   @Override
@@ -22,7 +22,7 @@ public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoPar
     }
 
     var isNonRootBranch = getCurrentBranchNameIfManaged(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
+        .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .map(b -> b.isNonRoot())
         .getOrElse(false);
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ResetCurrentBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ResetCurrentBranchToRemoteAction.java
@@ -10,6 +10,11 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseResetBranchToRemoteAct
 
 public class ResetCurrentBranchToRemoteAction extends BaseResetBranchToRemoteAction {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
     return getCurrentBranchNameIfManaged(anActionEvent);
   }
@@ -23,7 +28,7 @@ public class ResetCurrentBranchToRemoteAction extends BaseResetBranchToRemoteAct
       return;
     }
 
-    var isDivergedFromAndOlderThanRemote = getNameOfBranchUnderAction(anActionEvent)
+    var isDivergedFromAndOlderThanRemote = getCurrentBranchNameIfManaged(anActionEvent)
         .flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation() == DivergedFromAndOlderThanRemote)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ResetCurrentBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ResetCurrentBranchToRemoteAction.java
@@ -10,13 +10,13 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseResetBranchToRemoteAct
 
 public class ResetCurrentBranchToRemoteAction extends BaseResetBranchToRemoteAction {
   @Override
-  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
   }
 
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManaged(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 
   @Override
@@ -28,8 +28,8 @@ public class ResetCurrentBranchToRemoteAction extends BaseResetBranchToRemoteAct
       return;
     }
 
-    var isDivergedFromAndOlderThanRemote = getCurrentBranchNameIfManaged(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
+    var isDivergedFromAndOlderThanRemote = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
+        .flatMap(bn -> getGitMacheteBranchByNameWithoutLogging(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation() == DivergedFromAndOlderThanRemote)
         .getOrElse(false);
 

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ResetCurrentBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ResetCurrentBranchToRemoteAction.java
@@ -11,7 +11,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseResetBranchToRemoteAct
 public class ResetCurrentBranchToRemoteAction extends BaseResetBranchToRemoteAction {
   @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 
   @Override

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideInBranchBelowCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideInBranchBelowCurrentBranchAction.java
@@ -8,6 +8,6 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseSlideInBranchBelowActi
 public class SlideInBranchBelowCurrentBranchAction extends BaseSlideInBranchBelowAction {
   @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideInBranchBelowCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideInBranchBelowCurrentBranchAction.java
@@ -7,6 +7,11 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseSlideInBranchBelowActi
 
 public class SlideInBranchBelowCurrentBranchAction extends BaseSlideInBranchBelowAction {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideInBranchBelowCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideInBranchBelowCurrentBranchAction.java
@@ -7,7 +7,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseSlideInBranchBelowActi
 
 public class SlideInBranchBelowCurrentBranchAction extends BaseSlideInBranchBelowAction {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManaged(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideOutCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideOutCurrentBranchAction.java
@@ -10,7 +10,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseSlideOutBranchAction;
 public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
   @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
+    return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
 
   @Override
@@ -23,7 +23,7 @@ public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
     }
 
     var isMergedToParent = getCurrentBranchNameIfManaged(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
+        .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.MergedToParent)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideOutCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideOutCurrentBranchAction.java
@@ -9,6 +9,11 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseSlideOutBranchAction;
 
 public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
   @Override
+  public Option<String> getNameOfBranchUnderActionWithoutLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithoutLogging(anActionEvent);
+  }
+
+  @Override
   public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
     return getCurrentBranchNameIfManagedWithLogging(anActionEvent);
   }
@@ -22,7 +27,7 @@ public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
       return;
     }
 
-    var isMergedToParent = getCurrentBranchNameIfManaged(anActionEvent)
+    var isMergedToParent = getCurrentBranchNameIfManagedWithoutLogging(anActionEvent)
         .flatMap(bn -> getGitMacheteBranchByNameWithLogging(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.MergedToParent)

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideOutCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideOutCurrentBranchAction.java
@@ -9,8 +9,8 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseSlideOutBranchAction;
 
 public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
   @Override
-  public Option<String> getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
-    return getCurrentBranchNameIfManaged(anActionEvent);
+  public Option<String> getNameOfBranchUnderActionWithLogging(AnActionEvent anActionEvent) {
+    return getCurrentBranchNameIfManagedWithLoggingOnEmptyRepository(anActionEvent);
   }
 
   @Override
@@ -22,8 +22,8 @@ public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
       return;
     }
 
-    var isMergedToParent = getNameOfBranchUnderAction(anActionEvent)
-        .flatMap(bn -> getGitMacheteBranchByName(anActionEvent, bn))
+    var isMergedToParent = getCurrentBranchNameIfManaged(anActionEvent)
+        .flatMap(bn -> getGitMacheteBranchByNameWithLoggingOnEmpty(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.MergedToParent)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
@@ -38,7 +38,7 @@ public class ToggleListingCommitsAction extends BaseGitMacheteRepositoryReadyAct
       return;
     }
 
-    var branchLayout = getBranchLayout(anActionEvent);
+    var branchLayout = getBranchLayoutWithLoggingOnEmpty(anActionEvent);
     if (branchLayout.isEmpty()) {
       presentation.setEnabled(false);
       presentation.setDescription(getString("action.GitMachete.ToggleListingCommitsAction.description.disabled.no-branches"));

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
@@ -38,7 +38,7 @@ public class ToggleListingCommitsAction extends BaseGitMacheteRepositoryReadyAct
       return;
     }
 
-    var branchLayout = getBranchLayoutWithLoggingOnEmpty(anActionEvent);
+    var branchLayout = getBranchLayoutWithLogging(anActionEvent);
     if (branchLayout.isEmpty()) {
       presentation.setEnabled(false);
       presentation.setDescription(getString("action.GitMachete.ToggleListingCommitsAction.description.disabled.no-branches"));

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
@@ -55,7 +55,7 @@ public class ToggleListingCommitsAction extends BaseGitMacheteRepositoryReadyAct
       return;
     }
 
-    boolean anyCommitExists = getGitMacheteRepositorySnapshot(anActionEvent)
+    boolean anyCommitExists = getGitMacheteRepositorySnapshotWithoutLogging(anActionEvent)
         .map(repo -> repo.getManagedBranches()
             .exists(b -> b.isNonRoot() && b.asNonRoot().getCommits().nonEmpty()))
         .getOrElse(false);

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -341,7 +341,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
         public void run() {
           GuiUtils.invokeLaterIfNeeded(() -> graphTable.setRowSelectionAllowed(true), NON_MODAL);
         }
-      }, 35);
+      }, /* delay */ 35);
     }
 
     @Override


### PR DESCRIPTION
In this case, logging itself was a bug :bug:
When Git Machete was opened (at the same beginning) `KEY_GIT_MACHETE_REPOSITORY_SNAPSHOT` was unavailable (and this is normal at this stage) but the new version of `onUpdate` for `*Current*` actions used to use this key by calling `getNameOfBranchUnderAction` method that used to call `getGitMacheteRepositorySnapshotWithLoggingOnEmpty` that caused log production.

Methods in `IExpectedKeyGitMacheteRepository` was renamed (and some was created) to clearly distinguish which do logging and which not.
Methods without logging were used in `*Current*` actions on `onUpdate` method.

In addition, for `BaseResetBranchToRemoteAction` class `getNameOfBranchUnderAction` was created (this method is without logging, previous `getNameOfBranchUnderAction` was renamed to `getNameOfBranchUnderActionWithLogging`). This method is used in `onUpdate` in this class.