### PR TITLE
[discover] Properly chain machete file opening after discover (closes…

### DIFF
--- a/config/checker/com.intellij.astub
+++ b/config/checker/com.intellij.astub
@@ -425,10 +425,10 @@ interface Content {
 
 interface ContentManager {
   @SafeEffect
-  Content findContent(String displayName);
+  @Nullable Content findContent(String displayName);
 
   @SafeEffect
-  Content getSelectedContent();
+  @Nullable Content getSelectedContent();
 }
 
 @AlwaysSafe

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
@@ -19,6 +19,7 @@ import com.intellij.ui.GuiUtils;
 import git4idea.repo.GitRepository;
 import io.vavr.control.Try;
 import lombok.CustomLog;
+import lombok.SneakyThrows;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UI;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
@@ -112,11 +113,13 @@ public class DiscoverAction extends BaseProjectDependentAction {
 
     new Task.Backgroundable(project, getString("action.GitMachete.DiscoverAction.write-file.task-title")) {
       @Override
+      @SneakyThrows
       public void run(ProgressIndicator indicator) {
-        Try.run(() -> branchLayoutWriter.write(macheteFilePath, branchLayout, /* backupOldLayout */ true));
+        branchLayoutWriter.write(macheteFilePath, branchLayout, /* backupOldLayout */ true);
       }
 
       @Override
+      @UIEffect
       public void onSuccess() {
         baseEnhancedGraphTable.queueRepositoryUpdateAndModelRefresh();
         VfsUtil.markDirtyAndRefresh(/* async */ false, /* recursive */ true, /* reloadChildren */ false,
@@ -125,6 +128,7 @@ public class DiscoverAction extends BaseProjectDependentAction {
       }
 
       @Override
+      @UIEffect
       public void onThrowable(Throwable e) {
         VcsNotifier.getInstance(project).notifyError(
             /* title */ getString("action.GitMachete.DiscoverAction.notification.title.write-file-error"),

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
@@ -5,7 +5,6 @@ import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 import com.intellij.ide.actions.OpenFileAction;
@@ -60,8 +59,8 @@ public class DiscoverAction extends BaseProjectDependentAction {
     val mainDirPath = GitVfsUtils.getMainDirectoryPath(gitRepository).toAbsolutePath();
     val gitDirPath = GitVfsUtils.getGitDirectoryPath(gitRepository).toAbsolutePath();
 
-    var graphTable = getGraphTable(anActionEvent);
-    var branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
+    val graphTable = getGraphTable(anActionEvent);
+    val branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
 
     // Note that we're essentially doing a heavy-ish operation of discoverLayoutAndCreateSnapshot on UI thread here.
     // This is still acceptable since it simplifies the flow (no background task needed)
@@ -84,13 +83,13 @@ public class DiscoverAction extends BaseProjectDependentAction {
             /* shouldDisplayActionToolTips */ false).show(), NON_MODAL));
   }
 
-  public Consumer<IGitMacheteRepositorySnapshot> saveAndDoNotOpenMacheteFileSnapshotConsumer(GitRepository gitRepository,
+  private Consumer<IGitMacheteRepositorySnapshot> saveAndDoNotOpenMacheteFileSnapshotConsumer(GitRepository gitRepository,
       Project project, BaseEnhancedGraphTable graphTable, IBranchLayoutWriter branchLayoutWriter) {
     return repositorySnapshot -> saveDiscoveredLayout(repositorySnapshot,
         GitVfsUtils.getMacheteFilePath(gitRepository), project, graphTable, branchLayoutWriter, () -> {});
   }
 
-  public Consumer<IGitMacheteRepositorySnapshot> saveAndOpenMacheteFileSnapshotConsumer(GitRepository gitRepository,
+  private Consumer<IGitMacheteRepositorySnapshot> saveAndOpenMacheteFileSnapshotConsumer(GitRepository gitRepository,
       Project project, BaseEnhancedGraphTable graphTable, IBranchLayoutWriter branchLayoutWriter) {
     return repositorySnapshot -> saveDiscoveredLayout(repositorySnapshot,
         GitVfsUtils.getMacheteFilePath(gitRepository), project, graphTable,
@@ -143,7 +142,7 @@ public class DiscoverAction extends BaseProjectDependentAction {
       public void onThrowable(Throwable e) {
         VcsNotifier.getInstance(project).notifyError(
             /* title */ getString("action.GitMachete.DiscoverAction.notification.title.write-file-error"),
-            /* message */ Objects.requireNonNullElse(e.getMessage(), ""));
+            /* message */ e.getMessage() != null ? e.getMessage() : "");
       }
 
     }.queue();

--- a/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/project/MacheteProjectResolver.java
+++ b/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/project/MacheteProjectResolver.java
@@ -61,7 +61,8 @@ public class MacheteProjectResolver implements ExternalSystemProjectResolver<Mac
       val contentManager = toolWindow.getContentManagerIfCreated();
       if (contentManager != null) {
         val gitMacheteContent = contentManager.findContent("Git Machete");
-        return contentManager.getSelectedContent() == gitMacheteContent;
+        val selectedContent = contentManager.getSelectedContent();
+        return selectedContent != null && selectedContent == gitMacheteContent;
       }
     }
     return false;


### PR DESCRIPTION
… #686)

---

Previously there was no guarantee that `openMacheteFile` will be executed after `branchLayoutWriter.write`.
Although this issue was present it was hard to spot since in our day-to-day usage some machete file (before discover) already exists.

Additionally scenario from #686 supposes that the whole project dir is being deleted and recreated while IDE projected is still opened which seems to be a rare case.