### PR TITLE
In discover, pick `develop` as a fixed root if `master` isn't present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,12 @@ jobs:
           name: Compile tests
           command: ./gradlew compileTestJava
       - run:
+          name: '[TEMP] Upgrade git-machete CLI'
+          command: |
+            apt-get update
+            apt-get install --no-install-recommends -y python3-pip
+            pip3 install --upgrade git-machete==2.15.5
+      - run:
           name: Run backend tests
           command: ./gradlew test
       # Unfortunately, wildcards for test result paths aren't supported by CircleCI yet.

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/IntegrationTestUtils.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/IntegrationTestUtils.java
@@ -28,7 +28,7 @@ class IntegrationTestUtils {
         .stripTrailing()
         .replace("git-machete version ", "");
     if (!referenceCliVersions.contains(version)) {
-      Assert.fail("git-machete is expected in version ${referenceCliVersions}, found ${version}");
+      Assert.fail("git-machete is expected in one of versions ${referenceCliVersions}, found ${version}");
     }
   }
 }

--- a/backendImpl/src/test/resources/reference-cli-version.properties
+++ b/backendImpl/src/test/resources/reference-cli-version.properties
@@ -1,1 +1,1 @@
-referenceCliVersions=2.15.3,2.15.4
+referenceCliVersions=2.15.5


### PR DESCRIPTION
For tests to pass, CLI v2.15.5 (with the same changes applied) must be released