### PR TITLE
Fix inconsistencies to CLI in discovery algorithm + treat `develop` as root even if `master` present

### DIFF
--- a/backendImpl/src/test/resources/reference-cli-version.properties
+++ b/backendImpl/src/test/resources/reference-cli-version.properties
@@ -1,1 +1,1 @@
-referenceCliVersions=2.15.5,2.15.6,2.15.7
+referenceCliVersions=2.15.9


### PR DESCRIPTION
Wrt. "treat both `master` and `develop` as roots by default" part: applied the same changes in the CLI as 2.15.9