### PR TITLE
Add ability to enable/disable branch action hints (tooltips) and disable them in help&discover dialogs

### DIFF
--- a/config/checker/javax.swing.astub
+++ b/config/checker/javax.swing.astub
@@ -46,3 +46,8 @@ class DefaultTableCellRenderer {
   @UIEffect
   Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column);
 }
+
+class TableCellRenderer {
+  @UIEffect
+  Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column);
+}

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/dialogs/GraphTableDialog.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/dialogs/GraphTableDialog.java
@@ -27,17 +27,17 @@ public final class GraphTableDialog extends DialogWrapper {
 
   public static GraphTableDialog of(IGitMacheteRepositorySnapshot gitMacheteRepositorySnapshot, String windowTitle,
       @Nullable String emptyTableText, @Nullable Consumer<IGitMacheteRepositorySnapshot> okAction, String okButtonText,
-      boolean cancelButtonVisible, boolean hasBranchActionHints) {
+      boolean cancelButtonVisible, boolean hasBranchActionToolTips) {
     return of(gitMacheteRepositorySnapshot, windowTitle, /* windowWidth */ 800, /* windowHeight */ 500, emptyTableText,
-        okAction, okButtonText, cancelButtonVisible, hasBranchActionHints);
+        okAction, okButtonText, cancelButtonVisible, hasBranchActionToolTips);
   }
 
   public static GraphTableDialog of(IGitMacheteRepositorySnapshot gitMacheteRepositorySnapshot, String windowTitle,
       int windowWidth, int windowHeight, @Nullable String emptyTableText,
       @Nullable Consumer<IGitMacheteRepositorySnapshot> okAction, String okButtonText, boolean cancelButtonVisible,
-      boolean hasBranchActionHints) {
+      boolean hasBranchActionToolTips) {
     var table = RuntimeBinding.instantiateSoleImplementingClass(ISimpleGraphTableProvider.class)
-        .deriveInstance(gitMacheteRepositorySnapshot, /* isListingCommitsEnabled */ false, hasBranchActionHints);
+        .deriveInstance(gitMacheteRepositorySnapshot, /* isListingCommitsEnabled */ false, hasBranchActionToolTips);
     table.setTextForEmptyTable(emptyTableText != null ? emptyTableText : "");
     return new GraphTableDialog(table, gitMacheteRepositorySnapshot, windowTitle, windowWidth, windowHeight, okAction,
         okButtonText, cancelButtonVisible);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/dialogs/GraphTableDialog.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/dialogs/GraphTableDialog.java
@@ -27,16 +27,17 @@ public final class GraphTableDialog extends DialogWrapper {
 
   public static GraphTableDialog of(IGitMacheteRepositorySnapshot gitMacheteRepositorySnapshot, String windowTitle,
       @Nullable String emptyTableText, @Nullable Consumer<IGitMacheteRepositorySnapshot> okAction, String okButtonText,
-      boolean cancelButtonVisible) {
+      boolean cancelButtonVisible, boolean hasBranchActionHints) {
     return of(gitMacheteRepositorySnapshot, windowTitle, /* windowWidth */ 800, /* windowHeight */ 500, emptyTableText,
-        okAction, okButtonText, cancelButtonVisible);
+        okAction, okButtonText, cancelButtonVisible, hasBranchActionHints);
   }
 
   public static GraphTableDialog of(IGitMacheteRepositorySnapshot gitMacheteRepositorySnapshot, String windowTitle,
       int windowWidth, int windowHeight, @Nullable String emptyTableText,
-      @Nullable Consumer<IGitMacheteRepositorySnapshot> okAction, String okButtonText, boolean cancelButtonVisible) {
+      @Nullable Consumer<IGitMacheteRepositorySnapshot> okAction, String okButtonText, boolean cancelButtonVisible,
+      boolean hasBranchActionHints) {
     var table = RuntimeBinding.instantiateSoleImplementingClass(ISimpleGraphTableProvider.class)
-        .deriveInstance(gitMacheteRepositorySnapshot, /* isListingCommitsEnabled */ false);
+        .deriveInstance(gitMacheteRepositorySnapshot, /* isListingCommitsEnabled */ false, hasBranchActionHints);
     table.setTextForEmptyTable(emptyTableText != null ? emptyTableText : "");
     return new GraphTableDialog(table, gitMacheteRepositorySnapshot, windowTitle, windowWidth, windowHeight, okAction,
         okButtonText, cancelButtonVisible);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/graphtable/DiscoverAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/graphtable/DiscoverAction.java
@@ -60,7 +60,7 @@ public class DiscoverAction extends DumbAwareAction implements IExpectsKeyProjec
                 getBranchLayoutWriter(anActionEvent)),
             /* okButtonText */ getString("action.GitMachete.DiscoverAction.discovered-branch-tree-dialog.save-button-text"),
             /* cancelButtonVisible */ true,
-            /* hasBranchActionHints */ true).show(), NON_MODAL));
+            /* hasBranchActionToolTips */ false).show(), NON_MODAL));
   }
 
   private void saveDiscoveredLayout(IGitMacheteRepositorySnapshot repositorySnapshot, Path macheteFilePath, Project project,

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/graphtable/DiscoverAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/graphtable/DiscoverAction.java
@@ -59,7 +59,8 @@ public class DiscoverAction extends DumbAwareAction implements IExpectsKeyProjec
                 GitVfsUtils.getMacheteFilePath(selectedRepository), project, getGraphTable(anActionEvent),
                 getBranchLayoutWriter(anActionEvent)),
             /* okButtonText */ getString("action.GitMachete.DiscoverAction.discovered-branch-tree-dialog.save-button-text"),
