### PR TITLE
Prevent calling UI-thread-unsafe methods on UI thread (complement of GuiEffectChecker)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
             cli_version=$(grep -Po '(?<=referenceCliVersions=)[^,]*' backendImpl/src/test/resources/reference-cli-version.properties)
             pip3 install git-machete==$cli_version
       - run:
-          name: Run backend tests
+          name: Run unit & integration tests
           command: ./gradlew test
       # Unfortunately, wildcards for test result paths aren't supported by CircleCI yet.
       - store_test_results:

--- a/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepository.java
+++ b/backendApi/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepository.java
@@ -4,13 +4,17 @@ import io.vavr.collection.Set;
 import io.vavr.control.Option;
 
 import com.virtuslab.branchlayout.api.IBranchLayout;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 public interface IGitMacheteRepository {
+  @UIThreadUnsafe
   IGitMacheteRepositorySnapshot createSnapshotForLayout(IBranchLayout branchLayout) throws GitMacheteException;
 
+  @UIThreadUnsafe
   Option<ILocalBranchReference> inferParentForLocalBranch(
       Set<String> eligibleLocalBranchNames,
       String localBranchName) throws GitMacheteException;
 
+  @UIThreadUnsafe
   IGitMacheteRepositorySnapshot discoverLayoutAndCreateSnapshot() throws GitMacheteException;
 }

