### PR TITLE
Do not show double-listed branches in graph table (closes #341)

### DIFF
--- a/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
+++ b/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
@@ -1,6 +1,7 @@
 package com.virtuslab.gitmachete.backend.api;
 
 import io.vavr.collection.List;
+import io.vavr.collection.Set;
 import io.vavr.control.Option;
 
 import com.virtuslab.branchlayout.api.IBranchLayout;
@@ -21,9 +22,9 @@ public interface IGitMacheteRepositorySnapshot {
 
   Option<IManagedBranchSnapshot> getManagedBranchByName(String branchName);
 
-  List<String> getDuplicatedBranchNames();
+  Set<String> getDuplicatedBranchNames();
 
-  List<String> getSkippedBranchNames();
+  Set<String> getSkippedBranchNames();
 
   Option<IExecutionResult> executeMachetePreRebaseHookIfPresent(IGitRebaseParameters gitRebaseParameters)
       throws GitMacheteException;

--- a/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
+++ b/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
@@ -21,6 +21,8 @@ public interface IGitMacheteRepositorySnapshot {
 
   Option<IManagedBranchSnapshot> getManagedBranchByName(String branchName);
 
+  List<String> getDuplicatedBranchNames();
+
   List<String> getSkippedBranchNames();
 
   Option<IExecutionResult> executeMachetePreRebaseHookIfPresent(IGitRebaseParameters gitRebaseParameters)

--- a/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/NullGitMacheteRepositorySnapshot.java
+++ b/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/NullGitMacheteRepositorySnapshot.java
@@ -1,6 +1,8 @@
 package com.virtuslab.gitmachete.backend.api;
 
 import io.vavr.collection.List;
+import io.vavr.collection.Set;
+import io.vavr.collection.TreeSet;
 import io.vavr.control.Option;
 
 import com.virtuslab.branchlayout.api.IBranchLayout;
@@ -41,13 +43,13 @@ public final class NullGitMacheteRepositorySnapshot implements IGitMacheteReposi
   }
 
   @Override
-  public List<String> getDuplicatedBranchNames() {
-    return List.empty();
+  public Set<String> getDuplicatedBranchNames() {
+    return TreeSet.empty();
   }
 
   @Override
-  public List<String> getSkippedBranchNames() {
-    return List.empty();
+  public Set<String> getSkippedBranchNames() {
+    return TreeSet.empty();
   }
 
   @Override

--- a/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/NullGitMacheteRepositorySnapshot.java
+++ b/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/NullGitMacheteRepositorySnapshot.java
@@ -41,6 +41,11 @@ public final class NullGitMacheteRepositorySnapshot implements IGitMacheteReposi
   }
 
   @Override
+  public List<String> getDuplicatedBranchNames() {
+    return List.empty();
+  }
+
+  @Override
   public List<String> getSkippedBranchNames() {
     return List.empty();
   }

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitmachete.backend.impl;
 
 import io.vavr.collection.List;
 import io.vavr.collection.Map;
+import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -30,10 +31,10 @@ public class GitMacheteRepositorySnapshot implements IGitMacheteRepositorySnapsh
   private final Map<String, IManagedBranchSnapshot> managedBranchByName;
 
   @Getter
-  private final List<String> duplicatedBranchNames;
+  private final Set<String> duplicatedBranchNames;
 
   @Getter
-  private final List<String> skippedBranchNames;
+  private final Set<String> skippedBranchNames;
 
   private final PreRebaseHookExecutor preRebaseHookExecutor;
 

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
@@ -30,6 +30,9 @@ public class GitMacheteRepositorySnapshot implements IGitMacheteRepositorySnapsh
   private final Map<String, IManagedBranchSnapshot> managedBranchByName;
 
   @Getter
+  private final List<String> duplicatedBranchNames;
+
+  @Getter
   private final List<String> skippedBranchNames;
 
   private final PreRebaseHookExecutor preRebaseHookExecutor;

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTestSuite.java
@@ -1,13 +1,16 @@
 package com.virtuslab.gitmachete.backend.unit;
 
+import java.nio.file.Paths;
 import java.util.Arrays;
 
 import io.vavr.collection.List;
+import io.vavr.control.Option;
 import lombok.SneakyThrows;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.reflect.Whitebox;
 
 import com.virtuslab.gitcore.api.IGitCoreBranchSnapshot;
+import com.virtuslab.gitcore.api.IGitCoreHeadSnapshot;
 import com.virtuslab.gitcore.api.IGitCoreRepository;
 import com.virtuslab.gitmachete.backend.impl.GitMacheteRepository;
 import com.virtuslab.gitmachete.backend.impl.hooks.PreRebaseHookExecutor;
@@ -28,8 +31,15 @@ public class BaseGitMacheteRepositoryUnitTestSuite {
   protected Object aux(IGitCoreBranchSnapshot... localCoreBranches) {
     PowerMockito.doReturn(List.ofAll(Arrays.stream(localCoreBranches))).when(gitCoreRepository).deriveAllLocalBranches();
 
+    var iGitCoreHeadSnapshot = PowerMockito.mock(IGitCoreHeadSnapshot.class);
+    PowerMockito.doReturn(Option.none()).when(iGitCoreHeadSnapshot).getTargetBranch();
+    PowerMockito.doReturn(iGitCoreHeadSnapshot).when(gitCoreRepository).deriveHead();
+
+    // cannot be mocked as it is final
+    var statusBranchHookExecutor = new StatusBranchHookExecutor(Paths.get("void"), Paths.get("void"));
+
     return Whitebox
         .getConstructor(AUX_CLASS, IGitCoreRepository.class, StatusBranchHookExecutor.class, PreRebaseHookExecutor.class)
-        .newInstance(gitCoreRepository, /* statusBranchHookExecutor */ null, /* preRebaseHookExecutor */ null);
+        .newInstance(gitCoreRepository, statusBranchHookExecutor, /* preRebaseHookExecutor */ null);
   }
 }

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUnitTestSuite.java
@@ -1,0 +1,131 @@
+package com.virtuslab.gitmachete.backend.unit;
+
+import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.createGitCoreCommit;
+import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.createGitCoreLocalBranch;
+
+import io.vavr.collection.List;
+import io.vavr.control.Option;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import org.junit.Assert;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.reflect.Whitebox;
+
+import com.virtuslab.branchlayout.api.IBranchLayout;
+import com.virtuslab.branchlayout.api.IBranchLayoutEntry;
+import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
+import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
+import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot;
+
+public class GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUnitTestSuite
+    extends
+      BaseGitMacheteRepositoryUnitTestSuite {
+
+  @SneakyThrows
+  private IGitMacheteRepositorySnapshot invokeCreateSnapshot(
+      IBranchLayout branchLayout, IGitCoreLocalBranchSnapshot... localBranchSnapshots) {
+    PowerMockito.doReturn(List.empty()).when(gitCoreRepository).deriveAllRemoteNames();
+    return Whitebox.invokeMethod(aux(localBranchSnapshots), "createSnapshot", branchLayout);
+  }
+
+  @Test
+  public void singleBranch() {
+    // given
+    var branchAndEntry = createBranchAndEntry("main", List.empty());
+    var branchLayout = PowerMockito.mock(IBranchLayout.class);
+    PowerMockito.doReturn(List.of(branchAndEntry.entry)).when(branchLayout).getRootEntries();
+
+    // when
+    var repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
+
+    // then
+    Assert.assertEquals(List.of(branchAndEntry.entry).map(IBranchLayoutEntry::getName),
+        repositorySnapshot.getManagedBranches().map(IManagedBranchSnapshot::getName));
+    Assert.assertTrue(repositorySnapshot.getDuplicatedBranchNames().isEmpty());
+    Assert.assertTrue(repositorySnapshot.getSkippedBranchNames().isEmpty());
+  }
+
+  @Test
+  public void duplicatedBranch() {
+    // given
+    var mainBranchName = "main";
+    var duplicatedEntry = createEntry(mainBranchName, List.empty());
+    var branchAndEntry = createBranchAndEntry(mainBranchName, List.of(duplicatedEntry));
+    var branchLayout = PowerMockito.mock(IBranchLayout.class);
+    PowerMockito.doReturn(List.of(branchAndEntry.entry)).when(branchLayout).getRootEntries();
+
+    // when
+    var repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
+
+    // then
+    Assert.assertEquals(
+        List.of(branchAndEntry.entry).map(IBranchLayoutEntry::getName),
+        repositorySnapshot.getManagedBranches().map(IManagedBranchSnapshot::getName));
+    Assert.assertEquals(List.of(mainBranchName).toSet(), repositorySnapshot.getDuplicatedBranchNames());
+    Assert.assertTrue(repositorySnapshot.getSkippedBranchNames().isEmpty());
+  }
+
+  @Test
+  public void skippedBranch() {
+    // given
+    var skippedBranchName = "skipped";
+    var skippedEntry = createEntry(skippedBranchName, List.empty());
+    var branchAndEntry = createBranchAndEntry("main", List.of(skippedEntry));
+    var branchLayout = PowerMockito.mock(IBranchLayout.class);
+    PowerMockito.doReturn(List.of(branchAndEntry.entry)).when(branchLayout).getRootEntries();
+
+    // when
+    var repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
+
+    // then
+    Assert.assertEquals(
+        List.of(branchAndEntry.entry).map(IBranchLayoutEntry::getName),
+        repositorySnapshot.getManagedBranches().map(IManagedBranchSnapshot::getName));
+    Assert.assertTrue(repositorySnapshot.getDuplicatedBranchNames().isEmpty());
+    Assert.assertEquals(List.of(skippedBranchName).toSet(), repositorySnapshot.getSkippedBranchNames());
+  }
+
+  @Test
+  public void sameBranchDuplicatedAndSkipped() {
+    // given
+    var duplicatedAndSkippedBranchName = "duplicatedAndSkipped";
+    var duplicatedAndSkippedBranchName2 = createEntry(duplicatedAndSkippedBranchName, List.empty());
+    var duplicatedAndSkippedBranchName1 = createEntry(duplicatedAndSkippedBranchName, List.of(duplicatedAndSkippedBranchName2));
+    var branchAndEntry = createBranchAndEntry("main", List.of(duplicatedAndSkippedBranchName1));
+    var branchLayout = PowerMockito.mock(IBranchLayout.class);
+    PowerMockito.doReturn(List.of(branchAndEntry.entry)).when(branchLayout).getRootEntries();
+
+    // when
+    var repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
+
+    // then
+    Assert.assertEquals(
+        List.of(branchAndEntry.entry).map(IBranchLayoutEntry::getName),
+        repositorySnapshot.getManagedBranches().map(IManagedBranchSnapshot::getName));
+    Assert.assertTrue(repositorySnapshot.getDuplicatedBranchNames().isEmpty());
+    Assert.assertEquals(List.of(duplicatedAndSkippedBranchName).toSet(), repositorySnapshot.getSkippedBranchNames());
+  }
+
+  private BranchAndEntry createBranchAndEntry(String name, List<IBranchLayoutEntry> childEntries) {
+    var entry = createEntry(name, childEntries);
+    var commit = createGitCoreCommit();
+    var branch = createGitCoreLocalBranch(commit);
+    PowerMockito.doReturn(name).when(branch).getName();
+    return new BranchAndEntry(branch, entry);
+  }
+
+  private IBranchLayoutEntry createEntry(String name, List<IBranchLayoutEntry> childEntries) {
+    var entry = PowerMockito.mock(IBranchLayoutEntry.class);
+    PowerMockito.doReturn(name).when(entry).getName();
+    PowerMockito.doReturn(Option.none()).when(entry).getCustomAnnotation();
+    PowerMockito.doReturn(childEntries).when(entry).getChildren();
+    return entry;
+  }
+}
+
+@AllArgsConstructor
+class BranchAndEntry {
+  IGitCoreLocalBranchSnapshot branch;
+  IBranchLayoutEntry entry;
+}

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
@@ -37,7 +37,14 @@ public class BranchLayout implements IBranchLayout {
     if (entryToSlideOut == null) {
       throw new EntryDoesNotExistException("Branch entry '${branchName}' does not exist");
     }
-    return new BranchLayout(rootEntries.flatMap(rootEntry -> slideOut(rootEntry, entryToSlideOut)));
+
+    var newBranchLayout = new BranchLayout(rootEntries.flatMap(rootEntry -> slideOut(rootEntry, entryToSlideOut)));
+    try {
+      // TODO (#695): disable slide out for duplicated branches
+      return newBranchLayout.slideOut(branchName);
+    } catch (EntryDoesNotExistException e) {
+      return newBranchLayout;
+    }
   }
 
   private List<IBranchLayoutEntry> slideOut(

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
@@ -5,7 +5,6 @@ import io.vavr.collection.List;
 import io.vavr.collection.Map;
 import io.vavr.control.Option;
 import lombok.Getter;
-import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 
 @UsesObjectEquals
@@ -37,9 +36,7 @@ public class BranchLayout implements IBranchLayout {
     return new BranchLayout(rootEntries.flatMap(rootEntry -> slideOut(rootEntry, branchName)));
   }
 
-  private List<IBranchLayoutEntry> slideOut(
-      @FindDistinct IBranchLayoutEntry entry,
-      @FindDistinct String entryNameToSlideOut) {
+  private List<IBranchLayoutEntry> slideOut(IBranchLayoutEntry entry, String entryNameToSlideOut) {
     var children = entry.getChildren();
     if (entry.getName().equals(entryNameToSlideOut)) {
       return children;

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
@@ -32,29 +32,19 @@ public class BranchLayout implements IBranchLayout {
   }
 
   @Override
-  public IBranchLayout slideOut(String branchName) throws EntryDoesNotExistException {
-    var entryToSlideOut = findEntryByName(branchName).getOrNull();
-    if (entryToSlideOut == null) {
-      throw new EntryDoesNotExistException("Branch entry '${branchName}' does not exist");
-    }
-
-    var newBranchLayout = new BranchLayout(rootEntries.flatMap(rootEntry -> slideOut(rootEntry, entryToSlideOut)));
-    try {
-      // TODO (#695): disable slide out for duplicated branches
-      return newBranchLayout.slideOut(branchName);
-    } catch (EntryDoesNotExistException e) {
-      return newBranchLayout;
-    }
+  public IBranchLayout slideOut(String branchName) {
+    // TODO (#695): disable slide out for duplicated branches
+    return new BranchLayout(rootEntries.flatMap(rootEntry -> slideOut(rootEntry, branchName)));
   }
 
   private List<IBranchLayoutEntry> slideOut(
       @FindDistinct IBranchLayoutEntry entry,
-      @FindDistinct IBranchLayoutEntry entryToSlideOut) {
+      @FindDistinct String entryNameToSlideOut) {
     var children = entry.getChildren();
-    if (entry == entryToSlideOut) {
+    if (entry.getName().equals(entryNameToSlideOut)) {
       return children;
     } else {
-      return List.of(entry.withChildren(children.flatMap(child -> slideOut(child, entryToSlideOut))));
+      return List.of(entry.withChildren(children.flatMap(child -> slideOut(child, entryNameToSlideOut))));
     }
   }
 

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/IBranchLayout.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/IBranchLayout.java
@@ -11,5 +11,5 @@ public interface IBranchLayout {
   IBranchLayout slideIn(String parentBranchName, IBranchLayoutEntry entryToSlideIn)
       throws EntryDoesNotExistException, EntryIsDescendantOfException;
 
-  IBranchLayout slideOut(String branchName) throws EntryDoesNotExistException;
+  IBranchLayout slideOut(String branchName);
 }

--- a/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutTestSuite.java
+++ b/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutTestSuite.java
@@ -3,18 +3,18 @@ package com.virtuslab.branchlayout.unit;
 import static org.junit.Assert.assertEquals;
 
 import io.vavr.collection.List;
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.virtuslab.branchlayout.api.BranchLayout;
 import com.virtuslab.branchlayout.api.BranchLayoutEntry;
-import com.virtuslab.branchlayout.api.BranchLayoutException;
 import com.virtuslab.branchlayout.api.IBranchLayout;
 import com.virtuslab.branchlayout.api.IBranchLayoutEntry;
 
 public class BranchLayoutTestSuite {
 
   @Test
-  public void withBranchSlideOut_givenNonRootExistingBranch_slidesOut() throws BranchLayoutException {
+  public void withBranchSlideOut_givenNonRootExistingBranch_slidesOut() {
     // given
     String rootName = "root";
     String branchToSlideOutName = "parent";
@@ -49,7 +49,36 @@ public class BranchLayoutTestSuite {
   }
 
   @Test
-  public void withBranchSlideOut_givenRootBranchWithChildren_throwsException() throws BranchLayoutException {
+  public void withBranchSlideOut_givenDuplicatedBranch_slidesOut() {
+    // given
+    String rootName = "root";
+    String branchToSlideOutName = "child";
+
+    /*-
+        root                           root
+            child       slide out
+            child        ----->
+    */
+
+    List<IBranchLayoutEntry> childBranches = List.of(
+        new BranchLayoutEntry(branchToSlideOutName, /* customAnnotation */ null, List.empty()),
+        new BranchLayoutEntry(branchToSlideOutName, /* customAnnotation */ null, List.empty()));
+
+    var rootEntry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, childBranches);
+    var branchLayoutFile = new BranchLayout(List.of(rootEntry));
+
+    // when
+    IBranchLayout result = branchLayoutFile.slideOut(branchToSlideOutName);
+
+    // then
+    assertEquals(result.getRootEntries().size(), 1);
+    assertEquals(result.getRootEntries().get(0).getName(), rootName);
+    var children = result.getRootEntries().get(0).getChildren();
+    assertEquals(children.size(), 0);
+  }
+
+  @Test
+  public void withBranchSlideOut_givenRootBranchWithChildren_throwsException() {
     // given
     String rootName = "root";
     String childName0 = "child0";
@@ -78,7 +107,7 @@ public class BranchLayoutTestSuite {
   }
 
   @Test
-  public void withBranchSlideOut_givenSingleRootBranch_throwsException() throws BranchLayoutException {
+  public void withBranchSlideOut_givenSingleRootBranch_throwsException() {
     // given
     var rootName = "root";
     IBranchLayoutEntry entry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, List.empty());
@@ -92,7 +121,7 @@ public class BranchLayoutTestSuite {
   }
 
   @Test
-  public void withBranchSlideOut_givenTwoRootBranches_throwsException() throws BranchLayoutException {
+  public void withBranchSlideOut_givenTwoRootBranches_throwsException() {
     // given
     var rootName = "root";
     var masterRootName = "master";
@@ -108,8 +137,8 @@ public class BranchLayoutTestSuite {
     assertEquals(result.getRootEntries().get(0).getName(), masterRootName);
   }
 
-  @Test(expected = BranchLayoutException.class)
-  public void withBranchSlideOut_givenNonExistingBranch_throwsException() throws BranchLayoutException {
+  @Test
+  public void withBranchSlideOut_givenNonExistingBranch_noExceptionThrown() {
     // given
     var branchToSlideOutName = "branch";
     var branchLayoutFile = new BranchLayout(List.empty());
@@ -117,6 +146,7 @@ public class BranchLayoutTestSuite {
     // when
     branchLayoutFile.slideOut(branchToSlideOutName);
 
-    // then exception is thrown
+    // then no exception thrown
+    Assert.assertTrue(branchLayoutFile.getRootEntries().isEmpty());
   }
 }

--- a/config/checker/com.intellij.astub
+++ b/config/checker/com.intellij.astub
@@ -304,7 +304,7 @@ interface ToolWindow {
   void activate(@Nullable @UI Runnable runnable);
 
   @SafeEffect
-  ContentManager getContentManagerIfCreated();
+  @Nullable ContentManager getContentManagerIfCreated();
 }
 
 class ToolWindowManager {
@@ -312,7 +312,7 @@ class ToolWindowManager {
   ToolWindowManager getInstance(com.intellij.openapi.project.Project project);
 
   @SafeEffect
-  ToolWindow getToolWindow(String id);
+  @Nullable ToolWindow getToolWindow(String id);
 }
 
 

--- a/config/checker/com.intellij.astub
+++ b/config/checker/com.intellij.astub
@@ -302,6 +302,17 @@ class CommitMessage {
 
 interface ToolWindow {
   void activate(@Nullable @UI Runnable runnable);
+
+  @SafeEffect
+  ContentManager getContentManagerIfCreated();
+}
+
+class ToolWindowManager {
+  @SafeEffect
+  ToolWindowManager getInstance(com.intellij.openapi.project.Project project);
+
+  @SafeEffect
+  ToolWindow getToolWindow(String id);
 }
 
 
@@ -407,6 +418,14 @@ class TextFieldWithAutoCompletionListProvider<T> {
 interface Content {
   @SafeEffect
   String getDisplayName();
+}
+
+interface ContentManager {
+  @SafeEffect
+  Content findContent(String displayName);
+
+  @SafeEffect
+  Content getSelectedContent();
 }
 
 @AlwaysSafe

--- a/docs/features.md
+++ b/docs/features.md
@@ -188,7 +188,7 @@ It can be the commit inferred by Git Machete (the one marked in commits list), o
 
 The `machete` file describes relations between branches in your repository.
 These relations are probably determined by the order of branch creation &mdash;
-which branch has been created from which &mdash; but this is not a strict rule).<br/>
+which branch has been created from which &mdash; but this is not a strict rule.<br/>
 It'll be located under `.git/machete` path in your repository.
 
 This branch layout can be automatically discovered based on the state of your git repository by the `Discover Branch Layout` action.

--- a/docs/slide_in_use_cases.md
+++ b/docs/slide_in_use_cases.md
@@ -14,7 +14,7 @@ It should help to implement and understand the feature.
 
 ## Slide In - Logic
 
-This specification covers all of the cases.
+This specification covers all the cases.
 
 - When the **entry does not exist**, it must be added under the given branch.
 - When the **entry exists under the given parent**, branch layout must not be affected.

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/SlideInBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/SlideInBackgroundable.java
@@ -76,15 +76,7 @@ public class SlideInBackgroundable extends Task.Backgroundable {
         targetBranchLayout = branchLayout;
       } else {
         entryToSlideIn = entryByName.withChildren(List.empty());
-        try {
-          targetBranchLayout = branchLayout.slideOut(slideInOptions.getName());
-        } catch (EntryDoesNotExistException e) {
-          notifyError(
-              format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.entry-does-not-exist"),
-                  entryToSlideIn.getName()),
-              e);
-          return;
-        }
+        targetBranchLayout = branchLayout.slideOut(slideInOptions.getName());
       }
 
     } else {

--- a/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/project/MacheteProjectResolver.java
+++ b/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/project/MacheteProjectResolver.java
@@ -34,10 +34,7 @@ public class MacheteProjectResolver implements ExternalSystemProjectResolver<Mac
 
     var graphTableProvider = Option.of(settings)
         .map(s -> s.getProject().getService(GraphTableProvider.class));
-    var hasSelectedGitMacheteTab = Option.of(settings)
-        .map(s -> s.getProject())
-        .map(this::hasSelectedGitMacheteTab)
-        .getOrElse(Boolean.FALSE);
+    var hasSelectedGitMacheteTab = settings != null && hasSelectedGitMacheteTab(settings.getProject());
 
     if (graphTableProvider.isEmpty()) {
       LOG.warn("Graph table provider is undefined");
@@ -55,15 +52,17 @@ public class MacheteProjectResolver implements ExternalSystemProjectResolver<Mac
     return false;
   }
 
-  @SuppressWarnings({"guieffect:call.invalid.ui", "interning:not.interned"})
+  @SuppressWarnings("interning:not.interned")
   private Boolean hasSelectedGitMacheteTab(Project project) {
     var toolWindowManager = ToolWindowManager.getInstance(project);
     var toolWindow = toolWindowManager.getToolWindow(ToolWindowId.VCS);
     if (toolWindow != null) {
-      var contentManager = toolWindow.getContentManager();
-      var gitMacheteContent = contentManager.findContent("Git Machete");
-      return contentManager.getSelectedContent() == gitMacheteContent;
+      var contentManager = toolWindow.getContentManagerIfCreated();
+      if (contentManager != null) {
+        var gitMacheteContent = contentManager.findContent("Git Machete");
+        return contentManager.getSelectedContent() == gitMacheteContent;
+      }
     }
-    return Boolean.FALSE;
+    return false;
   }
 }

--- a/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/items/GraphItemColor.java
+++ b/frontendGraphApi/src/main/java/com/virtuslab/gitmachete/frontend/graph/api/items/GraphItemColor.java
@@ -1,5 +1,5 @@
 package com.virtuslab.gitmachete.frontend.graph.api.items;
 
 public enum GraphItemColor {
-  TRANSPARENT, GRAY, YELLOW, RED, GREEN;
+  TRANSPARENT, GRAY, YELLOW, RED, GREEN
 }

--- a/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
@@ -250,8 +250,8 @@ string.GitMachete.EnhancedGraphTable.automatic-discover.success-message=Branch l
 string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout=Provided machete file ({0}) is empty and branch layout can''t be automatically detected
 string.GitMachete.EnhancedGraphTable.empty-table-text.loading=Loading...
 string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file=None of the branches provided by machete file ({0}) exists within the local repository
-string.GitMachete.EnhancedGraphTable.duplicated-branches-text=The following branches defined by machete file appear more than once:
-string.GitMachete.EnhancedGraphTable.skipped-branches-text=The following branches defined by machete file do not belong to the local repository:
+string.GitMachete.EnhancedGraphTable.duplicated-branches-text=The following branches appear more than once in machete file:
+string.GitMachete.EnhancedGraphTable.skipped-branches-text=The following branches listed in machete file do not belong to the local repository:
 
 string.GitMachete.RediscoverSuggester.dialog.title=Git Machete: Rediscover Suggestion
 string.GitMachete.RediscoverSuggester.dialog.question=It looks that you have not modified your git machete file for a while. Would you like to rediscover the branch layout?

--- a/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontendResourceBundles/src/main/resources/GitMacheteBundle.properties
@@ -250,6 +250,7 @@ string.GitMachete.EnhancedGraphTable.automatic-discover.success-message=Branch l
 string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout=Provided machete file ({0}) is empty and branch layout can''t be automatically detected
 string.GitMachete.EnhancedGraphTable.empty-table-text.loading=Loading...
 string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file=None of the branches provided by machete file ({0}) exists within the local repository
+string.GitMachete.EnhancedGraphTable.duplicated-branches-text=The following branches defined by machete file appear more than once:
 string.GitMachete.EnhancedGraphTable.skipped-branches-text=The following branches defined by machete file do not belong to the local repository:
 
 string.GitMachete.RediscoverSuggester.dialog.title=Git Machete: Rediscover Suggestion

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
@@ -4,6 +4,8 @@ import java.time.Instant;
 
 import io.vavr.NotImplementedError;
 import io.vavr.collection.List;
+import io.vavr.collection.Set;
+import io.vavr.collection.TreeSet;
 import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -116,13 +118,13 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
   }
 
   @Override
-  public List<String> getDuplicatedBranchNames() {
-    return List.empty();
+  public Set<String> getDuplicatedBranchNames() {
+    return TreeSet.empty();
   }
 
   @Override
-  public List<String> getSkippedBranchNames() {
-    return List.empty();
+  public Set<String> getSkippedBranchNames() {
+    return TreeSet.empty();
   }
 
   @Override

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
@@ -116,6 +116,11 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
   }
 
   @Override
+  public List<String> getDuplicatedBranchNames() {
+    return List.empty();
+  }
+
+  @Override
   public List<String> getSkippedBranchNames() {
     return List.empty();
   }

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -48,7 +48,8 @@ import com.intellij.util.messages.Topic;
 import com.intellij.util.ui.JBUI;
 import git4idea.repo.GitRepository;
 import git4idea.repo.GitRepositoryChangeListener;
-import io.vavr.collection.List;
+import io.vavr.collection.Set;
+import io.vavr.collection.TreeSet;
 import io.vavr.control.Option;
 import lombok.CustomLog;
 import lombok.Getter;
@@ -159,8 +160,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
   @UIEffect
   private void refreshModel(
       GitRepository gitRepository,
-      List<String> duplicatedBranchNames,
-      List<String> skippedBranchNames,
+      Set<String> duplicatedBranchNames,
+      Set<String> skippedBranchNames,
       @UI Runnable doOnUIThreadWhenReady) {
     if (!project.isInitialized() || ApplicationManager.getApplication().isUnitTestMode()) {
       LOG.debug("Project is not initialized or application is in unit test mode. Returning.");
@@ -272,8 +273,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     Option<GitRepository> gitRepository = gitRepositorySelectionProvider.getSelectedGitRepository();
     if (gitRepository.isDefined()) {
       refreshModel(gitRepository.get(),
-          /* duplicatedBranchNames */ List.empty(),
-          /* skippedBranchNames */ List.empty(),
+          /* duplicatedBranchNames */ TreeSet.empty(),
+          /* skippedBranchNames */ TreeSet.empty(),
           /* doOnUIThreadWhenReady */ () -> {});
     } else {
       LOG.warn("Selected git repository is undefined; unable to refresh model");
@@ -310,7 +311,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
                 doOnUIThreadWhenReady);
 
           } else {
-            refreshModel(gitRepository, List.empty(), List.empty(), doOnUIThreadWhenReady);
+            refreshModel(gitRepository, TreeSet.empty(), TreeSet.empty(), doOnUIThreadWhenReady);
           }
         };
 

--- a/gitCoreApi/src/main/java/com/virtuslab/gitcore/api/IGitCoreRepository.java
+++ b/gitCoreApi/src/main/java/com/virtuslab/gitcore/api/IGitCoreRepository.java
@@ -21,7 +21,7 @@ public interface IGitCoreRepository {
       IGitCoreCommit fromPerspectiveOf,
       IGitCoreCommit asComparedTo) throws GitCoreException;
 
-  List<String> deriveAllRemoteNames() throws GitCoreException;
+  List<String> deriveAllRemoteNames();
 
   boolean isAncestor(IGitCoreCommit presumedAncestor, IGitCoreCommit presumedDescendant) throws GitCoreException;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19799111/106041924-b1621980-60dc-11eb-8ca8-1078868b9f09.png)

---

- add `duplicatedBranchNames` (to `IGitMacheteRepositorySnapshot`)
- add tests for the derivation of skipped and duplicated 
- fix floating "refresh" button