-            /* cancelButtonVisible */ true).show(), NON_MODAL));
+            /* cancelButtonVisible */ true,
+            /* hasBranchActionHints */ true).show(), NON_MODAL));
   }
 
   private void saveDiscoveredLayout(IGitMacheteRepositorySnapshot repositorySnapshot, Path macheteFilePath, Project project,

--- a/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/ISimpleGraphTableProvider.java
+++ b/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/ISimpleGraphTableProvider.java
@@ -6,7 +6,8 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 
 public interface ISimpleGraphTableProvider {
   @UIEffect
-  BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot, boolean isListingCommitsEnabled, boolean hasBranchActionToolTips);
+  BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot, boolean isListingCommitsEnabled,
+      boolean hasBranchActionToolTips);
 
   @UIEffect
   BaseGraphTable deriveDemoInstance();

--- a/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/ISimpleGraphTableProvider.java
+++ b/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/ISimpleGraphTableProvider.java
@@ -6,7 +6,7 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 
 public interface ISimpleGraphTableProvider {
   @UIEffect
-  BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot, boolean isListingCommitsEnabled, boolean hasBranchActionHints);
+  BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot, boolean isListingCommitsEnabled, boolean hasBranchActionToolTips);
 
   @UIEffect
   BaseGraphTable deriveDemoInstance();

--- a/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/ISimpleGraphTableProvider.java
+++ b/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/ISimpleGraphTableProvider.java
@@ -6,7 +6,7 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 
 public interface ISimpleGraphTableProvider {
   @UIEffect
-  BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot, boolean isListingCommitsEnabled);
+  BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot, boolean isListingCommitsEnabled, boolean hasBranchActionHints);
 
   @UIEffect
   BaseGraphTable deriveDemoInstance();

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRenderer.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRenderer.java
@@ -1,0 +1,23 @@
+package com.virtuslab.gitmachete.frontend.ui.impl.cell;
+
+import java.awt.Component;
+
+import javax.swing.JTable;
+import javax.swing.table.TableCellRenderer;
+
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+
+public class BranchOrCommitCellRenderer implements TableCellRenderer {
+  private final boolean hasBranchActionHints;
+
+  public BranchOrCommitCellRenderer(boolean hasBranchActionHints) {
+    this.hasBranchActionHints = hasBranchActionHints;
+  }
+
+  @Override
+  @UIEffect
+  public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row,
+      int column) {
+    return new BranchOrCommitCellRendererComponent(table, value, isSelected, hasFocus, row, column, hasBranchActionHints);
+  }
+}

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRenderer.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRenderer.java
@@ -5,19 +5,17 @@ import java.awt.Component;
 import javax.swing.JTable;
 import javax.swing.table.TableCellRenderer;
 
