### PR TITLE
Prevent spurious CI timeouts on closing the project in UI tests

### DIFF
--- a/scripts/run-ui-tests
+++ b/scripts/run-ui-tests
@@ -5,14 +5,14 @@
 
 # <intellij-version-key> can be a release (e.g. `2020.2`), build (e.g. `203.5419.21-EAP-SNAPSHOT`)
 # or a field of `ext.intellijVersions` from build.gradle (e.g. `earliestSupportedMajor`).
-# If skipped, then `buildTarget` is assumed.
+# If skipped or empty, then `buildTarget` is assumed.
 
 # If <only-tests> is present and non-empty, only the UI test methods
 # whose names start with the given prefix will be executed (instead of all UI test methods).
 
 set -e -o pipefail -u
 
-intellij_version_key=${1-buildTarget}
+intellij_version_key=${1:-buildTarget}
 test_method_prefix=${2-}
 
 if [[ ${CI-} == true ]]; then

--- a/uiTests/src/test/resources/ide.rhino.js
+++ b/uiTests/src/test/resources/ide.rhino.js
@@ -42,7 +42,16 @@ function Ide() {
   this.soleOpenedProject = function () {
     const openProjects = ProjectUtil.getOpenProjects();
     return openProjects.length === 1 ? new Project(openProjects[0]) : null;
-  }
+  };
+
+  this.closeOpenedProjects = function () {
+    ProjectUtil.getOpenProjects().forEach(function (project) {
+      GuiUtils.runOrInvokeAndWait(function () {
+        System.out.println('project to close = ' + project.toString());
+        ProjectUtil.closeAndDispose(project);
+      });
+    });
+  };
 }
 
 const ide = new Ide();

--- a/uiTests/src/test/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/uiTests/src/test/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -60,7 +60,9 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
   @After
   def afterEach(): Unit = {
     intelliJ.probe.awaitIdle()
-    intelliJ.probe.listOpenProjects.foreach(intelliJ.probe.closeProject)
+    // Note that we shouldn't wait for a response here (so we shouldn't call org.virtuslab.ideprobe.ProbeDriver#send),
+    // since the response sometimes never comes (due to the project being closed), depending on the specific timing.
+    intelliJ.machete.runJs("ide.closeOpenedProjects()")
   }
 
   @Test def skipNonExistentBranches_toggleListingCommits_slideOutRoot(): Unit = {


### PR DESCRIPTION
For instance, see https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin/3793/workflows/2b3434c2-9258-4305-9d60-b3bad59a342f/jobs/3979:

![image](https://user-images.githubusercontent.com/3383210/103176959-5091b800-4876-11eb-8b73-f3c1986deb37.png)
