### PR TITLE
[frontend][graph-table] Prettify a graph table due to highlighting in IntelliJ 2020.3

### DIFF
--- a/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/BaseGraphTable.java
+++ b/frontendUiApi/src/main/java/com/virtuslab/gitmachete/frontend/ui/api/table/BaseGraphTable.java
@@ -11,6 +11,7 @@ import io.vavr.collection.List;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 public abstract class BaseGraphTable extends JBTable {
+  private static int GRAPH_COLUMN_RIGHT_PADDING = 25;
   @UIEffect
   private List<Integer> rowWidths = List.empty();
 
@@ -43,7 +44,7 @@ public abstract class BaseGraphTable extends JBTable {
     rowWidths = rowWidths.update(row, rendererWidth);
 
     TableColumn tableColumn = getColumnModel().getColumn(column);
-    tableColumn.setPreferredWidth(rowWidths.max().getOrElse(0));
+    tableColumn.setPreferredWidth(rowWidths.max().map(maxWidth -> maxWidth + GRAPH_COLUMN_RIGHT_PADDING).getOrElse(0));
     return component;
   }
 

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -40,7 +40,6 @@ import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.ui.GuiUtils;
 import com.intellij.ui.PopupMenuListenerAdapter;
 import com.intellij.ui.ScrollingUtil;
-import com.intellij.ui.table.JBTable;
 import com.intellij.util.messages.Topic;
 import com.intellij.util.ui.JBUI;
 import git4idea.repo.GitRepository;
@@ -384,11 +383,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
       new Timer().schedule(new TimerTask() {
         @Override
         public void run() {
-          GuiUtils.invokeLaterIfNeeded(() -> {
-            // So that the selection spans over the full width of the row (for better feeling)
-            graphTable.setAutoResizeMode(JBTable.AUTO_RESIZE_ALL_COLUMNS);
-            graphTable.setRowSelectionAllowed(true);
-          }, NON_MODAL);
+          GuiUtils.invokeLaterIfNeeded(() -> graphTable.setRowSelectionAllowed(true), NON_MODAL);
         }
       }, /* delay */ 35);
     }
@@ -397,8 +392,6 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     @UIEffect
     public void popupMenuWillBecomeInvisible(PopupMenuEvent popupMenuEvent) {
       graphTable.setRowSelectionAllowed(false);
-      // So that the selection (and thus the area where tooltip is shown) has again the smallest possible size
-      graphTable.setAutoResizeMode(JBTable.AUTO_RESIZE_OFF);
     }
   }
 }


### PR DESCRIPTION
Add right padding for graph table row width and disable row full space filling when right click (for consistency)

`2020.3`:
![2020 3](https://user-images.githubusercontent.com/56402877/101372567-55350300-38ac-11eb-85f4-4d0b913a1787.gif)

`2020.2`:
![2020 2](https://user-images.githubusercontent.com/56402877/101372608-5fef9800-38ac-11eb-9021-6bce1ca9c942.gif)