+import lombok.RequiredArgsConstructor;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
+@RequiredArgsConstructor
 public class BranchOrCommitCellRenderer implements TableCellRenderer {
-  private final boolean hasBranchActionHints;
-
-  public BranchOrCommitCellRenderer(boolean hasBranchActionHints) {
-    this.hasBranchActionHints = hasBranchActionHints;
-  }
+  private final boolean hasBranchActionToolTips;
 
   @Override
   @UIEffect
   public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row,
       int column) {
-    return new BranchOrCommitCellRendererComponent(table, value, isSelected, hasFocus, row, column, hasBranchActionHints);
+    return new BranchOrCommitCellRendererComponent(table, value, isSelected, hasFocus, row, column, hasBranchActionToolTips);
   }
 }

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -85,7 +85,7 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
       boolean hasFocus,
       int row,
       int column,
-      boolean hasBranchActionHints) {
+      boolean hasBranchActionToolTips) {
 
     this.graphTable = table;
 
@@ -156,7 +156,7 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
       IBranchItem branchItem = graphItem.asBranchItem();
       IManagedBranchSnapshot branch = branchItem.getBranch();
 
-      if (hasBranchActionHints && branch.isNonRoot()) {
+      if (hasBranchActionToolTips && branch.isNonRoot()) {
         setToolTipText(getSyncToParentStatusBasedToolTipText(branch.asNonRoot()));
       }
 

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -84,7 +84,8 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
       boolean isSelected,
       boolean hasFocus,
       int row,
-      int column) {
+      int column,
+      boolean hasBranchActionHints) {
 
     this.graphTable = table;
 
@@ -155,7 +156,7 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
       IBranchItem branchItem = graphItem.asBranchItem();
       IManagedBranchSnapshot branch = branchItem.getBranch();
 
-      if (branch.isNonRoot()) {
+      if (hasBranchActionHints && branch.isNonRoot()) {
         setToolTipText(getSyncToParentStatusBasedToolTipText(branch.asNonRoot()));
       }
 

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -26,6 +26,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.PopupMenuEvent;
+import javax.swing.table.TableCellRenderer;
 
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.ActionGroup;
@@ -67,7 +68,7 @@ import com.virtuslab.gitmachete.frontend.graph.api.repository.NullRepositoryGrap
 import com.virtuslab.gitmachete.frontend.ui.api.gitrepositoryselection.IGitRepositorySelectionProvider;
 import com.virtuslab.gitmachete.frontend.ui.api.table.BaseEnhancedGraphTable;
 import com.virtuslab.gitmachete.frontend.ui.impl.cell.BranchOrCommitCell;
-import com.virtuslab.gitmachete.frontend.ui.impl.cell.BranchOrCommitCellRendererComponent;
+import com.virtuslab.gitmachete.frontend.ui.impl.cell.BranchOrCommitCellRenderer;
 import com.virtuslab.gitmachete.frontend.ui.providerservice.SelectedGitRepositoryProvider;
 
 /**
@@ -100,6 +101,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
   @UIEffect
   private @Nullable String selectedBranchName;
 
+  private final TableCellRenderer tableCellRenderer;
+
   @UIEffect
   public EnhancedGraphTable(Project project) {
     super(new GraphTableModel(NullRepositoryGraph.getInstance()));
@@ -108,6 +111,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     this.branchLayoutReader = RuntimeBinding.instantiateSoleImplementingClass(IBranchLayoutReader.class);
     this.repositoryGraphCache = RuntimeBinding.instantiateSoleImplementingClass(IRepositoryGraphCache.class);
     this.isListingCommits = false;
+    this.tableCellRenderer = new BranchOrCommitCellRenderer(/* hasBranchActionHints */ true);
 
     // InitializationChecker allows us to invoke the below methods because the class is final
     // and all `@NonNull` fields are already initialized. `this` is already `@Initialized` (and not just
@@ -120,7 +124,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     setRowSelectionAllowed(false);
     setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
-    setDefaultRenderer(BranchOrCommitCell.class, BranchOrCommitCellRendererComponent::new);
+    setDefaultRenderer(BranchOrCommitCell.class, tableCellRenderer);
 
     setShowVerticalLines(false);
     setShowHorizontalLines(false);

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -26,7 +26,6 @@ import javax.swing.JPopupMenu;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.PopupMenuEvent;
-import javax.swing.table.TableCellRenderer;
 
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.ActionGroup;
@@ -101,8 +100,6 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
   @UIEffect
   private @Nullable String selectedBranchName;
 
-  private final TableCellRenderer tableCellRenderer;
-
   @UIEffect
   public EnhancedGraphTable(Project project) {
     super(new GraphTableModel(NullRepositoryGraph.getInstance()));
@@ -111,7 +108,6 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     this.branchLayoutReader = RuntimeBinding.instantiateSoleImplementingClass(IBranchLayoutReader.class);
     this.repositoryGraphCache = RuntimeBinding.instantiateSoleImplementingClass(IRepositoryGraphCache.class);
     this.isListingCommits = false;
-    this.tableCellRenderer = new BranchOrCommitCellRenderer(/* hasBranchActionHints */ true);
 
     // InitializationChecker allows us to invoke the below methods because the class is final
     // and all `@NonNull` fields are already initialized. `this` is already `@Initialized` (and not just
@@ -124,7 +120,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     setRowSelectionAllowed(false);
     setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
-    setDefaultRenderer(BranchOrCommitCell.class, tableCellRenderer);
+    setDefaultRenderer(BranchOrCommitCell.class, new BranchOrCommitCellRenderer(/* hasBranchActionToolTips */ true));
 
     setShowVerticalLines(false);
     setShowHorizontalLines(false);

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTable.java
@@ -24,7 +24,8 @@ public final class SimpleGraphTable extends BaseGraphTable implements IGitMachet
       boolean isListingCommitsEnabled, boolean hasBranchActionToolTips) {
     // We can keep the data - graph table model,
     // but wee need to reinstantiate the UI - demo graph table.
-    return new SimpleGraphTable(deriveGraphTableModel(macheteRepositorySnapshot, isListingCommitsEnabled), hasBranchActionToolTips);
+    return new SimpleGraphTable(deriveGraphTableModel(macheteRepositorySnapshot, isListingCommitsEnabled),
+        hasBranchActionToolTips);
   }
 
   @UIEffect

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTable.java
@@ -1,6 +1,7 @@
 package com.virtuslab.gitmachete.frontend.ui.impl.table;
 
 import javax.swing.ListSelectionModel;
+import javax.swing.table.TableCellRenderer;
 
 import com.intellij.ui.ScrollingUtil;
 import com.intellij.util.ui.JBUI;
@@ -13,18 +14,20 @@ import com.virtuslab.gitmachete.backend.api.NullGitMacheteRepositorySnapshot;
 import com.virtuslab.gitmachete.frontend.graph.api.repository.IRepositoryGraphCache;
 import com.virtuslab.gitmachete.frontend.ui.api.table.BaseGraphTable;
 import com.virtuslab.gitmachete.frontend.ui.impl.cell.BranchOrCommitCell;
-import com.virtuslab.gitmachete.frontend.ui.impl.cell.BranchOrCommitCellRendererComponent;
+import com.virtuslab.gitmachete.frontend.ui.impl.cell.BranchOrCommitCellRenderer;
 
 public final class SimpleGraphTable extends BaseGraphTable implements IGitMacheteRepositorySnapshotProvider {
   @Getter
   private final IGitMacheteRepositorySnapshot gitMacheteRepositorySnapshot = NullGitMacheteRepositorySnapshot.getInstance();
 
+  private final TableCellRenderer tableCellRenderer;
+
   @UIEffect
   public static SimpleGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot,
-      boolean isListingCommitsEnabled) {
+      boolean isListingCommitsEnabled, boolean hasBranchActionHints) {
     // We can keep the data - graph table model,
     // but wee need to reinstantiate the UI - demo graph table.
-    return new SimpleGraphTable(deriveGraphTableModel(macheteRepositorySnapshot, isListingCommitsEnabled));
+    return new SimpleGraphTable(deriveGraphTableModel(macheteRepositorySnapshot, isListingCommitsEnabled), hasBranchActionHints);
   }
 
   @UIEffect
@@ -36,8 +39,10 @@ public final class SimpleGraphTable extends BaseGraphTable implements IGitMachet
   }
 
   @UIEffect
-  private SimpleGraphTable(GraphTableModel graphTableModel) {
+  private SimpleGraphTable(GraphTableModel graphTableModel, boolean hasBranchActionHints) {
     super(graphTableModel);
+
+    this.tableCellRenderer = new BranchOrCommitCellRenderer(hasBranchActionHints);
 
     createDefaultColumnsFromModel();
 
@@ -49,7 +54,7 @@ public final class SimpleGraphTable extends BaseGraphTable implements IGitMachet
     setRowSelectionAllowed(true);
     setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
-    setDefaultRenderer(BranchOrCommitCell.class, BranchOrCommitCellRendererComponent::new);
+    setDefaultRenderer(BranchOrCommitCell.class, tableCellRenderer);
 
     setShowVerticalLines(false);
     setShowHorizontalLines(false);

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTable.java
@@ -1,7 +1,6 @@
 package com.virtuslab.gitmachete.frontend.ui.impl.table;
 
 import javax.swing.ListSelectionModel;
-import javax.swing.table.TableCellRenderer;
 
 import com.intellij.ui.ScrollingUtil;
 import com.intellij.util.ui.JBUI;
@@ -20,14 +19,12 @@ public final class SimpleGraphTable extends BaseGraphTable implements IGitMachet
   @Getter
   private final IGitMacheteRepositorySnapshot gitMacheteRepositorySnapshot = NullGitMacheteRepositorySnapshot.getInstance();
 
-  private final TableCellRenderer tableCellRenderer;
-
   @UIEffect
   public static SimpleGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot,
-      boolean isListingCommitsEnabled, boolean hasBranchActionHints) {
+      boolean isListingCommitsEnabled, boolean hasBranchActionToolTips) {
     // We can keep the data - graph table model,
     // but wee need to reinstantiate the UI - demo graph table.
-    return new SimpleGraphTable(deriveGraphTableModel(macheteRepositorySnapshot, isListingCommitsEnabled), hasBranchActionHints);
+    return new SimpleGraphTable(deriveGraphTableModel(macheteRepositorySnapshot, isListingCommitsEnabled), hasBranchActionToolTips);
   }
 
   @UIEffect
@@ -39,10 +36,8 @@ public final class SimpleGraphTable extends BaseGraphTable implements IGitMachet
   }
 
   @UIEffect
-  private SimpleGraphTable(GraphTableModel graphTableModel, boolean hasBranchActionHints) {
+  private SimpleGraphTable(GraphTableModel graphTableModel, boolean hasBranchActionToolTips) {
     super(graphTableModel);
-
-    this.tableCellRenderer = new BranchOrCommitCellRenderer(hasBranchActionHints);
 
     createDefaultColumnsFromModel();
 
@@ -54,7 +49,7 @@ public final class SimpleGraphTable extends BaseGraphTable implements IGitMachet
     setRowSelectionAllowed(true);
     setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
-    setDefaultRenderer(BranchOrCommitCell.class, tableCellRenderer);
+    setDefaultRenderer(BranchOrCommitCell.class, new BranchOrCommitCellRenderer(hasBranchActionToolTips));
 
     setShowVerticalLines(false);
     setShowHorizontalLines(false);

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTableProvider.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTableProvider.java
@@ -10,15 +10,15 @@ public class SimpleGraphTableProvider implements ISimpleGraphTableProvider {
   @Override
   @UIEffect
   public BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot,
-      boolean isListingCommitsEnabled, boolean hasBranchActionHints) {
+     boolean isListingCommitsEnabled, boolean hasBranchActionToolTips) {
     // The reinstantiation is needed every time because without it
     // the table keeps the first IDE theme despite the theme changes.
-    return SimpleGraphTable.deriveInstance(macheteRepositorySnapshot, isListingCommitsEnabled, hasBranchActionHints);
+    return SimpleGraphTable.deriveInstance(macheteRepositorySnapshot, isListingCommitsEnabled, hasBranchActionToolTips);
   }
 
   @Override
   @UIEffect
   public BaseGraphTable deriveDemoInstance() {
-    return deriveInstance(new DemoGitMacheteRepositorySnapshot(), /* isListingCommitsEnabled */ true, /* hasBranchActionHints */ false);
+    return deriveInstance(new DemoGitMacheteRepositorySnapshot(), /* isListingCommitsEnabled */ true, /* hasBranchActionToolTips */ false);
   }
 }

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTableProvider.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTableProvider.java
@@ -10,7 +10,7 @@ public class SimpleGraphTableProvider implements ISimpleGraphTableProvider {
   @Override
   @UIEffect
   public BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot,
-     boolean isListingCommitsEnabled, boolean hasBranchActionToolTips) {
+      boolean isListingCommitsEnabled, boolean hasBranchActionToolTips) {
     // The reinstantiation is needed every time because without it
     // the table keeps the first IDE theme despite the theme changes.
     return SimpleGraphTable.deriveInstance(macheteRepositorySnapshot, isListingCommitsEnabled, hasBranchActionToolTips);
@@ -19,6 +19,7 @@ public class SimpleGraphTableProvider implements ISimpleGraphTableProvider {
   @Override
   @UIEffect
   public BaseGraphTable deriveDemoInstance() {
-    return deriveInstance(new DemoGitMacheteRepositorySnapshot(), /* isListingCommitsEnabled */ true, /* hasBranchActionToolTips */ false);
+    return deriveInstance(new DemoGitMacheteRepositorySnapshot(), /* isListingCommitsEnabled */ true,
+        /* hasBranchActionToolTips */ false);
   }
 }

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTableProvider.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTableProvider.java
@@ -10,15 +10,15 @@ public class SimpleGraphTableProvider implements ISimpleGraphTableProvider {
   @Override
   @UIEffect
   public BaseGraphTable deriveInstance(IGitMacheteRepositorySnapshot macheteRepositorySnapshot,
-      boolean isListingCommitsEnabled) {
+      boolean isListingCommitsEnabled, boolean hasBranchActionHints) {
     // The reinstantiation is needed every time because without it
     // the table keeps the first IDE theme despite the theme changes.
-    return SimpleGraphTable.deriveInstance(macheteRepositorySnapshot, isListingCommitsEnabled);
+    return SimpleGraphTable.deriveInstance(macheteRepositorySnapshot, isListingCommitsEnabled, hasBranchActionHints);
   }
 
   @Override
   @UIEffect
   public BaseGraphTable deriveDemoInstance() {
-    return deriveInstance(new DemoGitMacheteRepositorySnapshot(), /* isListingCommitsEnabled */ true);
+    return deriveInstance(new DemoGitMacheteRepositorySnapshot(), /* isListingCommitsEnabled */ true, /* hasBranchActionHints */ false);
   }
 }


### PR DESCRIPTION
Now `BranchOrCommitCellRenderer` is something like `proxy` for `BranchOrCommitCellRendererComponent` to enable pass additional argument to it.