### PR TITLE
Fix NPE in GitCoreRepository#deriveMergeBase

### DIFF
--- a/config/checker/org.eclipse.jgit.astub
+++ b/config/checker/org.eclipse.jgit.astub
@@ -1,5 +1,6 @@
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.aliasing.qual.NonLeaked;
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.checkerframework.common.value.qual.ArrayLen;
@@ -25,7 +26,7 @@ class RevWalk {
   // This comment applies everywhere in the codebase.
   // Note that both points are kind-of enforced by Checkstyle (every occurrence of "RevCommit" must be preceded with Checker's @Unique annotation),
   // but this is not perfect - for instance, it doesn't catch RevCommits declared as `var`s.
-  @Unique RevCommit next();
+  @Nullable @Unique RevCommit next();
 
   @NonNull @Unique RevCommit parseCommit(org.eclipse.jgit.lib.AnyObjectId id);
 }

--- a/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
@@ -29,6 +29,7 @@ action.GitMachete.GitCommandUpdatingCurrentBranchBackgroundable.notification.tit
 
 # Quasi-title capitalization intended since we always write "Git Machete" with initial caps.
 action.GitMachete.GitMacheteRepositoryUpdateBackgroundable.task-title=Updating Git Machete status
+action.GitMachete.GitMacheteRepositoryUpdateBackgroundable.notification.title.failed=Cannot display Git Machete branch layout
 
 action.GitMachete.MergeCurrentBranchFastForwardOnlyBackgroundable.operation-name=Fast-forward merge
 

--- a/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
@@ -29,7 +29,7 @@ action.GitMachete.GitCommandUpdatingCurrentBranchBackgroundable.notification.tit
 
 # Quasi-title capitalization intended since we always write "Git Machete" with initial caps.
 action.GitMachete.GitMacheteRepositoryUpdateBackgroundable.task-title=Updating Git Machete status
-action.GitMachete.GitMacheteRepositoryUpdateBackgroundable.notification.title.failed=Cannot display Git Machete branch layout
+action.GitMachete.GitMacheteRepositoryUpdateBackgroundable.notification.title.failed=Cannot create Git Machete branch layout
 
 action.GitMachete.MergeCurrentBranchFastForwardOnlyBackgroundable.operation-name=Fast-forward merge
 

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteRepositoryUpdateBackgroundable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteRepositoryUpdateBackgroundable.java
@@ -113,7 +113,8 @@ public final class GitMacheteRepositoryUpdateBackgroundable extends Task.Backgro
     }
     String exceptionMessage = cause.getMessage();
 
-    VcsNotifier.getInstance(getProject()).notifyError("Repository instantiation failed",
+    VcsNotifier.getInstance(getProject()).notifyError(
+        getString("action.GitMachete.GitMacheteRepositoryUpdateBackgroundable.notification.title.failed"),
         exceptionMessage != null ? exceptionMessage : "");
   }
 

--- a/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
+++ b/gitCoreJGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
@@ -334,7 +334,7 @@ public final class GitCoreRepository implements IGitCoreRepository {
       // it's basically impossible to get these numbers correctly in a unambiguous manner.
       @Unique RevCommit mergeBase = walk.next();
       LOG.debug(() -> "Detected merge base for ${c1.getHash().getHashString()} " +
-          "and ${c2.getHash().getHashString()} is ${mergeBase.getId().getName()}");
+          "and ${c2.getHash().getHashString()} is " + (mergeBase != null ? mergeBase.getId().getName() : "<none>"));
       if (mergeBase != null) {
         return Option.some(GitCoreCommitHash.of(mergeBase.getId()));
       } else {


### PR DESCRIPTION
Happened due to https://github.com/typetools/checker-framework/issues/4079. Not very harmful since it only happens when `DEBUG` log is turned on AND merge base can't be figured out for some two commits in the repo.