--- a/build.gradle
+++ b/build.gradle
@@ -121,9 +121,20 @@ allprojects {
   apply plugin: 'org.gradle.java-library'
   sourceCompatibility = 11
 
+  // String interpolation support, see https://github.com/antkorwin/better-strings
+  // This needs to be enabled in each subproject by default because there's going to be no warning
+  // if this annotation processor isn't run in any subproject (the strings will be just interpreted verbatim, without interpolation applied).
+  // We'd only capture that in CI's post-compile checks by analyzing constants in class files.
+  dependencies {
+    def betterStringsCoords = [ group: 'com.antkorwin', name: 'better-strings', version: betterStringsVersion ]
+    annotationProcessor(betterStringsCoords)
+    testAnnotationProcessor(betterStringsCoords)
+  }
+
   gradle.projectsEvaluated {
     tasks.withType(JavaCompile) {
       options.compilerArgs += [
+        '-AcallToStringExplicitlyInInterpolations', // Enforce explicit `.toString()` call in code generated for string interpolations
         '-Werror', // Treat each compiler warning (esp. the ones coming from Checker Framework) as an error.
         '-Xlint:unchecked', // Warn of type-unsafe operations on generics.
       ]
@@ -183,23 +194,6 @@ subprojects {
     dependencies {
       compileOnly      group: 'org.checkerframework', name: 'checker-qual', version: checkerFrameworkVersion
       checkerFramework group: 'org.checkerframework', name: 'checker',      version: checkerFrameworkVersion
-    }
-  }
-
-
-  // String interpolation support, see https://github.com/antkorwin/better-strings
-  // This needs to be enabled in each subproject by default because there's going to be no warning
-  // if this annotation processor isn't run in any subproject (the strings will be just interpreted verbatim, without interpolation applied).
-  // We'd only capture that in CI's post-compile checks by analyzing constants in class files.
-  dependencies {
-    def betterStringsCoords = [ group: 'com.antkorwin', name: 'better-strings', version: betterStringsVersion ]
-    annotationProcessor(betterStringsCoords)
-    testAnnotationProcessor(betterStringsCoords)
-  }
-
-  gradle.projectsEvaluated {
-    tasks.withType(JavaCompile) {
-      options.compilerArgs += '-AcallToStringExplicitlyInInterpolations'
     }
   }
 
@@ -485,7 +479,9 @@ if (ciBranch == 'master') {
 
 
 dependencies {
-  testImplementation group: 'com.tngtech.archunit', name: 'archunit', version: archUnitVersion
+  testImplementation group: 'com.tngtech.archunit', name: 'archunit',     version: archUnitVersion
+  // Checker is needed on root project runtime (not just compile-time) classpath for ArchUnit tests
+  testImplementation group: 'org.checkerframework', name: 'checker-qual', version: checkerFrameworkVersion
 }
 
 

--- a/config/checker/com.intellij.astub
+++ b/config/checker/com.intellij.astub
@@ -217,6 +217,9 @@ class Task {
   void onCancel();
 
   @UIEffect
+  void onFinished();
+
+  @UIEffect
   void onThrowable(Throwable error);
 
   @UIEffect

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/FetchBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/FetchBackgroundable.java
@@ -12,6 +12,8 @@ import lombok.CustomLog;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+
 @CustomLog
 public class FetchBackgroundable extends Task.Backgroundable {
 
@@ -56,6 +58,7 @@ public class FetchBackgroundable extends Task.Backgroundable {
   }
 
   @Override
+  @UIThreadUnsafe
   public void run(ProgressIndicator indicator) {
     if (taskSubtitle != null) {
       // This method set a text under a progress bar (despite of docstring)

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
@@ -48,6 +48,8 @@ import lombok.SneakyThrows;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+
 @CustomLog
 public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task.Backgroundable {
 
@@ -67,9 +69,11 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
 
   protected abstract String getTargetBranchName();
 
+  @UIThreadUnsafe
   protected abstract @Nullable GitLineHandler createGitLineHandler();
 
   @Override
+  @UIThreadUnsafe
   public final void run(ProgressIndicator indicator) {
     var handler = createGitLineHandler();
     if (handler == null) {
@@ -100,6 +104,7 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
     }
   }
 
+  @UIThreadUnsafe
   private @Nullable GitUpdatedRanges deriveGitUpdatedRanges(String remoteBranchName) {
     GitUpdatedRanges updatedRanges = null;
     var currentBranch = gitRepository.getCurrentBranch();
@@ -116,6 +121,7 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
     return updatedRanges;
   }
 
+  @UIThreadUnsafe
   private void handleResult(
       GitCommandResult result,
       GitLocalChangesWouldBeOverwrittenDetector localChangesDetector,
@@ -186,6 +192,7 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
 
   // TODO (#496): replace with a non-reflective constructor call
   @SneakyThrows
+  @UIThreadUnsafe
   private static MergeChangeCollector createMergeChangeCollector(
       Project project, GitRepository repository, GitRevisionNumber start) {
     try {
@@ -199,6 +206,7 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
     }
   }
 
+  @UIThreadUnsafe
   private void showUpdates(GitRevisionNumber currentRev, Label beforeLabel) {
     try {
       UpdatedFiles files = UpdatedFiles.create();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/MergeCurrentBranchFastForwardOnlyBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/MergeCurrentBranchFastForwardOnlyBackgroundable.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+
 public class MergeCurrentBranchFastForwardOnlyBackgroundable extends GitCommandUpdatingCurrentBranchBackgroundable {
 
   @Getter
@@ -30,6 +32,7 @@ public class MergeCurrentBranchFastForwardOnlyBackgroundable extends GitCommandU
   }
 
   @Override
+  @UIThreadUnsafe
   protected @Nullable GitLineHandler createGitLineHandler() {
     var handler = new GitLineHandler(project, gitRepository.getRoot(), GitCommand.MERGE);
     handler.addParameters("--ff-only");

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/PullCurrentBranchFastForwardOnlyBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/PullCurrentBranchFastForwardOnlyBackgroundable.java
@@ -14,6 +14,7 @@ import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.virtuslab.gitmachete.backend.api.IRemoteTrackingBranchReference;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 @CustomLog
 public class PullCurrentBranchFastForwardOnlyBackgroundable extends GitCommandUpdatingCurrentBranchBackgroundable {
@@ -40,6 +41,7 @@ public class PullCurrentBranchFastForwardOnlyBackgroundable extends GitCommandUp
   }
 
   @Override
+  @UIThreadUnsafe
   protected @Nullable GitLineHandler createGitLineHandler() {
     var handler = new GitLineHandler(project, gitRepository.getRoot(), GitCommand.PULL);
     String remoteName = remoteBranch.getRemoteName();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
@@ -21,7 +21,7 @@ import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.OverrideForkPointDialog;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.logger.IEnhancedLambdaLogger;
-import com.virtuslab.qual.guieffect.NotUIThreadSafe;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 @CustomLog
 public abstract class BaseOverrideForkPointAction extends BaseGitMacheteRepositoryReadyAction
@@ -81,13 +81,14 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
     LOG.debug("Enqueueing fork point override");
     new Task.Backgroundable(project, "Overriding fork point...") {
       @Override
+      @UIThreadUnsafe
       public void run(ProgressIndicator indicator) {
         overrideForkPoint(anActionEvent, branch, selectedCommit);
       }
     }.queue();
   }
 
-  @NotUIThreadSafe
+  @UIThreadUnsafe
   private void overrideForkPoint(AnActionEvent anActionEvent, IManagedBranchSnapshot branch, ICommitOfManagedBranch forkPoint) {
     var gitRepository = getSelectedGitRepository(anActionEvent);
 
@@ -100,7 +101,7 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
     getGraphTable(anActionEvent).queueRepositoryUpdateAndModelRefresh();
   }
 
-  @NotUIThreadSafe
+  @UIThreadUnsafe
   private void setOverrideForkPointConfigValues(
       Project project,
       VirtualFile root,

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
@@ -32,6 +32,7 @@ import com.virtuslab.gitmachete.frontend.actions.contextmenu.CheckoutSelectedBra
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
 import com.virtuslab.logger.IEnhancedLambdaLogger;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 @CustomLog
 public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRepositoryReadyAction
@@ -175,6 +176,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
 
     new Task.Backgroundable(project, getString("action.GitMachete.BaseRebaseBranchOntoParentAction.hook.task-title")) {
       @Override
+      @UIThreadUnsafe
       public void run(ProgressIndicator indicator) {
 
         var wrapper = new Object() {
@@ -214,6 +216,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
 
         new Task.Backgroundable(project, getString("action.GitMachete.BaseRebaseBranchOntoParentAction.task-title")) {
           @Override
+          @UIThreadUnsafe
           public void run(ProgressIndicator indicator) {
             GitRebaseParams params = getIdeaRebaseParamsOf(gitRepository, gitRebaseParameters);
             LOG.info("Rebasing '${gitRebaseParameters.getCurrentBranch().getName()}' branch " +
@@ -240,6 +243,7 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
     }.queue();
   }
 
+  @UIThreadUnsafe
   private GitRebaseParams getIdeaRebaseParamsOf(GitRepository repository, IGitRebaseParameters gitRebaseParameters) {
     GitVersion gitVersion = repository.getVcs().getVersion();
     String currentBranchName = gitRebaseParameters.getCurrentBranch().getName();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -41,6 +41,7 @@ import com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackground
 import com.virtuslab.gitmachete.frontend.actions.dialogs.ResetBranchToRemoteInfoDialog;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
 import com.virtuslab.logger.IEnhancedLambdaLogger;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 @CustomLog
 public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteRepositoryReadyAction
@@ -207,6 +208,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
         /* canBeCancelled */ true) {
 
       @Override
+      @UIThreadUnsafe
       public void run(ProgressIndicator indicator) {
         var localBranchName = localBranch.getName();
         var remoteTrackingBranchName = remoteTrackingBranch.getName();

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
@@ -17,6 +17,7 @@ import org.checkerframework.checker.guieffect.qual.UIEffect;
 import com.virtuslab.gitmachete.frontend.actions.base.BaseGitMacheteRepositoryReadyAction;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
 import com.virtuslab.logger.IEnhancedLambdaLogger;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 @CustomLog
 public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyAction
@@ -76,6 +77,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
       log().debug(() -> "Queuing '${selectedBranchName.get()}' branch checkout background task");
       new Task.Backgroundable(project, getString("action.GitMachete.CheckoutSelectedBranchAction.task-title")) {
         @Override
+        @UIThreadUnsafe
         public void run(ProgressIndicator indicator) {
           doCheckout(project, indicator, selectedBranchName.get(), gitRepository.get());
         }
@@ -84,6 +86,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
     }
   }
 
+  @UIThreadUnsafe
   public static void doCheckout(Project project, ProgressIndicator indicator, String branchToCheckoutName,
       GitRepository gitRepository) {
     GitBranchUiHandlerImpl uiHandler = new GitBranchUiHandlerImpl(project, Git.getInstance(), indicator);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
@@ -13,6 +13,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction;
 import com.virtuslab.logger.IEnhancedLambdaLogger;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 @CustomLog
 public class FetchAllRemotesAction extends BaseProjectDependentAction {
@@ -50,11 +51,13 @@ public class FetchAllRemotesAction extends BaseProjectDependentAction {
       private @MonotonicNonNull GitFetchResult result = null;
 
       @Override
+      @UIThreadUnsafe
       public void run(ProgressIndicator indicator) {
         result = GitFetchSupport.fetchSupport(project).fetchAllRemotes(gitRepository.toJavaList());
       }
 
       @Override
+      @UIEffect
       public void onFinished() {
         var result = this.result;
         if (result != null) {

--- a/frontendFile/build.gradle
+++ b/frontendFile/build.gradle
@@ -2,6 +2,7 @@ lombok()
 vavr()
 
 dependencies {
+  api project(':qual')
   implementation project(':frontendIcons')
   implementation project(':frontendResourceBundles')
   implementation project(':frontendVfsUtils')

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
@@ -10,9 +10,12 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.TextFieldWithAutoCompletionListProvider;
 
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+
 public class MacheteCompletionContributor extends CompletionContributor implements DumbAware {
 
   @Override
+  @UIThreadUnsafe
   public void fillCompletionVariants(CompletionParameters parameters, CompletionResultSet result) {
     PsiFile file = parameters.getOriginalFile();
 

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
@@ -5,10 +5,12 @@ import git4idea.repo.GitRepositoryManager;
 import io.vavr.collection.List;
 
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 public final class MacheteFileUtils {
   private MacheteFileUtils() {}
 
+  @UIThreadUnsafe
   public static List<String> getBranchNamesForPsiFile(PsiFile psiFile) {
     var project = psiFile.getProject();
 

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -29,11 +29,13 @@ import com.virtuslab.gitmachete.frontend.file.grammar.MacheteFile;
 import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedBranch;
 import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedElementTypes;
 import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedEntry;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 public class MacheteAnnotator implements Annotator, DumbAware {
   private boolean cantGetBranchesMessageWasShown = false;
 
   @Override
+  @UIThreadUnsafe
   public void annotate(PsiElement element, AnnotationHolder holder) {
     if (element instanceof MacheteGeneratedEntry) {
       processMacheteGeneratedEntry((MacheteGeneratedEntry) element, holder);
@@ -53,6 +55,7 @@ public class MacheteAnnotator implements Annotator, DumbAware {
     cantGetBranchesMessageWasShown = true;
   }
 
+  @UIThreadUnsafe
   private void processMacheteGeneratedEntry(MacheteGeneratedEntry macheteEntry, AnnotationHolder holder) {
     MacheteGeneratedBranch branch = macheteEntry.getBranch();
 

--- a/gitCoreApi/build.gradle
+++ b/gitCoreApi/build.gradle
@@ -1,2 +1,6 @@
 lombok()
 vavr()
+
+dependencies {
+  api project(':qual')
+}

--- a/gitCoreApi/src/main/java/com/virtuslab/gitcore/api/IGitCoreRepository.java
+++ b/gitCoreApi/src/main/java/com/virtuslab/gitcore/api/IGitCoreRepository.java
@@ -4,30 +4,42 @@ import io.vavr.collection.List;
 import io.vavr.collection.Stream;
 import io.vavr.control.Option;
 
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+
 public interface IGitCoreRepository {
+  @UIThreadUnsafe
   Option<String> deriveConfigValue(String section, String subsection, String name);
 
+  @UIThreadUnsafe
   Option<IGitCoreCommit> parseRevision(String revision) throws GitCoreException;
 
   /**
    * @return snapshots of all local branches in the repository, sorted by name
    * @throws GitCoreException when reading git repository data fails
    */
+  @UIThreadUnsafe
   List<IGitCoreLocalBranchSnapshot> deriveAllLocalBranches() throws GitCoreException;
 
+  @UIThreadUnsafe
   IGitCoreHeadSnapshot deriveHead() throws GitCoreException;
 
+  @UIThreadUnsafe
   Option<GitCoreRelativeCommitCount> deriveRelativeCommitCount(
       IGitCoreCommit fromPerspectiveOf,
       IGitCoreCommit asComparedTo) throws GitCoreException;
 
+  @UIThreadUnsafe
   List<String> deriveAllRemoteNames();
 
+  @UIThreadUnsafe
   boolean isAncestor(IGitCoreCommit presumedAncestor, IGitCoreCommit presumedDescendant) throws GitCoreException;
 
+  @UIThreadUnsafe
   Stream<IGitCoreCommit> ancestorsOf(IGitCoreCommit commitInclusive) throws GitCoreException;
 
+  @UIThreadUnsafe
   List<IGitCoreCommit> deriveCommitRange(IGitCoreCommit fromInclusive, IGitCoreCommit untilExclusive) throws GitCoreException;
 
+  @UIThreadUnsafe
   GitCoreRepositoryState deriveRepositoryState();
 }

--- a/qual/src/main/java/com/virtuslab/qual/guieffect/UIThreadUnsafe.java
+++ b/qual/src/main/java/com/virtuslab/qual/guieffect/UIThreadUnsafe.java
@@ -6,6 +6,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 // TODO (typetools/checker-framework#3252): replace with proper @Heavyweight
-@Retention(RetentionPolicy.CLASS)
-@Target({ElementType.METHOD})
-public @interface NotUIThreadSafe {}
+
+// Must have runtime retention to be visible to ArchUnit tests.
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+public @interface UIThreadUnsafe {}

--- a/src/test/java/com/virtuslab/archunit/UiThreadUnsafeMethodInvocationsTestSuite.java
+++ b/src/test/java/com/virtuslab/archunit/UiThreadUnsafeMethodInvocationsTestSuite.java
@@ -1,0 +1,116 @@
+package com.virtuslab.archunit;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+import java.util.Arrays;
+
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+import org.junit.Test;
+
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+
+public class UiThreadUnsafeMethodInvocationsTestSuite extends BaseArchUnitTestSuite {
+
+  private static final String UIThreadUnsafeName = "@" + UIThreadUnsafe.class.getSimpleName();
+
+  @Test
+  public void ui_thread_unsafe_methods_should_not_be_uieffect() {
+    methods()
+        .that()
+        .areAnnotatedWith(UIThreadUnsafe.class)
+        .should()
+        .notBeAnnotatedWith(UIEffect.class)
+        .check(importedClasses);
+  }
+
+  @Test
+  public void only_ui_thread_unsafe_methods_should_call_other_ui_thread_unsafe_methods() {
+    methods()
+        .that()
+        .areNotAnnotatedWith(UIThreadUnsafe.class)
+        .should(new ArchCondition<JavaMethod>("never call any ${UIThreadUnsafeName} methods") {
+          @Override
+          public void check(JavaMethod method, ConditionEvents events) {
+            // This makes the check somewhat unsound (some non-UI-safe calls can slip under the radar in lambdas),
+            // but annotating lambda methods isn't possible without expanding lambda into anonymous class...
+            // which would in turn heavily reduce readability, hence potentially leading to bugs in the long run.
+            if (method.getName().startsWith("lambda$")) {
+              return;
+            }
+
+            method.getCallsFromSelf().forEach(access -> {
+              var accessTarget = access.getTarget();
+              if (accessTarget.isAnnotatedWith(UIThreadUnsafe.class)) {
+                var message = "a non-${UIThreadUnsafeName} method ${method.getFullName()} " +
+                    "calls a ${UIThreadUnsafeName} method ${accessTarget.getFullName()}";
+                events.add(SimpleConditionEvent.violated(method, message));
+              }
+            });
+          }
+        })
+        .check(importedClasses);
+  }
+
+  @Test
+  public void only_ui_thread_unsafe_method_should_call_git4idea_methods() {
+    methods()
+        .that()
+        .areNotAnnotatedWith(UIThreadUnsafe.class)
+        .should(new ArchCondition<JavaMethod>("never call any heavyweight git4idea methods") {
+          @Override
+          public void check(JavaMethod method, ConditionEvents events) {
+            if (method.getName().startsWith("lambda$")) {
+              return;
+            }
+
+            method.getCallsFromSelf().forEach(call -> {
+              var callTarget = call.getTarget();
+              var callTargetPackageName = callTarget.getOwner().getPackageName();
+              if (callTargetPackageName.startsWith("git4idea")) {
+                String[] whitelistedMethodFullNames = {
+                    "git4idea.GitLocalBranch.getName()",
+                    "git4idea.GitRemoteBranch.getName()",
+                    "git4idea.GitUtil.findGitDir(com.intellij.openapi.vfs.VirtualFile)",
+                    "git4idea.GitUtil.getRepositories(com.intellij.openapi.project.Project)",
+                    "git4idea.GitUtil.getRepositoryManager(com.intellij.openapi.project.Project)",
+                    "git4idea.branch.GitBranchesCollection.findLocalBranch(java.lang.String)",
+                    "git4idea.branch.GitBranchesCollection.findRemoteBranch(java.lang.String)",
+                    "git4idea.branch.GitNewBranchDialog.<init>(com.intellij.openapi.project.Project, java.util.Collection, java.lang.String, java.lang.String, boolean, boolean, boolean)",
+                    "git4idea.branch.GitNewBranchDialog.showAndGetOptions()",
+                    "git4idea.branch.GitNewBranchOptions.getName()",
+                    "git4idea.branch.GitNewBranchOptions.shouldCheckout()",
+                    "git4idea.config.GitSharedSettings.getInstance(com.intellij.openapi.project.Project)",
+                    "git4idea.config.GitSharedSettings.isBranchProtected(java.lang.String)",
+                    "git4idea.config.GitVcsSettings.getInstance(com.intellij.openapi.project.Project)",
+                    "git4idea.config.GitVcsSettings.getRecentRootPath()",
+                    "git4idea.fetch.GitFetchSupport.isFetchRunning()",
+                    "git4idea.fetch.GitFetchResult.showNotification()",
+                    "git4idea.fetch.GitFetchSupport.fetchSupport(com.intellij.openapi.project.Project)",
+                    "git4idea.push.GitPushSource.create(git4idea.GitLocalBranch)",
+                    "git4idea.repo.GitRemote.getName()",
+                    "git4idea.repo.GitRepository.getBranches()",
+                    "git4idea.repo.GitRepository.getCurrentBranch()",
+                    "git4idea.repo.GitRepository.getRemotes()",
+                    "git4idea.repo.GitRepository.getRoot()",
+                    "git4idea.repo.GitRepository.getState()",
+                    "git4idea.repo.GitRepository.getVcs()",
+                    "git4idea.validators.GitBranchValidatorKt.checkRefName(java.lang.String)"
+                };
+                var calledMethodFullName = callTarget.getFullName();
+
+                if (!Arrays.asList(whitelistedMethodFullNames).contains(calledMethodFullName)) {
+                  var message = "a non-${UIThreadUnsafeName} method ${method.getFullName()} " +
+                      "calls method ${calledMethodFullName} from git4idea";
+                  events.add(SimpleConditionEvent.violated(method, message));
+                }
+              }
+            });
+          }
+        })
+        .check(importedClasses);
+  }
+}


### PR DESCRIPTION
GuiEffectChecker ensures that:
1. UI-touching (aka `@UIEffect`) methods are **only ever** called on UI thread
2. UI-touching methods are never called from non-UI-touching (aka `@SafeEffect`) methods

This PR kinda-ensures that:
1. UI-unsafe methods (mostly the heavyweight ones, due to disk/network access) are **never** called on UI thread
2. UI-unsafe methods are never called from non-UI-unsafe methods

Note that non-UI-unsafe does NOT imply UI-touching,
and non-UI-touching does NOT imply UI-unsafe.
In fact, most methods are both non-UI-touching and non-UI-unsafe.

There are, however, obviously no methods that would be both UI-touching AND UI-unsafe.