### PR TITLE
Print output from process in BaseGitRepositoryBackedIntegrationTestSuite#prepareRepoFromScript if not completed within 5 seconds

### DIFF
--- a/testCommon/src/test/java/com/virtuslab/gitmachete/testcommon/BaseGitRepositoryBackedIntegrationTestSuite.java
+++ b/testCommon/src/test/java/com/virtuslab/gitmachete/testcommon/BaseGitRepositoryBackedIntegrationTestSuite.java
@@ -50,8 +50,7 @@ public abstract class BaseGitRepositoryBackedIntegrationTestSuite {
         .start();
     var completed = process.waitFor(5, TimeUnit.SECONDS);
 
-    // In case of non 0 exit code print stdout and stderr
-    if (process.exitValue() != 0) {
+    if (!completed || process.exitValue() != 0) {
       System.out.println(new String(process.getInputStream().readAllBytes()));
       System.err.println(new String(process.getErrorStream().readAllBytes()));
     }


### PR DESCRIPTION
So that we can debug spurious failures like the one in https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin/3747/workflows/2ab02001-1f68-4805-ada7-43a70f4d542e/jobs/3928