### PR TITLE
Make plugin Android Studio-compatible (Java 8 + optional dependency on externalSystem)

### DIFF
--- a/backendImpl/build.gradle
+++ b/backendImpl/build.gradle
@@ -1,3 +1,4 @@
+commonsIO()
 junit()
 lombok()
 powerMock()

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/BaseManagedBranchSnapshot.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/BaseManagedBranchSnapshot.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import lombok.val;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -40,7 +41,7 @@ public abstract class BaseManagedBranchSnapshot implements IManagedBranchSnapsho
    * parent data somewhere outside of this class (e.g. in {@link GitMacheteRepositorySnapshot}).
    */
   protected void setParentForChildren() {
-    for (var child : children) {
+    for (val child : children) {
       child.setParent(this);
     }
   }

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.With;
+import lombok.val;
 import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -77,8 +78,8 @@ public class GitMacheteRepository implements IGitMacheteRepository {
   public IGitMacheteRepositorySnapshot createSnapshotForLayout(IBranchLayout branchLayout) throws GitMacheteException {
     LOG.startTimer().debug("Entering");
     try {
-      var aux = new CreateGitMacheteRepositoryAux(gitCoreRepository, statusHookExecutor, preRebaseHookExecutor);
-      var result = aux.createSnapshot(branchLayout);
+      val aux = new CreateGitMacheteRepositoryAux(gitCoreRepository, statusHookExecutor, preRebaseHookExecutor);
+      val result = aux.createSnapshot(branchLayout);
       LOG.withTimeElapsed().info("Finished");
       return result;
     } catch (GitCoreException e) {
@@ -93,8 +94,8 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       String localBranchName) throws GitMacheteException {
     LOG.startTimer().debug(() -> "Entering: localBranchName = ${localBranchName}");
     try {
-      var aux = new Aux(gitCoreRepository);
-      var result = aux.inferParentForLocalBranch(eligibleLocalBranchNames, localBranchName);
+      val aux = new Aux(gitCoreRepository);
+      val result = aux.inferParentForLocalBranch(eligibleLocalBranchNames, localBranchName);
       LOG.withTimeElapsed().info("Finished");
       return result;
     } catch (GitCoreException e) {
@@ -108,8 +109,8 @@ public class GitMacheteRepository implements IGitMacheteRepository {
     LOG.startTimer().debug("Entering");
 
     try {
-      var aux = new DiscoverGitMacheteRepositoryAux(gitCoreRepository, statusHookExecutor, preRebaseHookExecutor);
-      var result = aux.discoverLayoutAndCreateSnapshot(NUMBER_OF_MOST_RECENTLY_CHECKED_OUT_BRANCHES_FOR_DISCOVER);
+      val aux = new DiscoverGitMacheteRepositoryAux(gitCoreRepository, statusHookExecutor, preRebaseHookExecutor);
+      val result = aux.discoverLayoutAndCreateSnapshot(NUMBER_OF_MOST_RECENTLY_CHECKED_OUT_BRANCHES_FOR_DISCOVER);
       LOG.withTimeElapsed().info("Finished");
       return result;
     } catch (GitCoreException e) {
@@ -169,7 +170,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           .flatMap(branchAndReflog -> branchAndReflog._2
               .map(re -> Tuple.of(re.getNewCommitHash(), branchAndReflog._1)));
 
-      var result = reflogCommitHashAndBranchPairs
+      val result = reflogCommitHashAndBranchPairs
           .groupBy(reflogCommitHashAndBranch -> reflogCommitHashAndBranch._1)
           .mapValues(pairsOfReflogCommitHashAndBranch -> pairsOfReflogCommitHashAndBranch
               .map(reflogCommitHashAndBranch -> reflogCommitHashAndBranch._2));
@@ -197,7 +198,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
 
       IGitCoreCommitHash entryToExcludeNewId;
       if (reflogEntries.size() > 0) {
-        var firstEntry = reflogEntries.get(reflogEntries.size() - 1);
+        val firstEntry = reflogEntries.get(reflogEntries.size() - 1);
         String createdFromPrefix = "branch: Created from";
         if (firstEntry.getComment().startsWith(createdFromPrefix)) {
           entryToExcludeNewId = firstEntry.getNewCommitHash();
@@ -242,7 +243,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         return true;
       };
 
-      var result = reflogEntries.reject(isEntryExcluded);
+      val result = reflogEntries.reject(isEntryExcluded);
       LOG.debug(() -> "Filtered reflog of ${branch.getFullName()}:");
       LOG.debug(() -> result.mkString(System.lineSeparator()));
       filteredReflogByBranch.put(branch, result);
@@ -254,7 +255,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         Set<String> eligibleLocalBranchNames,
         String localBranchName) throws GitCoreException {
 
-      var localBranch = localBranchByName.get(localBranchName).getOrNull();
+      val localBranch = localBranchByName.get(localBranchName).getOrNull();
       if (localBranch == null) {
         return Option.none();
       }
@@ -262,7 +263,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       LOG.debug(() -> "Branch(es) eligible for becoming the parent of ${localBranchName}: " +
           "${eligibleLocalBranchNames.mkString(\", \")}");
 
-      var commitAndContainingBranches = gitCoreRepository
+      val commitAndContainingBranches = gitCoreRepository
           .ancestorsOf(localBranch.getPointedCommit())
           .map(commit -> {
             Seq<ILocalBranchReference> eligibleContainingBranches = deriveBranchesContainingGivenCommitInReflog()
@@ -278,8 +279,8 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           .getOrNull();
 
       if (commitAndContainingBranches != null) {
-        var commit = commitAndContainingBranches._1;
-        var containingBranches = commitAndContainingBranches._2.toList();
+        val commit = commitAndContainingBranches._1;
+        val containingBranches = commitAndContainingBranches._2.toList();
         assert containingBranches.nonEmpty() : "containingBranches is empty";
 
         ILocalBranchReference firstContainingBranch = containingBranches.head();
@@ -316,15 +317,15 @@ public class GitMacheteRepository implements IGitMacheteRepository {
 
     @UIThreadUnsafe
     IGitMacheteRepositorySnapshot createSnapshot(IBranchLayout branchLayout) throws GitMacheteException {
-      var rootBranchTries = branchLayout.getRootEntries().map(entry -> Try.of(() -> createGitMacheteRootBranch(entry)));
-      var rootBranchCreationResults = Try.sequence(rootBranchTries).getOrElseThrow(GitMacheteException::getOrWrap).toList();
-      var rootBranches = rootBranchCreationResults.flatMap(creationResult -> creationResult.getCreatedBranches());
-      var skippedBranchNames = rootBranchCreationResults.flatMap(creationResult -> creationResult.getSkippedBranchNames())
+      val rootBranchTries = branchLayout.getRootEntries().map(entry -> Try.of(() -> createGitMacheteRootBranch(entry)));
+      val rootBranchCreationResults = Try.sequence(rootBranchTries).getOrElseThrow(GitMacheteException::getOrWrap).toList();
+      val rootBranches = rootBranchCreationResults.flatMap(creationResult -> creationResult.getCreatedBranches());
+      val skippedBranchNames = rootBranchCreationResults.flatMap(creationResult -> creationResult.getSkippedBranchNames())
           .toSet();
-      var duplicatedBranchNames = rootBranchCreationResults
+      val duplicatedBranchNames = rootBranchCreationResults
           .flatMap(creationResult -> creationResult.getDuplicatedBranchNames()).toSet();
 
-      var managedBranchByName = createManagedBranchByNameMap(rootBranches);
+      val managedBranchByName = createManagedBranchByNameMap(rootBranches);
 
       Option<IGitCoreLocalBranchSnapshot> coreCurrentBranch = deriveCoreCurrentBranch();
 
@@ -339,7 +340,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           ? currentBranchIfManaged.getName()
           : "<none> (unmanaged branch or detached HEAD)"));
 
-      var ongoingOperation = Match(gitCoreRepository.deriveRepositoryState()).of(
+      val ongoingOperation = Match(gitCoreRepository.deriveRepositoryState()).of(
           Case($(GitCoreRepositoryState.CHERRY_PICK), OngoingRepositoryOperation.CHERRY_PICKING),
           Case($(GitCoreRepositoryState.MERGING), OngoingRepositoryOperation.MERGING),
           Case($(GitCoreRepositoryState.REBASING), OngoingRepositoryOperation.REBASING),
@@ -366,8 +367,8 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       Queue<IManagedBranchSnapshot> queue = Queue.ofAll(rootBranches);
       // BFS over all branches
       while (queue.nonEmpty()) {
-        var headAndTail = queue.dequeue();
-        var branch = headAndTail._1;
+        val headAndTail = queue.dequeue();
+        val branch = headAndTail._1;
         branchByName = branchByName.put(branch.getName(), branch);
         queue = headAndTail._2.appendAll(branch.getChildren());
       }
@@ -378,38 +379,38 @@ public class GitMacheteRepository implements IGitMacheteRepository {
     private CreatedAndDuplicatedAndSkippedBranches<RootManagedBranchSnapshot> createGitMacheteRootBranch(
         IBranchLayoutEntry entry) throws GitCoreException {
 
-      var branchName = entry.getName();
+      val branchName = entry.getName();
       IGitCoreLocalBranchSnapshot coreLocalBranch = localBranchByName.get(branchName).getOrNull();
       if (coreLocalBranch == null) {
-        var childBranchTries = entry.getChildren()
+        val childBranchTries = entry.getChildren()
             .map(childEntry -> Try.of(() -> createGitMacheteRootBranch(childEntry)));
-        var newRoots = Try.sequence(childBranchTries)
+        val newRoots = Try.sequence(childBranchTries)
             .getOrElseThrow(GitCoreException::getOrWrap)
             .fold(CreatedAndDuplicatedAndSkippedBranches.empty(), CreatedAndDuplicatedAndSkippedBranches::merge);
         return newRoots.withExtraSkippedBranch(branchName);
       }
 
       if (!createdBranches.add(branchName)) {
-        var childBranchTries = entry.getChildren()
+        val childBranchTries = entry.getChildren()
             .map(childEntry -> Try.of(() -> createGitMacheteRootBranch(childEntry)));
-        var newRoots = Try.sequence(childBranchTries)
+        val newRoots = Try.sequence(childBranchTries)
             .getOrElseThrow(GitCoreException::getOrWrap)
             .fold(CreatedAndDuplicatedAndSkippedBranches.empty(), CreatedAndDuplicatedAndSkippedBranches::merge);
         return newRoots.withExtraDuplicatedBranch(branchName);
       }
 
-      var branchFullName = coreLocalBranch.getFullName();
+      val branchFullName = coreLocalBranch.getFullName();
 
       IGitCoreCommit corePointedCommit = coreLocalBranch.getPointedCommit();
 
-      var pointedCommit = new CommitOfManagedBranch(corePointedCommit);
-      var syncToRemoteStatus = deriveSyncToRemoteStatus(coreLocalBranch);
-      var customAnnotation = entry.getCustomAnnotation().getOrNull();
-      var childBranches = deriveChildBranches(coreLocalBranch, entry.getChildren());
-      var remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
-      var statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit).getOrNull();
+      val pointedCommit = new CommitOfManagedBranch(corePointedCommit);
+      val syncToRemoteStatus = deriveSyncToRemoteStatus(coreLocalBranch);
+      val customAnnotation = entry.getCustomAnnotation().getOrNull();
+      val childBranches = deriveChildBranches(coreLocalBranch, entry.getChildren());
+      val remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
+      val statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit).getOrNull();
 
-      var createdRootBranch = new RootManagedBranchSnapshot(branchName, branchFullName,
+      val createdRootBranch = new RootManagedBranchSnapshot(branchName, branchFullName,
           childBranches.getCreatedBranches(), pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation,
           statusHookOutput);
       return CreatedAndDuplicatedAndSkippedBranches.of(List.of(createdRootBranch),
@@ -421,7 +422,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         IGitCoreLocalBranchSnapshot parentCoreLocalBranch,
         IBranchLayoutEntry entry) throws GitCoreException {
 
-      var branchName = entry.getName();
+      val branchName = entry.getName();
       IGitCoreLocalBranchSnapshot coreLocalBranch = localBranchByName.get(branchName).getOrNull();
       if (coreLocalBranch == null) {
         CreatedAndDuplicatedAndSkippedBranches<NonRootManagedBranchSnapshot> childResult = deriveChildBranches(
@@ -437,13 +438,13 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         return childResult.withExtraDuplicatedBranch(branchName);
       }
 
-      var branchFullName = coreLocalBranch.getFullName();
+      val branchFullName = coreLocalBranch.getFullName();
 
       IGitCoreCommit corePointedCommit = coreLocalBranch.getPointedCommit();
 
       ForkPointCommitOfManagedBranch forkPoint = deriveParentAwareForkPoint(coreLocalBranch, parentCoreLocalBranch);
 
-      var syncToParentStatus = deriveSyncToParentStatus(coreLocalBranch, parentCoreLocalBranch, forkPoint);
+      val syncToParentStatus = deriveSyncToParentStatus(coreLocalBranch, parentCoreLocalBranch, forkPoint);
 
       List<IGitCoreCommit> commits;
       if (forkPoint == null) {
@@ -458,14 +459,14 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         commits = gitCoreRepository.deriveCommitRange(corePointedCommit, forkPoint.getCoreCommit());
       }
 
-      var pointedCommit = new CommitOfManagedBranch(corePointedCommit);
-      var syncToRemoteStatus = deriveSyncToRemoteStatus(coreLocalBranch);
-      var customAnnotation = entry.getCustomAnnotation().getOrNull();
-      var childBranches = deriveChildBranches(coreLocalBranch, entry.getChildren());
-      var remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
-      var statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit).getOrNull();
+      val pointedCommit = new CommitOfManagedBranch(corePointedCommit);
+      val syncToRemoteStatus = deriveSyncToRemoteStatus(coreLocalBranch);
+      val customAnnotation = entry.getCustomAnnotation().getOrNull();
+      val childBranches = deriveChildBranches(coreLocalBranch, entry.getChildren());
+      val remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
+      val statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit).getOrNull();
 
-      var result = new NonRootManagedBranchSnapshot(branchName, branchFullName, childBranches.getCreatedBranches(),
+      val result = new NonRootManagedBranchSnapshot(branchName, branchFullName, childBranches.getCreatedBranches(),
           pointedCommit, remoteTrackingBranch, syncToRemoteStatus, customAnnotation, statusHookOutput, forkPoint,
           commits.map(CommitOfManagedBranch::new), syncToParentStatus);
       return CreatedAndDuplicatedAndSkippedBranches.of(List.of(result),
@@ -493,15 +494,15 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           ? ForkPointCommitOfManagedBranch.overridden(overriddenForkPointCommit)
           : deriveParentAgnosticInferredForkPoint(coreLocalBranch);
 
-      var parentAgnosticForkPointString = parentAgnosticForkPoint != null ? parentAgnosticForkPoint.toString() : "empty";
-      var parentPointedCommit = parentCoreLocalBranch.getPointedCommit();
-      var pointedCommit = coreLocalBranch.getPointedCommit();
+      val parentAgnosticForkPointString = parentAgnosticForkPoint != null ? parentAgnosticForkPoint.toString() : "empty";
+      val parentPointedCommit = parentCoreLocalBranch.getPointedCommit();
+      val pointedCommit = coreLocalBranch.getPointedCommit();
 
       LOG.debug(() -> "parentAgnosticForkPoint = ${parentAgnosticForkPointString}, " +
           "parentPointedCommit = ${parentPointedCommit.getHash().getHashString()}, " +
           "pointedCommit = ${pointedCommit.getHash().getHashString()}");
 
-      var isParentAncestorOfChild = gitCoreRepository.isAncestor(parentPointedCommit, pointedCommit);
+      val isParentAncestorOfChild = gitCoreRepository.isAncestor(parentPointedCommit, pointedCommit);
 
       LOG.debug(() -> "Parent branch commit (${parentPointedCommit.getHash().getHashString()}) " +
           "is${isParentAncestorOfChild ? \"\" : \" NOT\"} ancestor of commit " +
@@ -509,7 +510,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
 
       if (isParentAncestorOfChild) {
         if (parentAgnosticForkPoint != null) {
-          var isParentAncestorOfForkPoint = gitCoreRepository.isAncestor(parentPointedCommit,
+          val isParentAncestorOfForkPoint = gitCoreRepository.isAncestor(parentPointedCommit,
               parentAgnosticForkPoint.getCoreCommit());
 
           if (!isParentAncestorOfForkPoint) {
@@ -578,7 +579,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
 
       // Now we know that the override config is consistent, but it still doesn't mean
       // that it actually applies to the given branch AT THIS POINT (it could e.g. have applied earlier but now no longer applies).
-      var branchCommit = coreLocalBranch.getPointedCommit();
+      val branchCommit = coreLocalBranch.getPointedCommit();
       if (!gitCoreRepository.isAncestor(whileDescendantOf, branchCommit)) {
         LOG.debug(() -> "Branch ${branchName} (${branchCommit}) is NOT a descendant of " +
             "<whileDescendantOf> (${whileDescendantOf}), ignoring outdated fork point override");
@@ -600,10 +601,10 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         throws GitCoreException {
       LOG.debug(() -> "Entering: branch = '${branch.getFullName()}'");
 
-      var forkPointAndContainingBranches = gitCoreRepository
+      val forkPointAndContainingBranches = gitCoreRepository
           .ancestorsOf(branch.getPointedCommit())
           .map(commit -> {
-            var containingBranches = deriveBranchesContainingGivenCommitInReflog()
+            Seq<IBranchReference> containingBranches = deriveBranchesContainingGivenCommitInReflog()
                 .getOrElse(commit.getHash(), List.empty())
                 .reject(candidateBranch -> {
                   ILocalBranchReference correspondingLocalBranch = candidateBranch.isLocal()
@@ -617,8 +618,8 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           .getOrNull();
 
       if (forkPointAndContainingBranches != null) {
-        var forkPoint = forkPointAndContainingBranches._1;
-        var containingBranches = forkPointAndContainingBranches._2.toList();
+        val forkPoint = forkPointAndContainingBranches._1;
+        val containingBranches = forkPointAndContainingBranches._2.toList();
         LOG.debug(() -> "Commit ${forkPoint} found in filtered reflog(s) of ${containingBranches.mkString(\", \")}; " +
             "returning as fork point for branch '${branch.getFullName()}'");
         return ForkPointCommitOfManagedBranch.inferred(forkPoint, containingBranches);
@@ -632,7 +633,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         IGitCoreLocalBranchSnapshot parentCoreLocalBranch,
         List<IBranchLayoutEntry> entries) throws GitCoreException {
 
-      var childBranchTries = entries.map(entry -> Try.of(
+      val childBranchTries = entries.map(entry -> Try.of(
           () -> createGitMacheteNonRootBranch(parentCoreLocalBranch, entry)));
       return Try.sequence(childBranchTries)
           .getOrElseThrow(GitCoreException::getOrWrap)
@@ -702,7 +703,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         IGitCoreLocalBranchSnapshot coreLocalBranch,
         IGitCoreLocalBranchSnapshot parentCoreLocalBranch,
         @Nullable ForkPointCommitOfManagedBranch forkPoint) throws GitCoreException {
-      var branchName = coreLocalBranch.getName();
+      val branchName = coreLocalBranch.getName();
       LOG.debug(() -> "Entering: coreLocalBranch = '${branchName}', " +
           "parentCoreLocalBranch = '${parentCoreLocalBranch.getName()}', " +
           "forkPoint = ${forkPoint})");
@@ -725,7 +726,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           return SyncToParentStatus.MergedToParent;
         }
       } else {
-        var isParentAncestorOfChild = gitCoreRepository.isAncestor(
+        val isParentAncestorOfChild = gitCoreRepository.isAncestor(
             /* presumedAncestor */ parentPointedCommit, /* presumedDescendant */ pointedCommit);
 
         if (isParentAncestorOfChild) {
@@ -743,7 +744,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
             return SyncToParentStatus.InSyncButForkPointOff;
           }
         } else {
-          var isChildAncestorOfParent = gitCoreRepository.isAncestor(
+          val isChildAncestorOfParent = gitCoreRepository.isAncestor(
               /* presumedAncestor */ pointedCommit, /* presumedDescendant */ parentPointedCommit);
 
           if (isChildAncestorOfParent) {
@@ -847,10 +848,10 @@ public class GitMacheteRepository implements IGitMacheteRepository {
     private Map<String, Instant> deriveLastCheckoutTimestampByBranchName() throws GitCoreException {
       java.util.Map<String, Instant> result = new java.util.HashMap<>();
 
-      for (var reflogEntry : gitCoreRepository.deriveHead().getReflogFromMostRecent()) {
-        var checkoutEntry = reflogEntry.parseCheckout().getOrNull();
+      for (val reflogEntry : gitCoreRepository.deriveHead().getReflogFromMostRecent()) {
+        val checkoutEntry = reflogEntry.parseCheckout().getOrNull();
         if (checkoutEntry != null) {
-          var timestamp = reflogEntry.getTimestamp();
+          val timestamp = reflogEntry.getTimestamp();
           // `putIfAbsent` since we only care about the most recent occurrence of the given branch being checked out,
           // and we iterate over the reflog starting from the latest entries.
           result.putIfAbsent(checkoutEntry.getFromBranchName(), timestamp);
@@ -886,7 +887,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       } else {
         Map<String, Instant> lastCheckoutTimestampByBranchName = deriveLastCheckoutTimestampByBranchName();
 
-        var freshAndStaleNonFixedRootBranchNames = nonFixedRootBranchNames
+        val freshAndStaleNonFixedRootBranchNames = nonFixedRootBranchNames
             .sortBy(branchName -> lastCheckoutTimestampByBranchName.getOrElse(branchName, Instant.MIN))
             .reverse()
             .splitAt(mostRecentlyCheckedOutBranchesCount);
@@ -909,7 +910,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       List<MyBranchLayoutEntry> roots = entryByFixedRootBranchNames.values().toList();
 
       // Skipping the parent inference for fixed roots and for the stale non-fixed-root branches.
-      for (var branchEntry : entryByFreshNonFixedRootBranch.values()) {
+      for (val branchEntry : entryByFreshNonFixedRootBranch.values()) {
         // Note that stale non-fixed-root branches are never considered as candidates for the parent.
         Seq<String> parentCandidateNames = entryByIncludedBranchName.values()
             .filter(e -> e.getRoot() != branchEntry)
@@ -922,7 +923,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           String parentName = parent.getName();
           LOG.debug(() -> "Parent inferred for ${branchEntry.getName()} is ${parentName}");
 
-          var parentEntry = entryByIncludedBranchName.get(parentName).getOrNull();
+          val parentEntry = entryByIncludedBranchName.get(parentName).getOrNull();
           // Generally we expect an entry for parent to always be present.
           if (parentEntry != null) {
             branchEntry.attachUnder(parentEntry);
@@ -935,24 +936,24 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         }
       }
 
-      var NL = System.lineSeparator();
+      val NL = System.lineSeparator();
       LOG.debug(() -> "Final discovered entries: " + NL + entryByIncludedBranchName.values().mkString(NL));
 
       // Post-process the discovered layout to remove the branches that would both:
       // 1. have no child AND
       // 2. be merged to their respective parents.
-      for (var branchEntry : entryByFreshNonFixedRootBranch.values()) {
+      for (val branchEntry : entryByFreshNonFixedRootBranch.values()) {
         if (branchEntry.getChildren().nonEmpty()) {
           continue;
         }
 
-        var parentEntry = branchEntry.getParent();
+        val parentEntry = branchEntry.getParent();
         if (parentEntry == null) {
           // This will happen for the roots of the discovered layout.
           continue;
         }
-        var branch = localBranchByName.get(branchEntry.getName()).getOrNull();
-        var parentBranch = localBranchByName.get(parentEntry.getName()).getOrNull();
+        val branch = localBranchByName.get(branchEntry.getName()).getOrNull();
+        val parentBranch = localBranchByName.get(parentEntry.getName()).getOrNull();
         if (branch == null || parentBranch == null) {
           // This should never happen.
           continue;

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositoryCache.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositoryCache.java
@@ -5,6 +5,7 @@ import java.util.WeakHashMap;
 
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
+import lombok.val;
 
 import com.virtuslab.binding.RuntimeBinding;
 import com.virtuslab.gitcore.api.GitCoreException;
@@ -28,12 +29,12 @@ public class GitMacheteRepositoryCache implements IGitMacheteRepositoryCache {
 
   @Override
   public IGitMacheteRepository getInstance(Path mainDirectoryPath, Path gitDirectoryPath) throws GitMacheteException {
-    var key = Tuple.of(mainDirectoryPath, gitDirectoryPath);
+    val key = Tuple.of(mainDirectoryPath, gitDirectoryPath);
     if (!gitMacheteRepositoryCache.containsKey(key)) {
-      var gitCoreRepository = createGitCoreRepository(mainDirectoryPath, gitDirectoryPath);
-      var statusHookExecutor = new StatusBranchHookExecutor(gitCoreRepository, mainDirectoryPath, gitDirectoryPath);
-      var preRebaseHookExecutor = new PreRebaseHookExecutor(gitCoreRepository, mainDirectoryPath, gitDirectoryPath);
-      var value = new GitMacheteRepository(gitCoreRepository, statusHookExecutor, preRebaseHookExecutor);
+      val gitCoreRepository = createGitCoreRepository(mainDirectoryPath, gitDirectoryPath);
+      val statusHookExecutor = new StatusBranchHookExecutor(gitCoreRepository, mainDirectoryPath, gitDirectoryPath);
+      val preRebaseHookExecutor = new PreRebaseHookExecutor(gitCoreRepository, mainDirectoryPath, gitDirectoryPath);
+      val value = new GitMacheteRepository(gitCoreRepository, statusHookExecutor, preRebaseHookExecutor);
       gitMacheteRepositoryCache.put(key, value);
     }
     return gitMacheteRepositoryCache.get(key);

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/NonRootManagedBranchSnapshot.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/NonRootManagedBranchSnapshot.java
@@ -5,6 +5,7 @@ import io.vavr.control.Option;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.val;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -81,7 +82,7 @@ public final class NonRootManagedBranchSnapshot extends BaseManagedBranchSnapsho
     if (forkPoint == null) {
       throw new GitMacheteMissingForkPointException("Cannot get fork point for branch '${getName()}'");
     }
-    var newBaseBranch = getParent();
+    val newBaseBranch = getParent();
 
     LOG.debug(() -> "Inferred rebase parameters: currentBranch = ${getName()}, " +
         "newBaseCommit = ${newBaseBranch.getPointedCommit().getHash()}, " +

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/IntegrationTestUtils.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/IntegrationTestUtils.java
@@ -6,6 +6,8 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import lombok.SneakyThrows;
+import lombok.val;
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 
 class IntegrationTestUtils {
@@ -13,19 +15,19 @@ class IntegrationTestUtils {
   @SneakyThrows
   static void ensureExpectedCliVersion() {
     Properties prop = new Properties();
-    try (var inputStream = IntegrationTestUtils.class.getResourceAsStream("/reference-cli-version.properties")) {
+    try (val inputStream = IntegrationTestUtils.class.getResourceAsStream("/reference-cli-version.properties")) {
       prop.load(inputStream);
     }
     List<String> referenceCliVersions = Arrays.asList(prop.getProperty("referenceCliVersions").split(","));
 
-    var process = new ProcessBuilder().command("git", "machete", "--version").start();
+    val process = new ProcessBuilder().command("git", "machete", "--version").start();
     process.waitFor(1, TimeUnit.SECONDS);
-    var exitValue = process.exitValue();
+    val exitValue = process.exitValue();
     if (exitValue != 0) {
       Assert.fail("git-machete CLI is not installed");
     }
-    var version = new String(process.getInputStream().readAllBytes())
-        .stripTrailing()
+    val version = IOUtils.toString(process.getInputStream())
+        .trim()
         .replace("git-machete version ", "");
     if (!referenceCliVersions.contains(version)) {
       Assert.fail("git-machete is expected in one of versions ${referenceCliVersions}, found ${version}");

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/ParentInferenceIntegrationTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/integration/ParentInferenceIntegrationTestSuite.java
@@ -6,6 +6,7 @@ import static org.junit.runners.Parameterized.Parameters;
 import io.vavr.collection.Set;
 import io.vavr.control.Option;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -55,8 +56,8 @@ public class ParentInferenceIntegrationTestSuite extends BaseGitRepositoryBacked
     this.forBranch = forBranch;
     this.expectedParent = expectedParent;
 
-    var branchLayoutReader = RuntimeBinding.instantiateSoleImplementingClass(IBranchLayoutReader.class);
-    var branchLayout = branchLayoutReader.read(repositoryGitDir.resolve("machete"));
+    val branchLayoutReader = RuntimeBinding.instantiateSoleImplementingClass(IBranchLayoutReader.class);
+    val branchLayout = branchLayoutReader.read(repositoryGitDir.resolve("machete"));
 
     gitMacheteRepository = gitMacheteRepositoryCache.getInstance(repositoryMainDir, repositoryGitDir);
     gitMacheteRepositorySnapshot = gitMacheteRepository.createSnapshotForLayout(branchLayout);

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTestSuite.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.reflect.Whitebox;
 
@@ -31,13 +32,13 @@ public class BaseGitMacheteRepositoryUnitTestSuite {
   protected Object aux(IGitCoreBranchSnapshot... localCoreBranches) {
     PowerMockito.doReturn(List.ofAll(Arrays.stream(localCoreBranches))).when(gitCoreRepository).deriveAllLocalBranches();
 
-    var iGitCoreHeadSnapshot = PowerMockito.mock(IGitCoreHeadSnapshot.class);
+    val iGitCoreHeadSnapshot = PowerMockito.mock(IGitCoreHeadSnapshot.class);
     PowerMockito.doReturn(Option.none()).when(iGitCoreHeadSnapshot).getTargetBranch();
     PowerMockito.doReturn(iGitCoreHeadSnapshot).when(gitCoreRepository).deriveHead();
     PowerMockito.doReturn(Option.none()).when(gitCoreRepository).deriveConfigValue("core", "hooksPath");
 
     // cannot be mocked as it is final
-    var statusBranchHookExecutor = new StatusBranchHookExecutor(gitCoreRepository, Paths.get("void"), Paths.get("void"));
+    val statusBranchHookExecutor = new StatusBranchHookExecutor(gitCoreRepository, Paths.get("void"), Paths.get("void"));
 
     return Whitebox
         .getConstructor(AUX_CLASS, IGitCoreRepository.class, StatusBranchHookExecutor.class, PreRebaseHookExecutor.class)

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUnitTestSuite.java
@@ -7,6 +7,7 @@ import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
@@ -32,12 +33,12 @@ public class GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUn
   @Test
   public void singleBranch() {
     // given
-    var branchAndEntry = createBranchAndEntry("main", List.empty());
-    var branchLayout = PowerMockito.mock(IBranchLayout.class);
+    val branchAndEntry = createBranchAndEntry("main", List.empty());
+    val branchLayout = PowerMockito.mock(IBranchLayout.class);
     PowerMockito.doReturn(List.of(branchAndEntry.entry)).when(branchLayout).getRootEntries();
 
     // when
-    var repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
+    val repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
 
     // then
     Assert.assertEquals(List.of(branchAndEntry.entry).map(IBranchLayoutEntry::getName),
@@ -49,14 +50,14 @@ public class GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUn
   @Test
   public void duplicatedBranch() {
     // given
-    var mainBranchName = "main";
-    var duplicatedEntry = createEntry(mainBranchName, List.empty());
-    var branchAndEntry = createBranchAndEntry(mainBranchName, List.of(duplicatedEntry));
-    var branchLayout = PowerMockito.mock(IBranchLayout.class);
+    val mainBranchName = "main";
+    val duplicatedEntry = createEntry(mainBranchName, List.empty());
+    val branchAndEntry = createBranchAndEntry(mainBranchName, List.of(duplicatedEntry));
+    val branchLayout = PowerMockito.mock(IBranchLayout.class);
     PowerMockito.doReturn(List.of(branchAndEntry.entry)).when(branchLayout).getRootEntries();
 
     // when
-    var repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
+    val repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
 
     // then
     Assert.assertEquals(
@@ -69,14 +70,14 @@ public class GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUn
   @Test
   public void skippedBranch() {
     // given
-    var skippedBranchName = "skipped";
-    var skippedEntry = createEntry(skippedBranchName, List.empty());
-    var branchAndEntry = createBranchAndEntry("main", List.of(skippedEntry));
-    var branchLayout = PowerMockito.mock(IBranchLayout.class);
+    val skippedBranchName = "skipped";
+    val skippedEntry = createEntry(skippedBranchName, List.empty());
+    val branchAndEntry = createBranchAndEntry("main", List.of(skippedEntry));
+    val branchLayout = PowerMockito.mock(IBranchLayout.class);
     PowerMockito.doReturn(List.of(branchAndEntry.entry)).when(branchLayout).getRootEntries();
 
     // when
-    var repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
+    val repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
 
     // then
     Assert.assertEquals(
@@ -89,15 +90,15 @@ public class GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUn
   @Test
   public void sameBranchDuplicatedAndSkipped() {
     // given
-    var duplicatedAndSkippedBranchName = "duplicatedAndSkipped";
-    var duplicatedAndSkippedBranchName2 = createEntry(duplicatedAndSkippedBranchName, List.empty());
-    var duplicatedAndSkippedBranchName1 = createEntry(duplicatedAndSkippedBranchName, List.of(duplicatedAndSkippedBranchName2));
-    var branchAndEntry = createBranchAndEntry("main", List.of(duplicatedAndSkippedBranchName1));
-    var branchLayout = PowerMockito.mock(IBranchLayout.class);
+    val duplicatedAndSkippedBranchName = "duplicatedAndSkipped";
+    val duplicatedAndSkippedBranchName2 = createEntry(duplicatedAndSkippedBranchName, List.empty());
+    val duplicatedAndSkippedBranchName1 = createEntry(duplicatedAndSkippedBranchName, List.of(duplicatedAndSkippedBranchName2));
+    val branchAndEntry = createBranchAndEntry("main", List.of(duplicatedAndSkippedBranchName1));
+    val branchLayout = PowerMockito.mock(IBranchLayout.class);
     PowerMockito.doReturn(List.of(branchAndEntry.entry)).when(branchLayout).getRootEntries();
 
     // when
-    var repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
+    val repositorySnapshot = invokeCreateSnapshot(branchLayout, branchAndEntry.branch);
 
     // then
     Assert.assertEquals(
@@ -108,15 +109,15 @@ public class GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranchesUn
   }
 
   private BranchAndEntry createBranchAndEntry(String name, List<IBranchLayoutEntry> childEntries) {
-    var entry = createEntry(name, childEntries);
-    var commit = createGitCoreCommit();
-    var branch = createGitCoreLocalBranch(commit);
+    val entry = createEntry(name, childEntries);
+    val commit = createGitCoreCommit();
+    val branch = createGitCoreLocalBranch(commit);
     PowerMockito.doReturn(name).when(branch).getName();
     return new BranchAndEntry(branch, entry);
   }
 
   private IBranchLayoutEntry createEntry(String name, List<IBranchLayoutEntry> childEntries) {
-    var entry = PowerMockito.mock(IBranchLayoutEntry.class);
+    val entry = PowerMockito.mock(IBranchLayoutEntry.class);
     PowerMockito.doReturn(name).when(entry).getName();
     PowerMockito.doReturn(Option.none()).when(entry).getCustomAnnotation();
     PowerMockito.doReturn(childEntries).when(entry).getChildren();

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite.java
@@ -6,6 +6,7 @@ import java.time.temporal.ChronoUnit;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
@@ -69,7 +70,7 @@ public class GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite extends 
 
     PowerMockito.doReturn(coreLocalBranchCommit).when(coreLocalBranch).getPointedCommit();
     PowerMockito.doReturn(coreRemoteBranchCommit).when(coreRemoteBranch).getPointedCommit();
-    var relativeCommitCount = GitCoreRelativeCommitCount.of(1, 1);
+    val relativeCommitCount = GitCoreRelativeCommitCount.of(1, 1);
     PowerMockito.doReturn(Option.some(relativeCommitCount)).when(gitCoreRepository)
         .deriveRelativeCommitCount(coreLocalBranchCommit, coreRemoteBranchCommit);
 
@@ -95,7 +96,7 @@ public class GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite extends 
 
     PowerMockito.doReturn(coreLocalBranchCommit).when(coreLocalBranch).getPointedCommit();
     PowerMockito.doReturn(coreRemoteBranchCommit).when(coreRemoteBranch).getPointedCommit();
-    var relativeCommitCount = GitCoreRelativeCommitCount.of(1, 2);
+    val relativeCommitCount = GitCoreRelativeCommitCount.of(1, 2);
     PowerMockito.doReturn(Option.some(relativeCommitCount)).when(gitCoreRepository)
         .deriveRelativeCommitCount(coreLocalBranchCommit, coreRemoteBranchCommit);
 
@@ -121,7 +122,7 @@ public class GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite extends 
 
     PowerMockito.doReturn(coreLocalBranchCommit).when(coreLocalBranch).getPointedCommit();
     PowerMockito.doReturn(coreRemoteBranchCommit).when(coreRemoteBranch).getPointedCommit();
-    var relativeCommitCount = GitCoreRelativeCommitCount.of(2, 1);
+    val relativeCommitCount = GitCoreRelativeCommitCount.of(2, 1);
     PowerMockito.doReturn(Option.some(relativeCommitCount)).when(gitCoreRepository)
         .deriveRelativeCommitCount(coreLocalBranchCommit, coreRemoteBranchCommit);
 
@@ -146,7 +147,7 @@ public class GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite extends 
 
     PowerMockito.doReturn(coreLocalBranchCommit).when(coreLocalBranch).getPointedCommit();
     PowerMockito.doReturn(coreRemoteBranchCommit).when(coreRemoteBranch).getPointedCommit();
-    var relativeCommitCount = GitCoreRelativeCommitCount.of(3, 0);
+    val relativeCommitCount = GitCoreRelativeCommitCount.of(3, 0);
     PowerMockito.doReturn(Option.some(relativeCommitCount)).when(gitCoreRepository)
         .deriveRelativeCommitCount(coreLocalBranchCommit, coreRemoteBranchCommit);
 
@@ -167,7 +168,7 @@ public class GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite extends 
 
     PowerMockito.doReturn(coreLocalBranchCommit).when(coreLocalBranch).getPointedCommit();
     PowerMockito.doReturn(coreRemoteBranchCommit).when(coreRemoteBranch).getPointedCommit();
-    var relativeCommitCount = GitCoreRelativeCommitCount.of(0, 3);
+    val relativeCommitCount = GitCoreRelativeCommitCount.of(0, 3);
     PowerMockito.doReturn(Option.some(relativeCommitCount)).when(gitCoreRepository)
         .deriveRelativeCommitCount(coreLocalBranchCommit, coreRemoteBranchCommit);
 
@@ -188,7 +189,7 @@ public class GitMacheteRepository_deriveSyncToRemoteStatusUnitTestSuite extends 
 
     PowerMockito.doReturn(coreLocalBranchCommit).when(coreLocalBranch).getPointedCommit();
     PowerMockito.doReturn(coreRemoteBranchCommit).when(coreRemoteBranch).getPointedCommit();
-    var relativeCommitCount = GitCoreRelativeCommitCount.of(0, 0);
+    val relativeCommitCount = GitCoreRelativeCommitCount.of(0, 0);
     PowerMockito.doReturn(Option.some(relativeCommitCount)).when(gitCoreRepository)
         .deriveRelativeCommitCount(coreLocalBranchCommit, coreRemoteBranchCommit);
 

--- a/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/UnitTestUtils.java
+++ b/backendImpl/src/test/java/com/virtuslab/gitmachete/backend/unit/UnitTestUtils.java
@@ -47,7 +47,7 @@ class UnitTestUtils {
 
     @Override
     public String getHashString() {
-      return String.valueOf(id).repeat(40);
+      return String.format("%40d", id);
     }
 
     @Override

--- a/binding/src/main/java/com/virtuslab/binding/RuntimeBinding.java
+++ b/binding/src/main/java/com/virtuslab/binding/RuntimeBinding.java
@@ -4,6 +4,7 @@ import java.util.stream.Collectors;
 
 import lombok.CustomLog;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.reflections.Reflections;
 
 @CustomLog
@@ -34,13 +35,13 @@ public final class RuntimeBinding {
       throw new ClassNotFoundException("No viable class implementing " + interfaze.getCanonicalName() + " found");
     }
     if (classes.size() > 1) {
-      var classesString = String.join(", ",
+      val classesString = String.join(", ",
           classes.stream().map(c -> String.valueOf(c.getCanonicalName())).collect(Collectors.toSet()));
       throw new ClassNotFoundException(
           "More than one viable class implementing " + interfaze.getCanonicalName() + " found: " + classesString);
     }
 
-    var soleImplementingClass = classes.iterator().next();
+    val soleImplementingClass = classes.iterator().next();
     LOG.debug(() -> "Binding " + interfaze.getCanonicalName() + " to " + soleImplementingClass.getCanonicalName());
     return soleImplementingClass.getDeclaredConstructor().newInstance();
   }

--- a/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
+++ b/branchLayoutApi/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
@@ -5,6 +5,7 @@ import io.vavr.collection.List;
 import io.vavr.collection.Map;
 import io.vavr.control.Option;
 import lombok.Getter;
+import lombok.val;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 
 @UsesObjectEquals
@@ -37,7 +38,7 @@ public class BranchLayout implements IBranchLayout {
   }
 
   private List<IBranchLayoutEntry> slideOut(IBranchLayoutEntry entry, String entryNameToSlideOut) {
-    var children = entry.getChildren();
+    val children = entry.getChildren();
     if (entry.getName().equals(entryNameToSlideOut)) {
       return children;
     } else {
@@ -48,12 +49,12 @@ public class BranchLayout implements IBranchLayout {
   @Override
   public IBranchLayout slideIn(String parentBranchName, IBranchLayoutEntry entryToSlideIn)
       throws EntryDoesNotExistException, EntryIsDescendantOfException {
-    var parentEntry = findEntryByName(parentBranchName).getOrNull();
+    val parentEntry = findEntryByName(parentBranchName).getOrNull();
     if (parentEntry == null) {
       throw new EntryDoesNotExistException("Parent branch entry '${parentBranchName}' does not exist");
     }
-    var entry = findEntryByName(entryToSlideIn.getName());
-    var entryAlreadyExists = entry.isDefined();
+    val entry = findEntryByName(entryToSlideIn.getName());
+    val entryAlreadyExists = entry.isDefined();
 
     if (entry.map(e -> isDescendant(/* presumedAncestor */ e, /* presumedDescendant */ parentEntry)).getOrElse(false)) {
       throw new EntryIsDescendantOfException(
@@ -62,7 +63,7 @@ public class BranchLayout implements IBranchLayout {
           /* ancestor */ entryToSlideIn);
     }
 
-    var newRootEntries = entryAlreadyExists
+    val newRootEntries = entryAlreadyExists
         ? removeEntry(/* branchLayout */ this, entryToSlideIn.getName())
         : rootEntries;
     return new BranchLayout(newRootEntries.map(rootEntry -> slideIn(rootEntry, entryToSlideIn, parentEntry)));
@@ -77,7 +78,7 @@ public class BranchLayout implements IBranchLayout {
   }
 
   private static List<IBranchLayoutEntry> removeEntry(IBranchLayout branchLayout, String branchName) {
-    var rootEntries = branchLayout.getRootEntries();
+    val rootEntries = branchLayout.getRootEntries();
     if (rootEntries.map(e -> e.getName()).exists(name -> name.equals(branchName))) {
       return rootEntries.reject(e -> e.getName().equals(branchName));
     } else {
@@ -94,7 +95,7 @@ public class BranchLayout implements IBranchLayout {
       IBranchLayoutEntry entry,
       IBranchLayoutEntry entryToSlideIn,
       IBranchLayoutEntry parent) {
-    var children = entry.getChildren();
+    val children = entry.getChildren();
     if (entry.getName().equals(parent.getName())) {
       return entry.withChildren(children.append(entryToSlideIn));
     } else {

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReader.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReader.java
@@ -7,6 +7,7 @@ import io.vavr.Tuple2;
 import io.vavr.collection.Array;
 import io.vavr.collection.List;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.index.qual.GTENegativeOne;
 import org.checkerframework.checker.index.qual.NonNegative;
 
@@ -30,7 +31,7 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
         "code = ${(int)indentSpec.getIndentCharacter()} and indent width = ${indentSpec.getIndentWidth()}");
 
     List<String> lines = BranchLayoutFileUtils.readFileLines(path);
-    List<String> linesWithoutBlank = lines.reject(String::isBlank);
+    List<String> linesWithoutBlank = lines.reject(line -> line.trim().isEmpty());
 
     LOG.debug(() -> "${lines.length()} line(s) found");
 
@@ -91,7 +92,7 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
       customAnnotation = null;
     }
 
-    var result = new BranchLayoutEntry(branchName, customAnnotation, children);
+    val result = new BranchLayoutEntry(branchName, customAnnotation, children);
     LOG.debug(() -> "Created ${result}");
     return result;
   }
@@ -103,7 +104,7 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
   private Array<Tuple2<Integer, Integer>> parseToArrayRepresentation(Path path, IndentSpec indentSpec, List<String> lines)
       throws BranchLayoutException {
 
-    List<String> linesWithoutBlank = lines.reject(String::isBlank);
+    List<String> linesWithoutBlank = lines.reject(line -> line.trim().isEmpty());
 
     if (linesWithoutBlank.nonEmpty() && BranchLayoutFileUtils.getIndentWidth(linesWithoutBlank.head(),
         indentSpec.getIndentCharacter()) > 0) {
@@ -121,7 +122,7 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
     int lineIndex = 0;
     for (int realLineNumber = 0; realLineNumber < lines.length(); ++realLineNumber) {
       String line = lines.get(realLineNumber);
-      if (line.isBlank()) {
+      if (line.trim().isEmpty()) {
         // Can't use lambda because `realLineNumber` is not effectively final
         LOG.debug("Line no ${realLineNumber + 1} is blank. Skipping");
         continue;

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileUtils.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileUtils.java
@@ -10,6 +10,7 @@ import io.vavr.collection.List;
 import io.vavr.collection.Stream;
 import io.vavr.control.Try;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
 
@@ -29,7 +30,7 @@ public final class BranchLayoutFileUtils {
   }
 
   public static @NonNegative int getIndentWidth(String line, char indentCharacter) {
-    return (int) line.chars().takeWhile(c -> c == indentCharacter).count();
+    return Stream.ofAll(line.chars().boxed()).takeWhile(c -> c == indentCharacter).size();
   }
 
   public static IndentSpec deriveIndentSpec(Path path) {
@@ -43,7 +44,7 @@ public final class BranchLayoutFileUtils {
 
     LOG.debug(() -> "${lines.length()} line(s) found");
 
-    var firstLineWithBlankPrefixOption = lines.reject(String::isBlank)
+    val firstLineWithBlankPrefixOption = lines.reject(line -> line.trim().isEmpty())
         .find(line -> line.startsWith(String.valueOf(SPACE))
             || line.startsWith(String.valueOf(TAB)));
     char indentCharacter = BranchLayoutFileUtils.DEFAULT_INDENT_CHARACTER;

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileWriter.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileWriter.java
@@ -53,7 +53,8 @@ public class BranchLayoutFileWriter implements IBranchLayoutWriter {
     List<String> stringList = List.empty();
     for (val entry : entries) {
       val sb = new StringBuilder();
-      for (int i = 0; i < level * indentSpec.getIndentWidth(); i++) {
+      val count = level * indentSpec.getIndentWidth();
+      for (int i = 0; i < count; i++) {
         sb.append(indentSpec.getIndentCharacter());
       }
       sb.append(entry.getName());

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileWriter.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileWriter.java
@@ -9,6 +9,7 @@ import io.vavr.control.Option;
 import io.vavr.control.Try;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.checkerframework.checker.index.qual.NonNegative;
 
 import com.virtuslab.branchlayout.api.BranchLayoutException;
@@ -23,9 +24,9 @@ public class BranchLayoutFileWriter implements IBranchLayoutWriter {
   @Override
   public void write(Path path, IBranchLayout branchLayout, boolean backupOldFile) throws BranchLayoutException {
     LOG.debug(() -> "Entering: path = ${path}, branchLayout = ${branchLayout}, backupOldFile = ${backupOldFile}");
-    var indentSpec = BranchLayoutFileUtils.deriveIndentSpec(path);
+    val indentSpec = BranchLayoutFileUtils.deriveIndentSpec(path);
 
-    var lines = printEntriesOntoStringList(branchLayout.getRootEntries(), indentSpec, /* level */ 0);
+    val lines = printEntriesOntoStringList(branchLayout.getRootEntries(), indentSpec, /* level */ 0);
 
     if (backupOldFile && Files.isRegularFile(path)) {
       Path parentDir = path.getParent();
@@ -50,10 +51,12 @@ public class BranchLayoutFileWriter implements IBranchLayoutWriter {
       @NonNegative int level) {
 
     List<String> stringList = List.empty();
-    for (var entry : entries) {
-      var sb = new StringBuilder();
-      sb.append(String.valueOf(indentSpec.getIndentCharacter()).repeat(level * indentSpec.getIndentWidth()))
-          .append(entry.getName());
+    for (val entry : entries) {
+      val sb = new StringBuilder();
+      for (int i = 0; i < level * indentSpec.getIndentWidth(); i++) {
+        sb.append(indentSpec.getIndentCharacter());
+      }
+      sb.append(entry.getName());
       Option<String> customAnnotation = entry.getCustomAnnotation();
       if (customAnnotation.isDefined()) {
         sb.append(" ").append(customAnnotation.get());

--- a/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutFileReaderTestSuite.java
+++ b/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutFileReaderTestSuite.java
@@ -1,5 +1,6 @@
 package com.virtuslab.branchlayout.unit;
 
+import static com.virtuslab.branchlayout.impl.readwrite.BranchLayoutFileUtils.DEFAULT_INDENT_CHARACTER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
@@ -35,7 +36,7 @@ public class BranchLayoutFileReaderTestSuite {
     BranchLayoutFileReader reader = new BranchLayoutFileReader();
 
     PowerMockito.mockStatic(BranchLayoutFileUtils.class);
-    val indentSpec = new IndentSpec(/* indentCharacter */ ' ', indentWidth);
+    val indentSpec = new IndentSpec(/* indentCharacter */ DEFAULT_INDENT_CHARACTER, indentWidth);
     PowerMockito.when(BranchLayoutFileUtils.getDefaultSpec()).thenReturn(indentSpec);
     PowerMockito.when(BranchLayoutFileUtils.readFileLines(any())).thenReturn(linesToReturn);
     PowerMockito.when(BranchLayoutFileUtils.getIndentWidth(anyString(), anyChar())).thenCallRealMethod();

--- a/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutFileReaderTestSuite.java
+++ b/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutFileReaderTestSuite.java
@@ -6,9 +6,11 @@ import static org.mockito.ArgumentMatchers.*;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import io.vavr.collection.List;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,14 +28,14 @@ import com.virtuslab.branchlayout.impl.readwrite.IndentSpec;
 @PrepareForTest({BranchLayoutFileUtils.class, Files.class})
 public class BranchLayoutFileReaderTestSuite {
 
-  private final Path path = Path.of("");
+  private final Path path = Paths.get("");
 
   @SneakyThrows
   private BranchLayoutFileReader getBranchLayoutFileReaderForLines(List<String> linesToReturn, int indentWidth) {
     BranchLayoutFileReader reader = new BranchLayoutFileReader();
 
     PowerMockito.mockStatic(BranchLayoutFileUtils.class);
-    var indentSpec = new IndentSpec(/* indentCharacter */ ' ', indentWidth);
+    val indentSpec = new IndentSpec(/* indentCharacter */ ' ', indentWidth);
     PowerMockito.when(BranchLayoutFileUtils.getDefaultSpec()).thenReturn(indentSpec);
     PowerMockito.when(BranchLayoutFileUtils.readFileLines(any())).thenReturn(linesToReturn);
     PowerMockito.when(BranchLayoutFileUtils.getIndentWidth(anyString(), anyChar())).thenCallRealMethod();

--- a/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutTestSuite.java
+++ b/branchLayoutImpl/src/test/java/com/virtuslab/branchlayout/unit/BranchLayoutTestSuite.java
@@ -3,6 +3,7 @@ package com.virtuslab.branchlayout.unit;
 import static org.junit.Assert.assertEquals;
 
 import io.vavr.collection.List;
+import lombok.val;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,9 +33,9 @@ public class BranchLayoutTestSuite {
         new BranchLayoutEntry(childName0, /* customAnnotation */ null, List.empty()),
         new BranchLayoutEntry(childName1, /* customAnnotation */ null, List.empty()));
 
-    var entry = new BranchLayoutEntry(branchToSlideOutName, /* customAnnotation */ null, childBranches);
-    var rootEntry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, List.of(entry));
-    var branchLayoutFile = new BranchLayout(List.of(rootEntry));
+    val entry = new BranchLayoutEntry(branchToSlideOutName, /* customAnnotation */ null, childBranches);
+    val rootEntry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, List.of(entry));
+    val branchLayoutFile = new BranchLayout(List.of(rootEntry));
 
     // when
     IBranchLayout result = branchLayoutFile.slideOut(branchToSlideOutName);
@@ -42,7 +43,7 @@ public class BranchLayoutTestSuite {
     // then
     assertEquals(result.getRootEntries().size(), 1);
     assertEquals(result.getRootEntries().get(0).getName(), rootName);
-    var children = result.getRootEntries().get(0).getChildren();
+    val children = result.getRootEntries().get(0).getChildren();
     assertEquals(children.size(), 2);
     assertEquals(children.get(0).getName(), childName0);
     assertEquals(children.get(1).getName(), childName1);
@@ -64,8 +65,8 @@ public class BranchLayoutTestSuite {
         new BranchLayoutEntry(branchToSlideOutName, /* customAnnotation */ null, List.empty()),
         new BranchLayoutEntry(branchToSlideOutName, /* customAnnotation */ null, List.empty()));
 
-    var rootEntry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, childBranches);
-    var branchLayoutFile = new BranchLayout(List.of(rootEntry));
+    val rootEntry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, childBranches);
+    val branchLayoutFile = new BranchLayout(List.of(rootEntry));
 
     // when
     IBranchLayout result = branchLayoutFile.slideOut(branchToSlideOutName);
@@ -73,7 +74,7 @@ public class BranchLayoutTestSuite {
     // then
     assertEquals(result.getRootEntries().size(), 1);
     assertEquals(result.getRootEntries().get(0).getName(), rootName);
-    var children = result.getRootEntries().get(0).getChildren();
+    val children = result.getRootEntries().get(0).getChildren();
     assertEquals(children.size(), 0);
   }
 
@@ -94,8 +95,8 @@ public class BranchLayoutTestSuite {
         new BranchLayoutEntry(childName0, /* customAnnotation */ null, List.empty()),
         new BranchLayoutEntry(childName1, /* customAnnotation */ null, List.empty()));
 
-    var entry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, childBranches);
-    var branchLayoutFile = new BranchLayout(List.of(entry));
+    val entry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, childBranches);
+    val branchLayoutFile = new BranchLayout(List.of(entry));
 
     // when
     IBranchLayout result = branchLayoutFile.slideOut(rootName);
@@ -109,12 +110,12 @@ public class BranchLayoutTestSuite {
   @Test
   public void withBranchSlideOut_givenSingleRootBranch_throwsException() {
     // given
-    var rootName = "root";
+    val rootName = "root";
     IBranchLayoutEntry entry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, List.empty());
-    var branchLayoutFile = new BranchLayout(List.of(entry));
+    val branchLayoutFile = new BranchLayout(List.of(entry));
 
     // when
-    var result = branchLayoutFile.slideOut(rootName);
+    val result = branchLayoutFile.slideOut(rootName);
 
     // then
     assertEquals(result.getRootEntries().size(), 0);
@@ -123,14 +124,14 @@ public class BranchLayoutTestSuite {
   @Test
   public void withBranchSlideOut_givenTwoRootBranches_throwsException() {
     // given
-    var rootName = "root";
-    var masterRootName = "master";
+    val rootName = "root";
+    val masterRootName = "master";
     IBranchLayoutEntry entry = new BranchLayoutEntry(rootName, /* customAnnotation */ null, List.empty());
     IBranchLayoutEntry masterEntry = new BranchLayoutEntry(masterRootName, /* customAnnotation */ null, List.empty());
-    var branchLayoutFile = new BranchLayout(List.of(entry, masterEntry));
+    val branchLayoutFile = new BranchLayout(List.of(entry, masterEntry));
 
     // when
-    var result = branchLayoutFile.slideOut(rootName);
+    val result = branchLayoutFile.slideOut(rootName);
 
     // then
     assertEquals(result.getRootEntries().size(), 1);
@@ -140,8 +141,8 @@ public class BranchLayoutTestSuite {
   @Test
   public void withBranchSlideOut_givenNonExistingBranch_noExceptionThrown() {
     // given
-    var branchToSlideOutName = "branch";
-    var branchLayoutFile = new BranchLayout(List.empty());
+    val branchToSlideOutName = "branch";
+    val branchLayoutFile = new BranchLayout(List.empty());
 
     // when
     branchLayoutFile.slideOut(branchToSlideOutName);

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ ext {
   betterStringsVersion = '0.5'
   checkerFrameworkVersion = '3.10.0'
   checkstyleToolVersion = '8.33'
+  commonsIOVersion = '2.5'
   ideProbeVersion = '0.3.0'
   jetbrainsAnnotationsVersion = '19.0.0' // version effectively enforced by the IntelliJ plugin
   jgitVersion = '5.10.0.202012080955-r'
@@ -140,7 +141,7 @@ allprojects {
 
 
   apply plugin: 'org.gradle.java-library'
-  sourceCompatibility = 11
+  sourceCompatibility = 8
 
   // String interpolation support, see https://github.com/antkorwin/better-strings
   // This needs to be enabled in each subproject by default because there's going to be no warning
@@ -159,6 +160,7 @@ allprojects {
         '-Werror', // Treat each compiler warning (esp. the ones coming from Checker Framework) as an error.
         '-Xlint:unchecked', // Warn of type-unsafe operations on generics.
       ]
+      options.release = 8
       options.forkOptions.jvmArgs += jvmArgsForJavaCompilation ?: (isCI ? [] : ['-Xmx6g', '-XX:+HeapDumpOnOutOfMemoryError'])
     }
 
@@ -334,6 +336,12 @@ subprojects {
           def qualClassDir = project(':qual').sourceSets.main.output.classesDirs.asPath
           extraJavacArgs += "-ASubtypingChecker_qualDirs=${qualClassDir}"
         }
+      }
+    }
+
+    commonsIO = { ->
+      dependencies {
+        implementation group: 'commons-io', name: 'commons-io', version: commonsIOVersion
       }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,13 @@ allprojects {
 
 
   apply plugin: 'org.gradle.java-library'
-  sourceCompatibility = 8
+
+  // We've consciously downgraded Java from 11 to 8 to provide compatibility with Android Studio,
+  // which as of 2020.3 still executes on Java 8-based runtime.
+  def javaMajorVersion = 8
+
+  sourceCompatibility = javaMajorVersion
+  targetCompatibility = javaMajorVersion // redundant, added for clarity
 
   // String interpolation support, see https://github.com/antkorwin/better-strings
   // This needs to be enabled in each subproject by default because there's going to be no warning
@@ -160,8 +166,17 @@ allprojects {
         '-Werror', // Treat each compiler warning (esp. the ones coming from Checker Framework) as an error.
         '-Xlint:unchecked', // Warn of type-unsafe operations on generics.
       ]
-      options.release = 8
+
       options.forkOptions.jvmArgs += jvmArgsForJavaCompilation ?: (isCI ? [] : ['-Xmx6g', '-XX:+HeapDumpOnOutOfMemoryError'])
+
+      // `sourceCompatibility` and `targetCompatibility` say nothing about the Java APIs available to the compiled code.
+      // In fact, it's perfectly possible to compile Java 8 code that uses Java 11 APIs...
+      // This will work fine, until we actually try to run those compiled classes under Java 8-compatible JVM,
+      // when we'll end up with NoSuchMethodError for APIs added between Java 9 and Java 11
+      // (most notably, InputStream#readAllBytes, Stream#takeWhile and String#isBlank).
+      // `options.release = 8` makes sure that regardless of Java version installed in the system,
+      // only Java 8-compatible APIs are available to the compiled code.
+      options.release = javaMajorVersion
     }
 
     tasks.withType(Javadoc) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/FetchBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/FetchBackgroundable.java
@@ -9,6 +9,7 @@ import git4idea.fetch.GitFetchSupport;
 import git4idea.repo.GitRemote;
 import git4idea.repo.GitRepository;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -64,8 +65,8 @@ public class FetchBackgroundable extends Task.Backgroundable {
       // This method set a text under a progress bar (despite of docstring)
       indicator.setText(taskSubtitle);
     }
-    var fetchSupport = GitFetchSupport.fetchSupport(project);
-    var remote = remoteName.equals(LOCAL_REPOSITORY_NAME)
+    val fetchSupport = GitFetchSupport.fetchSupport(project);
+    GitRemote remote = remoteName.equals(LOCAL_REPOSITORY_NAME)
         ? GitRemote.DOT
         : GitUtil.findRemoteByName(gitRepository, remoteName);
     if (remote == null) {
@@ -74,7 +75,7 @@ public class FetchBackgroundable extends Task.Backgroundable {
       LOG.warn("Remote '${remoteName}' does not exist");
       return;
     }
-    var fetchResult = fetchSupport.fetch(gitRepository, remote, refspec);
+    val fetchResult = fetchSupport.fetch(gitRepository, remote, refspec);
     fetchResult.showNotificationIfFailed(failureNotificationText);
     fetchResult.throwExceptionIfFailed();
   }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
@@ -45,6 +45,7 @@ import git4idea.util.GitUntrackedFilesHelper;
 import git4idea.util.LocalChangesWouldBeOverwrittenHelper;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -75,12 +76,12 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
   @Override
   @UIThreadUnsafe
   public final void run(ProgressIndicator indicator) {
-    var handler = createGitLineHandler();
+    val handler = createGitLineHandler();
     if (handler == null) {
       return;
     }
-    var localChangesDetector = new GitLocalChangesWouldBeOverwrittenDetector(gitRepository.getRoot(), MERGE);
-    var untrackedFilesDetector = new GitUntrackedFilesOverwrittenByOperationDetector(gitRepository.getRoot());
+    val localChangesDetector = new GitLocalChangesWouldBeOverwrittenDetector(gitRepository.getRoot(), MERGE);
+    val untrackedFilesDetector = new GitUntrackedFilesOverwrittenByOperationDetector(gitRepository.getRoot());
     handler.addLineListener(localChangesDetector);
     handler.addLineListener(untrackedFilesDetector);
 
@@ -107,7 +108,7 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
   @UIThreadUnsafe
   private @Nullable GitUpdatedRanges deriveGitUpdatedRanges(String remoteBranchName) {
     GitUpdatedRanges updatedRanges = null;
-    var currentBranch = gitRepository.getCurrentBranch();
+    val currentBranch = gitRepository.getCurrentBranch();
     if (currentBranch != null) {
       GitBranch targetBranch = gitRepository.getBranches().findBranchByName(remoteBranchName);
       if (targetBranch != null) {
@@ -136,7 +137,7 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
       if (updatedRanges != null &&
           AbstractCommonUpdateAction
               .showsCustomNotification(java.util.Collections.singletonList(GitVcs.getInstance(project)))) {
-        var ranges = updatedRanges.calcCurrentPositions();
+        val ranges = updatedRanges.calcCurrentPositions();
         GitUpdateInfoAsLog.NotificationData notificationData = new GitUpdateInfoAsLog(project, ranges)
             .calculateDataAndCreateLogTab();
 
@@ -181,7 +182,7 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
           /* description */ null);
 
     } else {
-      var notifier = VcsNotifier.getInstance(project);
+      val notifier = VcsNotifier.getInstance(project);
       notifier.notifyError(
           format(getString("action.GitMachete.GitCommandUpdatingCurrentBranchBackgroundable.notification.title.update-fail"),
               getOperationName()),
@@ -197,11 +198,11 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
       Project project, GitRepository repository, GitRevisionNumber start) {
     try {
       // Proper solution for 2020.2+
-      var constructor = MergeChangeCollector.class.getConstructor(Project.class, GitRepository.class, GitRevisionNumber.class);
+      val constructor = MergeChangeCollector.class.getConstructor(Project.class, GitRepository.class, GitRevisionNumber.class);
       return constructor.newInstance(project, repository, start);
     } catch (NoSuchMethodException e) {
       // Fallback for 2020.1 (also available on 2020.2, but scheduled for removal in 2020.3)
-      var constructor = MergeChangeCollector.class.getConstructor(Project.class, VirtualFile.class, GitRevisionNumber.class);
+      val constructor = MergeChangeCollector.class.getConstructor(Project.class, VirtualFile.class, GitRevisionNumber.class);
       return constructor.newInstance(project, repository.getRoot(), start);
     }
   }
@@ -211,11 +212,11 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
     try {
       UpdatedFiles files = UpdatedFiles.create();
 
-      var collector = createMergeChangeCollector(project, gitRepository, currentRev);
+      val collector = createMergeChangeCollector(project, gitRepository, currentRev);
       collector.collect(files);
 
       GuiUtils.invokeLaterIfNeeded(() -> {
-        var manager = ProjectLevelVcsManagerEx.getInstanceEx(project);
+        val manager = ProjectLevelVcsManagerEx.getInstanceEx(project);
         UpdateInfoTree tree = manager.showUpdateProjectInfo(files, getOperationName(), ActionInfo.UPDATE, /* canceled */ false);
         if (tree != null) {
           tree.setBefore(beforeLabel);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/MergeCurrentBranchFastForwardOnlyBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/MergeCurrentBranchFastForwardOnlyBackgroundable.java
@@ -7,6 +7,7 @@ import git4idea.commands.GitCommand;
 import git4idea.commands.GitLineHandler;
 import git4idea.repo.GitRepository;
 import lombok.Getter;
+import lombok.val;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -34,7 +35,7 @@ public class MergeCurrentBranchFastForwardOnlyBackgroundable extends GitCommandU
   @Override
   @UIThreadUnsafe
   protected @Nullable GitLineHandler createGitLineHandler() {
-    var handler = new GitLineHandler(project, gitRepository.getRoot(), GitCommand.MERGE);
+    val handler = new GitLineHandler(project, gitRepository.getRoot(), GitCommand.MERGE);
     handler.addParameters("--ff-only");
     handler.addParameters(targetBranchName);
     return handler;

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/PullCurrentBranchFastForwardOnlyBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/PullCurrentBranchFastForwardOnlyBackgroundable.java
@@ -10,6 +10,7 @@ import git4idea.commands.GitLineHandler;
 import git4idea.repo.GitRemote;
 import git4idea.repo.GitRepository;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -43,7 +44,7 @@ public class PullCurrentBranchFastForwardOnlyBackgroundable extends GitCommandUp
   @Override
   @UIThreadUnsafe
   protected @Nullable GitLineHandler createGitLineHandler() {
-    var handler = new GitLineHandler(project, gitRepository.getRoot(), GitCommand.PULL);
+    val handler = new GitLineHandler(project, gitRepository.getRoot(), GitCommand.PULL);
     String remoteName = remoteBranch.getRemoteName();
     GitRemote remote = GitUtil.findRemoteByName(gitRepository, remoteName);
     if (remote == null) {
@@ -55,8 +56,8 @@ public class PullCurrentBranchFastForwardOnlyBackgroundable extends GitCommandUp
     handler.setUrls(remote.getUrls());
     handler.addParameters("--ff-only");
     handler.addParameters(remote.getName());
-    var remoteBranchFullNameAsLocalBranchOnRemote = remoteBranch.getFullNameAsLocalBranchOnRemote();
-    var remoteBranchFullName = remoteBranch.getFullName();
+    val remoteBranchFullNameAsLocalBranchOnRemote = remoteBranch.getFullNameAsLocalBranchOnRemote();
+    val remoteBranchFullName = remoteBranch.getFullName();
     // This strategy is used to fetch branch from remote repository to remote branch in our repository.
     String refspec = createRefspec(remoteBranchFullNameAsLocalBranchOnRemote,
         remoteBranchFullName, /* allowNonFastForward */ true);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/SlideInBackgroundable.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/SlideInBackgroundable.java
@@ -66,17 +66,15 @@ public class SlideInBackgroundable extends Task.Backgroundable {
 
     Path macheteFilePath = getMacheteFilePath(gitRepository);
 
-    var childEntryByName = branchLayout.findEntryByName(slideInOptions.getName());
+    IBranchLayoutEntry childEntryByName = branchLayout.findEntryByName(slideInOptions.getName()).getOrNull();
     IBranchLayoutEntry entryToSlideIn;
     IBranchLayout targetBranchLayout;
-    if (childEntryByName.isDefined()) {
-      var entryByName = childEntryByName.get();
-
+    if (childEntryByName != null) {
       if (slideInOptions.shouldReattach()) {
-        entryToSlideIn = entryByName;
+        entryToSlideIn = childEntryByName;
         targetBranchLayout = branchLayout;
       } else {
-        entryToSlideIn = entryByName.withChildren(List.empty());
+        entryToSlideIn = childEntryByName.withChildren(List.empty());
         targetBranchLayout = branchLayout.slideOut(slideInOptions.getName());
       }
 
@@ -103,7 +101,7 @@ public class SlideInBackgroundable extends Task.Backgroundable {
       return;
     }
 
-    final var finalNewBranchLayout = newBranchLayout;
+    final IBranchLayout finalNewBranchLayout = newBranchLayout;
     Try.run(() -> branchLayoutWriter.write(macheteFilePath, finalNewBranchLayout, /* backupOldLayout */ true))
         .onFailure(t -> notifier.notifyError(
             /* title */ getString(

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardMergeBranchToParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardMergeBranchToParentAction.java
@@ -12,6 +12,7 @@ import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 
@@ -58,21 +59,21 @@ public abstract class BaseFastForwardMergeBranchToParentAction extends BaseGitMa
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
 
-    var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var targetBranchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    val project = getProject(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    val targetBranchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
     if (gitRepository == null || targetBranchName == null) {
       return;
     }
 
-    var targetBranch = getManagedBranchByName(anActionEvent, targetBranchName).getOrNull();
+    val targetBranch = getManagedBranchByName(anActionEvent, targetBranchName).getOrNull();
     if (targetBranch == null) {
       return;
     }
     // This is guaranteed by `syncToParentStatusDependentActionUpdate` invoked from `onUpdate`.
     assert targetBranch.isNonRoot() : "Target branch provided to fast forward is a root";
 
-    var currentBranchName = Option.of(gitRepository.getCurrentBranch()).map(b -> b.getName()).getOrNull();
+    val currentBranchName = Option.of(gitRepository.getCurrentBranch()).map(b -> b.getName()).getOrNull();
     if (targetBranch.asNonRoot().getParent().getName().equals(currentBranchName)) {
       doFastForwardCurrentBranch(project, gitRepository, targetBranch.asNonRoot());
     } else {
@@ -84,7 +85,7 @@ public abstract class BaseFastForwardMergeBranchToParentAction extends BaseGitMa
       GitRepository gitRepository,
       INonRootManagedBranchSnapshot targetBranch) {
 
-    var taskTitle = getString("action.GitMachete.BaseFastForwardMergeBranchToParentAction.task-title");
+    val taskTitle = getString("action.GitMachete.BaseFastForwardMergeBranchToParentAction.task-title");
 
     new MergeCurrentBranchFastForwardOnlyBackgroundable(project, gitRepository, taskTitle, targetBranch.getName()).queue();
   }
@@ -92,9 +93,9 @@ public abstract class BaseFastForwardMergeBranchToParentAction extends BaseGitMa
   private void doFastForwardNonCurrentBranch(Project project,
       GitRepository gitRepository,
       INonRootManagedBranchSnapshot targetBranch) {
-    var localFullName = targetBranch.getFullName();
-    var parentLocalFullName = targetBranch.getParent().getFullName();
-    var refspecFromChildToParent = createRefspec(localFullName, parentLocalFullName, /* allowNonFastForward */ false);
+    val localFullName = targetBranch.getFullName();
+    val parentLocalFullName = targetBranch.getParent().getFullName();
+    val refspecFromChildToParent = createRefspec(localFullName, parentLocalFullName, /* allowNonFastForward */ false);
 
     new FetchBackgroundable(
         project,

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import git4idea.config.GitConfigUtil;
 import io.vavr.collection.List;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 
@@ -60,17 +61,17 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
   @Override
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
-    var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var branchUnderAction = getNameOfBranchUnderAction(anActionEvent);
-    var branch = branchUnderAction.flatMap(pn -> getManagedBranchByName(anActionEvent, pn)).getOrNull();
+    val project = getProject(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    val branchUnderAction = getNameOfBranchUnderAction(anActionEvent);
+    val branch = branchUnderAction.flatMap(pn -> getManagedBranchByName(anActionEvent, pn)).getOrNull();
 
     if (gitRepository == null || branch == null || branch.isRoot()) {
       return;
     }
 
-    var nonRootBranch = branch.asNonRoot();
-    var selectedCommit = new OverrideForkPointDialog(project, nonRootBranch.getParent(), nonRootBranch)
+    val nonRootBranch = branch.asNonRoot();
+    val selectedCommit = new OverrideForkPointDialog(project, nonRootBranch.getParent(), nonRootBranch)
         .showAndGetSelectedCommit();
     if (selectedCommit == null) {
       log().debug(
@@ -90,11 +91,11 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
 
   @UIThreadUnsafe
   private void overrideForkPoint(AnActionEvent anActionEvent, IManagedBranchSnapshot branch, ICommitOfManagedBranch forkPoint) {
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent);
 
     if (gitRepository.isDefined()) {
-      var root = gitRepository.get().getRoot();
-      var project = getProject(anActionEvent);
+      val root = gitRepository.get().getRoot();
+      val project = getProject(anActionEvent);
       setOverrideForkPointConfigValues(project, root, branch.getName(), forkPoint, branch.getPointedCommit());
     }
 
@@ -108,16 +109,16 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
       String branchName,
       ICommitOfManagedBranch forkPoint,
       ICommitOfManagedBranch ancestorCommit) {
-    var section = "machete";
-    var subsectionPrefix = "overrideForkPoint";
-    var to = "to";
-    var whileDescendantOf = "whileDescendantOf";
+    val section = "machete";
+    val subsectionPrefix = "overrideForkPoint";
+    val to = "to";
+    val whileDescendantOf = "whileDescendantOf";
 
     // Section spans the characters before the first dot
     // Name spans the characters after the last dot
     // Subsection is everything else
-    var toKey = "${section}.${subsectionPrefix}.${branchName}.${to}";
-    var whileDescendantOfKey = "${section}.${subsectionPrefix}.${branchName}.${whileDescendantOf}";
+    val toKey = "${section}.${subsectionPrefix}.${branchName}.${to}";
+    val whileDescendantOfKey = "${section}.${subsectionPrefix}.${branchName}.${whileDescendantOf}";
 
     try {
       GitConfigUtil.setValue(project, root, toKey, forkPoint.getHash());

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseProjectDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseProjectDependentAction.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import git4idea.repo.GitRepository;
 import io.vavr.control.Option;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.branchlayout.api.readwrite.IBranchLayoutWriter;
@@ -32,8 +33,8 @@ public abstract class BaseProjectDependentAction extends DumbAwareAction impleme
 
     isUpdateInProgressOnUIThread = true;
 
-    var maybeProject = anActionEvent.getProject();
-    var presentation = anActionEvent.getPresentation();
+    val maybeProject = anActionEvent.getProject();
+    val presentation = anActionEvent.getPresentation();
     if (maybeProject == null) {
       presentation.setEnabledAndVisible(false);
     } else {
@@ -56,7 +57,7 @@ public abstract class BaseProjectDependentAction extends DumbAwareAction impleme
   public abstract IEnhancedLambdaLogger log();
 
   protected Project getProject(AnActionEvent anActionEvent) {
-    var project = anActionEvent.getProject();
+    val project = anActionEvent.getProject();
     assert project != null : "Can't get project from action event";
     return project;
   }
@@ -70,7 +71,7 @@ public abstract class BaseProjectDependentAction extends DumbAwareAction impleme
   }
 
   protected Option<GitRepository> getSelectedGitRepository(AnActionEvent anActionEvent) {
-    var gitRepository = getProject(anActionEvent).getService(SelectedGitRepositoryProvider.class)
+    val gitRepository = getProject(anActionEvent).getService(SelectedGitRepositoryProvider.class)
         .getSelectedGitRepository();
     if (isLoggingAcceptable() && gitRepository.isEmpty()) {
       log().warn("No Git repository is selected");

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchFastForwardOnlyAction.java
@@ -10,6 +10,7 @@ import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 
@@ -62,20 +63,20 @@ public abstract class BasePullBranchFastForwardOnlyAction extends BaseGitMachete
   public void actionPerformed(AnActionEvent anActionEvent) {
     log().debug("Performing");
 
-    var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var localBranchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
-    var gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshot(anActionEvent).getOrNull();
+    val project = getProject(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    val localBranchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    val gitMacheteRepositorySnapshot = getGitMacheteRepositorySnapshot(anActionEvent).getOrNull();
 
     if (localBranchName != null && gitRepository != null && gitMacheteRepositorySnapshot != null) {
-      var localBranch = gitMacheteRepositorySnapshot.getManagedBranchByName(localBranchName).getOrNull();
+      val localBranch = gitMacheteRepositorySnapshot.getManagedBranchByName(localBranchName).getOrNull();
       if (localBranch == null) {
         // This is generally NOT expected, the action should never be triggered
         // for an unmanaged branch in the first place.
         log().warn("Branch '${localBranchName}' not found or not managed by Git Machete");
         return;
       }
-      var remoteBranch = localBranch.getRemoteTrackingBranch().getOrNull();
+      val remoteBranch = localBranch.getRemoteTrackingBranch().getOrNull();
       if (remoteBranch == null) {
         // This is generally NOT expected, the action should never be triggered
         // for an untracked branch in the first place (see `getEligibleRelations`)
@@ -83,7 +84,7 @@ public abstract class BasePullBranchFastForwardOnlyAction extends BaseGitMachete
         return;
       }
 
-      var currentBranchName = Option.of(gitRepository.getCurrentBranch()).map(b -> b.getName()).getOrNull();
+      val currentBranchName = Option.of(gitRepository.getCurrentBranch()).map(b -> b.getName()).getOrNull();
       if (localBranchName.equals(currentBranchName)) {
         doPullCurrentBranchFastForwardOnly(project, gitRepository, remoteBranch);
       } else {
@@ -96,7 +97,7 @@ public abstract class BasePullBranchFastForwardOnlyAction extends BaseGitMachete
       GitRepository gitRepository,
       IRemoteTrackingBranchReference remoteBranch) {
 
-    var taskTitle = getString("action.GitMachete.BasePullBranchFastForwardOnlyAction.task-title");
+    val taskTitle = getString("action.GitMachete.BasePullBranchFastForwardOnlyAction.task-title");
 
     new PullCurrentBranchFastForwardOnlyBackgroundable(project, gitRepository, taskTitle, remoteBranch).queue();
   }
@@ -106,18 +107,18 @@ public abstract class BasePullBranchFastForwardOnlyAction extends BaseGitMachete
       IManagedBranchSnapshot localBranch,
       IRemoteTrackingBranchReference remoteBranch) {
 
-    var remoteName = remoteBranch.getRemoteName();
-    var remoteBranchFullNameAsLocalBranchOnRemote = remoteBranch.getFullNameAsLocalBranchOnRemote();
-    var remoteBranchFullName = remoteBranch.getFullName();
-    var localBranchFullName = localBranch.getFullName();
+    val remoteName = remoteBranch.getRemoteName();
+    val remoteBranchFullNameAsLocalBranchOnRemote = remoteBranch.getFullNameAsLocalBranchOnRemote();
+    val remoteBranchFullName = remoteBranch.getFullName();
+    val localBranchFullName = localBranch.getFullName();
 
     // This strategy is used to fetch branch from remote repository to remote branch in our repository.
-    var refspecFromRemoteRepoToOurRemoteBranch = createRefspec(remoteBranchFullNameAsLocalBranchOnRemote,
+    val refspecFromRemoteRepoToOurRemoteBranch = createRefspec(remoteBranchFullNameAsLocalBranchOnRemote,
         remoteBranchFullName, /* allowNonFastForward */ true);
 
     // We want a fetch from remote branch in our repository
     // to local branch in our repository to only ever be fast-forward.
-    var refspecFromOurRemoteBranchToOurLocalBranch = createRefspec(remoteBranchFullName,
+    val refspecFromOurRemoteBranchToOurLocalBranch = createRefspec(remoteBranchFullName,
         localBranchFullName, /* allowNonFastForward */ false);
 
     String taskTitle = getString("action.GitMachete.BasePullBranchFastForwardOnlyAction.task-title");

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
@@ -16,6 +16,7 @@ import git4idea.push.GitPushSource;
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -61,10 +62,10 @@ public abstract class BasePushBranchAction extends BaseGitMacheteRepositoryReady
 
     syncToRemoteStatusDependentActionUpdate(anActionEvent);
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent);
-    var relation = branchName.flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
+    val branchName = getNameOfBranchUnderAction(anActionEvent);
+    val relation = branchName.flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation());
-    var project = getProject(anActionEvent);
+    val project = getProject(anActionEvent);
 
     if (branchName.isDefined() && relation.isDefined() && isForcePushRequired(relation.get())) {
       if (GitSharedSettings.getInstance(project).isBranchProtected(branchName.get())) {
@@ -80,10 +81,10 @@ public abstract class BasePushBranchAction extends BaseGitMacheteRepositoryReady
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
 
-    var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
-    var branchName = getNameOfBranchUnderAction(anActionEvent);
-    var relation = branchName.flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
+    val project = getProject(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent);
+    val branchName = getNameOfBranchUnderAction(anActionEvent);
+    val relation = branchName.flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation());
 
     if (branchName.isDefined() && gitRepository.isDefined() && relation.isDefined()) {

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -31,6 +31,7 @@ import git4idea.util.LocalChangesWouldBeOverwrittenHelper;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 
@@ -89,9 +90,9 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
     super.onUpdate(anActionEvent);
     syncToRemoteStatusDependentActionUpdate(anActionEvent);
 
-    var branch = getNameOfBranchUnderAction(anActionEvent);
+    val branch = getNameOfBranchUnderAction(anActionEvent);
     if (branch.isDefined()) {
-      var isResettingCurrent = getCurrentBranchNameIfManaged(anActionEvent)
+      val isResettingCurrent = getCurrentBranchNameIfManaged(anActionEvent)
           .map(bn -> bn.equals(branch.get())).getOrElse(false);
       if (anActionEvent.getPlace().equals(ActionPlaces.ACTION_PLACE_CONTEXT_MENU) && isResettingCurrent) {
         anActionEvent.getPresentation().setText(() -> getActionName());
@@ -105,9 +106,9 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
     log().debug("Performing");
 
     Project project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
-    var macheteRepository = getGitMacheteRepositorySnapshot(anActionEvent).getOrNull();
+    val gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    val branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    val macheteRepository = getGitMacheteRepositorySnapshot(anActionEvent).getOrNull();
 
     if (gitRepository == null) {
       VcsNotifier.getInstance(project).notifyWarning(VCS_NOTIFIER_TITLE,
@@ -127,13 +128,13 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
       return;
     }
 
-    var localBranch = getManagedBranchByName(anActionEvent, branchName).getOrNull();
+    val localBranch = getManagedBranchByName(anActionEvent, branchName).getOrNull();
     if (localBranch == null) {
       VcsNotifier.getInstance(project).notifyError(VCS_NOTIFIER_TITLE, "Cannot get local branch '${branchName}'");
       return;
     }
 
-    var remoteTrackingBranch = localBranch.getRemoteTrackingBranch().getOrNull();
+    val remoteTrackingBranch = localBranch.getRemoteTrackingBranch().getOrNull();
     if (remoteTrackingBranch == null) {
       String message = "Branch '${localBranch.getName()}' doesn't have remote tracking branch, so cannot be reset";
       log().warn(message);
@@ -168,7 +169,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
     // Required to avoid reset with uncommitted changes and file cache conflicts
     FileDocumentManager.getInstance().saveAllDocuments();
 
-    var currentBranchName = Option.of(gitRepository.getCurrentBranch()).map(b -> b.getName()).getOrNull();
+    val currentBranchName = Option.of(gitRepository.getCurrentBranch()).map(b -> b.getName()).getOrNull();
     if (branchName.equals(currentBranchName)) {
       doResetCurrentBranchToRemoteWithKeep(project, gitRepository, localBranch, remoteTrackingBranch);
     } else {
@@ -180,7 +181,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
       GitRepository gitRepository,
       IManagedBranchSnapshot localBranch,
       IRemoteTrackingBranchReference remoteTrackingBranch) {
-    var refspecFromRemoteToLocal = createRefspec(
+    val refspecFromRemoteToLocal = createRefspec(
         remoteTrackingBranch.getFullName(), localBranch.getFullName(), /* allowNonFastForward */ true);
 
     new FetchBackgroundable(
@@ -210,8 +211,8 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
       @Override
       @UIThreadUnsafe
       public void run(ProgressIndicator indicator) {
-        var localBranchName = localBranch.getName();
-        var remoteTrackingBranchName = remoteTrackingBranch.getName();
+        val localBranchName = localBranch.getName();
+        val remoteTrackingBranchName = remoteTrackingBranch.getName();
         log().debug(() -> "Resetting '${localBranchName}' to '${remoteTrackingBranchName}'");
 
         try (AccessToken ignored = DvcsUtil.workingTreeChangeStarted(project,
@@ -221,7 +222,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
           resetHandler.addParameters(remoteTrackingBranchName);
           resetHandler.endOptions();
 
-          var localChangesDetector = new GitLocalChangesWouldBeOverwrittenDetector(gitRepository.getRoot(), RESET);
+          val localChangesDetector = new GitLocalChangesWouldBeOverwrittenDetector(gitRepository.getRoot(), RESET);
           resetHandler.addLineListener(localChangesDetector);
 
           GitCommandResult result = Git.getInstance().runCommand(resetHandler);
@@ -244,7 +245,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
             VcsNotifier.getInstance(project).notifyError(VCS_NOTIFIER_TITLE, result.getErrorOutputAsHtmlString());
           }
 
-          var repositoryRoot = getMainDirectory(gitRepository);
+          val repositoryRoot = getMainDirectory(gitRepository);
           GitRepositoryManager.getInstance(project).updateRepository(repositoryRoot);
           VfsUtil.markDirtyAndRefresh(/* async */ false, /* recursive */ true, /* reloadChildren */ false, repositoryRoot);
         }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
@@ -22,6 +22,7 @@ import io.vavr.Tuple2;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -52,8 +53,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
       return;
     }
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
-    var branch = branchName != null
+    val branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    val branch = branchName != null
         ? getManagedBranchByName(anActionEvent, branchName).getOrNull()
         : null;
 
@@ -73,18 +74,18 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
   @Override
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
-    var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
-    var parentName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
-    var branchLayout = getBranchLayout(anActionEvent).getOrNull();
-    var branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
-    var notifier = VcsNotifier.getInstance(project);
+    val project = getProject(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent).getOrNull();
+    val parentName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    val branchLayout = getBranchLayout(anActionEvent).getOrNull();
+    val branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
+    val notifier = VcsNotifier.getInstance(project);
 
     if (gitRepository == null || parentName == null || branchLayout == null) {
       return;
     }
 
-    var slideInOptions = new SlideInDialog(project, branchLayout, parentName).showAndGetBranchName();
+    val slideInOptions = new SlideInDialog(project, branchLayout, parentName).showAndGetBranchName();
     if (slideInOptions == null) {
       log().debug("Options of branch to slide in is null: most likely the action has been canceled from slide-in dialog");
       return;
@@ -99,15 +100,15 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
       return;
     }
 
-    var localBranch = gitRepository.getBranches().findLocalBranch(slideInOptions.getName());
+    val localBranch = gitRepository.getBranches().findLocalBranch(slideInOptions.getName());
     Runnable preSlideInRunnable = () -> {};
     if (localBranch == null) {
       Tuple2<@Nullable String, Runnable> branchNameAndPreSlideInRunnable = getBranchNameAndPreSlideInRunnable(project,
           gitRepository, parentName, slideInOptions.getName());
       preSlideInRunnable = branchNameAndPreSlideInRunnable._2();
-      var branchName = branchNameAndPreSlideInRunnable._1();
+      val branchName = branchNameAndPreSlideInRunnable._1();
       if (!slideInOptions.getName().equals(branchName)) {
-        var branchNameFromNewBranchDialog = branchName != null ? branchName : "no name provided";
+        val branchNameFromNewBranchDialog = branchName != null ? branchName : "no name provided";
         notifier.notifyWeakError(
             format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.title.mismatched-names"),
                 slideInOptions.getName(), branchNameFromNewBranchDialog));
@@ -116,8 +117,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
     }
 
     // TODO (#430): expose getParent from branch layout API
-    var parentEntry = branchLayout.findEntryByName(parentName);
-    var entryAlreadyExistsBelowGivenParent = parentEntry
+    val parentEntry = branchLayout.findEntryByName(parentName);
+    val entryAlreadyExistsBelowGivenParent = parentEntry
         .map(entry -> entry.getChildren())
         .map(children -> children.map(e -> e.getName()))
         .map(names -> names.contains(slideInOptions.getName()))
@@ -147,8 +148,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
       GitRepository gitRepository,
       String startPoint,
       String initialName) {
-    var repositories = java.util.Collections.singletonList(gitRepository);
-    var gitNewBranchDialog = new GitNewBranchDialog(project,
+    val repositories = java.util.Collections.singletonList(gitRepository);
+    val gitNewBranchDialog = new GitNewBranchDialog(project,
         repositories,
         /* title */ format(getString("action.GitMachete.BaseSlideInBranchBelowAction.dialog.create-new-branch.title"),
             startPoint),
@@ -165,20 +166,20 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
       return Tuple.of(null, () -> {});
     }
 
-    var branchName = options.getName();
+    val branchName = options.getName();
     if (!initialName.equals(branchName)) {
       return Tuple.of(branchName, () -> {});
     }
 
     Runnable preSlideInRunnable = () -> {};
-    var remoteBranch = getGitRemoteBranch(project, gitRepository, branchName);
+    val remoteBranch = getGitRemoteBranch(project, gitRepository, branchName);
 
     if (options.shouldCheckout() && remoteBranch != null) {
       preSlideInRunnable = () -> checkoutRemoteBranch(project, repositories, remoteBranch.getName());
 
     } else if (!options.shouldCheckout() && remoteBranch != null) {
 
-      var refspec = createRefspec("refs/remotes/${remoteBranch.getName()}",
+      val refspec = createRefspec("refs/remotes/${remoteBranch.getName()}",
           "refs/heads/${branchName}", /* allowNonFastForward */ false);
       preSlideInRunnable = () -> new FetchBackgroundable(
           project,
@@ -204,10 +205,10 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
 
   private static @Nullable GitRemoteBranch getGitRemoteBranch(Project project, GitRepository gitRepository, String branchName) {
 
-    var remotesWithBranch = List.ofAll(gitRepository.getRemotes())
+    val remotesWithBranch = List.ofAll(gitRepository.getRemotes())
         .flatMap(r -> {
-          var remoteBranchName = "${r.getName()}/${branchName}";
-          var remoteBranch = gitRepository.getBranches().findRemoteBranch(remoteBranchName);
+          val remoteBranchName = "${r.getName()}/${branchName}";
+          GitRemoteBranch remoteBranch = gitRepository.getBranches().findRemoteBranch(remoteBranchName);
           return remoteBranch != null ? Option.some(Tuple.of(r, remoteBranch)) : Option.none();
         })
         // Note: false < true. Hence the pair with origin will be first (head) if exists.
@@ -217,7 +218,7 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
       return null;
     }
 
-    var chosen = remotesWithBranch.head();
+    val chosen = remotesWithBranch.head();
     if (remotesWithBranch.size() > 1) {
       VcsNotifier.getInstance(project).notifyInfo(format(
           getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.multiple-remotes"),

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToParentStatusDependentAction.java
@@ -11,6 +11,7 @@ import static org.checkerframework.checker.i18nformatter.qual.I18nConversionCate
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import io.vavr.collection.List;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 
@@ -51,8 +52,8 @@ public interface ISyncToParentStatusDependentAction extends IBranchNameProvider,
       return;
     }
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
-    var gitMacheteBranchByName = branchName != null
+    val branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    val gitMacheteBranchByName = branchName != null
         ? getManagedBranchByName(anActionEvent, branchName).getOrNull()
         : null;
 
@@ -74,21 +75,21 @@ public interface ISyncToParentStatusDependentAction extends IBranchNameProvider,
       return;
     }
 
-    var gitMacheteNonRootBranch = gitMacheteBranchByName.asNonRoot();
-    var syncToParentStatus = gitMacheteNonRootBranch.getSyncToParentStatus();
+    val gitMacheteNonRootBranch = gitMacheteBranchByName.asNonRoot();
+    val syncToParentStatus = gitMacheteNonRootBranch.getSyncToParentStatus();
 
-    var isStatusEligible = getEligibleStatuses().contains(syncToParentStatus);
+    val isStatusEligible = getEligibleStatuses().contains(syncToParentStatus);
 
     if (isStatusEligible) {
-      var parentName = gitMacheteNonRootBranch.getParent().getName();
-      var enabledDesc = format(getEnabledDescriptionFormat(), parentName, branchName);
+      val parentName = gitMacheteNonRootBranch.getParent().getName();
+      val enabledDesc = format(getEnabledDescriptionFormat(), parentName, branchName);
       presentation.setDescription(enabledDesc);
 
     } else {
       presentation.setEnabled(false);
 
       // @formatter:off
-      var desc = Match(syncToParentStatus).of(
+      val desc = Match(syncToParentStatus).of(
           Case($(SyncToParentStatus.InSync),
               getString("action.GitMachete.ISyncToParentStatusDependentAction.description.sync-to-parent-status.in-sync")),
           Case($(SyncToParentStatus.InSyncButForkPointOff),

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/ISyncToRemoteStatusDependentAction.java
@@ -11,6 +11,7 @@ import static org.checkerframework.checker.i18nformatter.qual.I18nConversionCate
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import io.vavr.collection.List;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 
@@ -51,8 +52,8 @@ public interface ISyncToRemoteStatusDependentAction extends IBranchNameProvider,
       return;
     }
 
-    var branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
-    var gitMacheteBranch = branchName != null
+    val branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
+    val gitMacheteBranch = branchName != null
         ? getManagedBranchByName(anActionEvent, branchName).getOrNull()
         : null;
 
@@ -63,21 +64,21 @@ public interface ISyncToRemoteStatusDependentAction extends IBranchNameProvider,
               getActionNameForDescription(), getQuotedStringOrCurrent(branchName)));
       return;
     }
-    var syncToRemoteStatus = gitMacheteBranch.getSyncToRemoteStatus();
+    val syncToRemoteStatus = gitMacheteBranch.getSyncToRemoteStatus();
 
     SyncToRemoteStatus.Relation relation = syncToRemoteStatus.getRelation();
-    var isRelationEligible = getEligibleRelations().contains(relation);
+    val isRelationEligible = getEligibleRelations().contains(relation);
 
     if (isRelationEligible) {
       // At this point `branchName` must be present, so `.getOrNull()` is here only to satisfy checker framework
-      var enabledDesc = format(getEnabledDescriptionFormat(), getActionNameForDescription(), branchName);
+      val enabledDesc = format(getEnabledDescriptionFormat(), getActionNameForDescription(), branchName);
       presentation.setDescription(enabledDesc);
 
     } else {
       presentation.setEnabled(false);
 
       // @formatter:off
-      var desc = Match(relation).of(
+      val desc = Match(relation).of(
           Case($(SyncToRemoteStatus.Relation.AheadOfRemote),
               getString("action.GitMachete.ISyncToRemoteStatusDependentAction.description.sync-to-remote-status.relation.ahead-of-remote")),
           Case($(SyncToRemoteStatus.Relation.BehindRemote),

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
@@ -3,6 +3,8 @@ package com.virtuslab.gitmachete.frontend.actions.contextmenu;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
+import java.util.Collections;
+
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
@@ -12,6 +14,7 @@ import git4idea.branch.GitBranchWorker;
 import git4idea.commands.Git;
 import git4idea.repo.GitRepository;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseGitMacheteRepositoryReadyAction;
@@ -34,12 +37,12 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
 
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     if (!presentation.isEnabledAndVisible()) {
       return;
     }
 
-    var selectedBranchName = getSelectedBranchName(anActionEvent);
+    val selectedBranchName = getSelectedBranchName(anActionEvent);
     // It's very unlikely that selectedBranchName is empty at this point since it's assigned directly before invoking this
     // action in GitMacheteGraphTable.GitMacheteGraphTableMouseAdapter.mouseClicked; still, it's better to be safe.
     if (selectedBranchName.isEmpty()) {
@@ -48,7 +51,7 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
       return;
     }
 
-    var currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
 
     if (currentBranchName.isDefined() && currentBranchName.get().equals(selectedBranchName.get())) {
       presentation.setEnabled(false);
@@ -65,13 +68,13 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
   @Override
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
-    var selectedBranchName = getSelectedBranchName(anActionEvent);
+    val selectedBranchName = getSelectedBranchName(anActionEvent);
     if (selectedBranchName.isEmpty()) {
       return;
     }
 
-    var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    val project = getProject(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent);
 
     if (gitRepository.isDefined()) {
       log().debug(() -> "Queuing '${selectedBranchName.get()}' branch checkout background task");
@@ -91,6 +94,6 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
       GitRepository gitRepository) {
     GitBranchUiHandlerImpl uiHandler = new GitBranchUiHandlerImpl(project, Git.getInstance(), indicator);
     new GitBranchWorker(project, Git.getInstance(), uiHandler)
-        .checkout(branchToCheckoutName, /* detach */ false, java.util.List.of(gitRepository));
+        .checkout(branchToCheckoutName, /* detach */ false, Collections.singletonList(gitRepository));
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitmachete.frontend.actions.expectedkeys;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
+import lombok.val;
 
 import com.virtuslab.branchlayout.api.IBranchLayout;
 import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
@@ -11,7 +12,7 @@ import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 
 public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
   default Option<IGitMacheteRepositorySnapshot> getGitMacheteRepositorySnapshot(AnActionEvent anActionEvent) {
-    var gitMacheteRepositorySnapshot = Option.of(anActionEvent.getData(DataKeys.KEY_GIT_MACHETE_REPOSITORY_SNAPSHOT));
+    val gitMacheteRepositorySnapshot = Option.of(anActionEvent.getData(DataKeys.KEY_GIT_MACHETE_REPOSITORY_SNAPSHOT));
     if (isLoggingAcceptable() && gitMacheteRepositorySnapshot.isEmpty()) {
       log().warn("Git Machete repository snapshot is undefined");
     }
@@ -19,7 +20,7 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
   }
 
   default Option<IBranchLayout> getBranchLayout(AnActionEvent anActionEvent) {
-    var branchLayout = getGitMacheteRepositorySnapshot(anActionEvent)
+    val branchLayout = getGitMacheteRepositorySnapshot(anActionEvent)
         .flatMap(repository -> repository.getBranchLayout());
     if (isLoggingAcceptable() && branchLayout.isEmpty()) {
       log().warn("Branch layout is undefined");
@@ -33,7 +34,7 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
   }
 
   default Option<String> getCurrentBranchNameIfManaged(AnActionEvent anActionEvent) {
-    var currentBranchName = getCurrentMacheteBranchIfManaged(anActionEvent).map(branch -> branch.getName());
+    val currentBranchName = getCurrentMacheteBranchIfManaged(anActionEvent).map(branch -> branch.getName());
     if (isLoggingAcceptable() && currentBranchName.isEmpty()) {
       log().warn("Current Git Machete branch name is undefined");
     }
@@ -41,7 +42,7 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
   }
 
   default Option<IManagedBranchSnapshot> getManagedBranchByName(AnActionEvent anActionEvent, String branchName) {
-    var branch = getGitMacheteRepositorySnapshot(anActionEvent)
+    val branch = getGitMacheteRepositorySnapshot(anActionEvent)
         .flatMap(r -> r.getManagedBranchByName(branchName));
     if (isLoggingAcceptable() && branch.isEmpty()) {
       log().warn(branchName + " Git Machete branch is undefined");

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeySelectedBranchName.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeySelectedBranchName.java
@@ -2,13 +2,14 @@ package com.virtuslab.gitmachete.frontend.actions.expectedkeys;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
+import lombok.val;
 
 import com.virtuslab.gitmachete.frontend.actions.base.IWithLogger;
 import com.virtuslab.gitmachete.frontend.datakeys.DataKeys;
 
 public interface IExpectsKeySelectedBranchName extends IWithLogger {
   default Option<String> getSelectedBranchName(AnActionEvent anActionEvent) {
-    var selectedBranchName = Option.of(anActionEvent.getData(DataKeys.KEY_SELECTED_BRANCH_NAME));
+    val selectedBranchName = Option.of(anActionEvent.getData(DataKeys.KEY_SELECTED_BRANCH_NAME));
     if (isLoggingAcceptable() && selectedBranchName.isEmpty()) {
       log().warn("Selected branch is undefined");
     }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
@@ -17,6 +17,7 @@ import com.intellij.ui.GuiUtils;
 import git4idea.repo.GitRepository;
 import io.vavr.control.Try;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.binding.RuntimeBinding;
@@ -41,9 +42,9 @@ public class DiscoverAction extends BaseProjectDependentAction {
   @Override
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
-    var project = getProject(anActionEvent);
-    var selectedRepoProvider = project.getService(SelectedGitRepositoryProvider.class).getGitRepositorySelectionProvider();
-    var gitRepository = selectedRepoProvider.getSelectedGitRepository().getOrNull();
+    val project = getProject(anActionEvent);
+    val selectedRepoProvider = project.getService(SelectedGitRepositoryProvider.class).getGitRepositorySelectionProvider();
+    val gitRepository = selectedRepoProvider.getSelectedGitRepository().getOrNull();
     if (gitRepository == null) {
       VcsNotifier.getInstance(project).notifyError(
           /* title */ getString("action.GitMachete.DiscoverAction.notification.title.cannot-get-current-repository-error"),
@@ -51,8 +52,8 @@ public class DiscoverAction extends BaseProjectDependentAction {
       return;
     }
 
-    var mainDirPath = GitVfsUtils.getMainDirectoryPath(gitRepository).toAbsolutePath();
-    var gitDirPath = GitVfsUtils.getGitDirectoryPath(gitRepository).toAbsolutePath();
+    val mainDirPath = GitVfsUtils.getMainDirectoryPath(gitRepository).toAbsolutePath();
+    val gitDirPath = GitVfsUtils.getGitDirectoryPath(gitRepository).toAbsolutePath();
 
     Consumer<IGitMacheteRepositorySnapshot> saveAction = repositorySnapshot -> saveDiscoveredLayout(repositorySnapshot,
         GitVfsUtils.getMacheteFilePath(gitRepository), project, getGraphTable(anActionEvent),
@@ -83,7 +84,7 @@ public class DiscoverAction extends BaseProjectDependentAction {
 
   private static void openMacheteFile(Project project, GitRepository gitRepository) {
     GuiUtils.invokeLaterIfNeeded(() -> {
-      var file = GitVfsUtils.getMacheteFile(gitRepository);
+      val file = GitVfsUtils.getMacheteFile(gitRepository);
       if (file.isDefined()) {
         OpenFileAction.openFile(file.get(), project);
       } else {
@@ -99,7 +100,7 @@ public class DiscoverAction extends BaseProjectDependentAction {
 
   private void saveDiscoveredLayout(IGitMacheteRepositorySnapshot repositorySnapshot, Path macheteFilePath, Project project,
       BaseEnhancedGraphTable baseEnhancedGraphTable, IBranchLayoutWriter branchLayoutWriter) {
-    var branchLayout = repositorySnapshot.getBranchLayout().getOrNull();
+    val branchLayout = repositorySnapshot.getBranchLayout().getOrNull();
     if (branchLayout == null) {
       VcsNotifier.getInstance(project).notifyError(
           /* title */ getString("action.GitMachete.DiscoverAction.notification.title.cannot-discover-layout-error"),

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FastForwardMergeCurrentBranchToParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FastForwardMergeCurrentBranchToParentAction.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitmachete.frontend.actions.toolbar;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
@@ -18,12 +19,12 @@ public class FastForwardMergeCurrentBranchToParentAction extends BaseFastForward
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
 
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     if (!presentation.isVisible()) {
       return;
     }
 
-    var isInSyncToParent = getCurrentBranchNameIfManaged(anActionEvent)
+    val isInSyncToParent = getCurrentBranchNameIfManaged(anActionEvent)
         .flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.InSync)

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.progress.Task;
 import git4idea.fetch.GitFetchResult;
 import git4idea.fetch.GitFetchSupport;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
@@ -28,8 +29,8 @@ public class FetchAllRemotesAction extends BaseProjectDependentAction {
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
 
-    var project = getProject(anActionEvent);
-    var presentation = anActionEvent.getPresentation();
+    val project = getProject(anActionEvent);
+    val presentation = anActionEvent.getPresentation();
     if (GitFetchSupport.fetchSupport(project).isFetchRunning()) {
       presentation.setEnabled(false);
       presentation.setDescription(getString("action.GitMachete.FetchAllRemotesAction.description.disabled.already-running"));
@@ -43,8 +44,8 @@ public class FetchAllRemotesAction extends BaseProjectDependentAction {
   public void actionPerformed(AnActionEvent anActionEvent) {
     log().debug("Performing");
 
-    var project = getProject(anActionEvent);
-    var gitRepository = getSelectedGitRepository(anActionEvent);
+    val project = getProject(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent);
 
     String title = getString("action.GitMachete.FetchAllRemotesAction.task-title");
     new Task.Backgroundable(project, title, /* canBeCancelled */ true) {
@@ -59,7 +60,7 @@ public class FetchAllRemotesAction extends BaseProjectDependentAction {
       @Override
       @UIEffect
       public void onFinished() {
-        var result = this.result;
+        val result = this.result;
         if (result != null) {
           result.showNotification();
         }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
@@ -14,6 +14,7 @@ import git4idea.GitUtil;
 import git4idea.config.GitVcsSettings;
 import io.vavr.control.Try;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction;
@@ -35,7 +36,7 @@ public class OpenMacheteFileAction extends BaseProjectDependentAction {
 
     // When selected Git repository is empty (due to e.g. unopened Git Machete tab)
     // an attempt to guess current repository based on presently opened file
-    var gitDir = getSelectedGitRepository(anActionEvent)
+    val gitDir = getSelectedGitRepository(anActionEvent)
         .onEmpty(() -> DvcsUtil.guessCurrentRepositoryQuick(project,
             GitUtil.getRepositoryManager(project),
             GitVcsSettings.getInstance(project).getRecentRootPath()))
@@ -46,7 +47,7 @@ public class OpenMacheteFileAction extends BaseProjectDependentAction {
       return;
     }
 
-    var macheteFile = WriteAction.compute(() -> Try
+    val macheteFile = WriteAction.compute(() -> Try
         .of(() -> gitDir.get().findOrCreateChildData(/* requestor */ this, /* name */ "machete"))
         .onFailure(e -> VcsNotifier.getInstance(project).notifyWeakError(
             /* message */ getString("action.GitMachete.OpenMacheteFileAction.notification.title.cannot-open")))

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OverrideForkPointOfCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OverrideForkPointOfCurrentBranchAction.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitmachete.frontend.actions.toolbar;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
@@ -17,12 +18,12 @@ public class OverrideForkPointOfCurrentBranchAction extends BaseOverrideForkPoin
   @UIEffect
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     if (!presentation.isVisible()) {
       return;
     }
 
-    var isInSyncButForkPointOff = getCurrentBranchNameIfManaged(anActionEvent)
+    val isInSyncButForkPointOff = getCurrentBranchNameIfManaged(anActionEvent)
         .flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff)

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PullCurrentBranchFastForwardOnlyAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PullCurrentBranchFastForwardOnlyAction.java
@@ -6,6 +6,7 @@ import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Relation.I
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BasePullBranchFastForwardOnlyAction;
@@ -21,12 +22,12 @@ public class PullCurrentBranchFastForwardOnlyAction extends BasePullBranchFastFo
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
 
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     if (!presentation.isVisible()) {
       return;
     }
 
-    var isBehindOrInSyncToRemote = getCurrentBranchNameIfManaged(anActionEvent)
+    val isBehindOrInSyncToRemote = getCurrentBranchNameIfManaged(anActionEvent)
         .flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation())
         .map(strs -> List.of(BehindRemote, InSyncToRemote).contains(strs))

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PushCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/PushCurrentBranchAction.java
@@ -7,6 +7,7 @@ import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Relation.U
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BasePushBranchAction;
@@ -21,12 +22,12 @@ public class PushCurrentBranchAction extends BasePushBranchAction {
   @UIEffect
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     if (!presentation.isVisible()) {
       return;
     }
 
-    var isAheadOrDivergedAndNewerOrUntracked = getCurrentBranchNameIfManaged(anActionEvent)
+    val isAheadOrDivergedAndNewerOrUntracked = getCurrentBranchNameIfManaged(anActionEvent)
         .flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation())
         .map(strs -> List.of(AheadOfRemote, DivergedFromAndNewerThanRemote, Untracked).contains(strs))

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/RebaseCurrentBranchOntoParentAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/RebaseCurrentBranchOntoParentAction.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitmachete.frontend.actions.toolbar;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
@@ -17,17 +18,17 @@ public class RebaseCurrentBranchOntoParentAction extends BaseRebaseBranchOntoPar
   @UIEffect
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     if (!presentation.isVisible()) {
       return;
     }
 
-    var currentBranch = getCurrentBranchNameIfManaged(anActionEvent)
+    val currentBranch = getCurrentBranchNameIfManaged(anActionEvent)
         .flatMap(bn -> getManagedBranchByName(anActionEvent, bn)).getOrNull();
 
     if (currentBranch != null) {
       if (currentBranch.isNonRoot()) {
-        var isNotMerged = currentBranch.asNonRoot().getSyncToParentStatus() != SyncToParentStatus.MergedToParent;
+        val isNotMerged = currentBranch.asNonRoot().getSyncToParentStatus() != SyncToParentStatus.MergedToParent;
         presentation.setVisible(isNotMerged);
       } else {
         presentation.setVisible(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ResetCurrentBranchToRemoteAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ResetCurrentBranchToRemoteAction.java
@@ -4,6 +4,7 @@ import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Relation.D
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseResetBranchToRemoteAction;
@@ -18,12 +19,12 @@ public class ResetCurrentBranchToRemoteAction extends BaseResetBranchToRemoteAct
   @UIEffect
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     if (!presentation.isVisible()) {
       return;
     }
 
-    var isDivergedFromAndOlderThanRemote = getCurrentBranchNameIfManaged(anActionEvent)
+    val isDivergedFromAndOlderThanRemote = getCurrentBranchNameIfManaged(anActionEvent)
         .flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
         .map(b -> b.getSyncToRemoteStatus().getRelation() == DivergedFromAndOlderThanRemote)
         .getOrElse(false);

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideOutCurrentBranchAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SlideOutCurrentBranchAction.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitmachete.frontend.actions.toolbar;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.control.Option;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
@@ -17,12 +18,12 @@ public class SlideOutCurrentBranchAction extends BaseSlideOutBranchAction {
   @UIEffect
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     if (!presentation.isVisible()) {
       return;
     }
 
-    var isMergedToParent = getCurrentBranchNameIfManaged(anActionEvent)
+    val isMergedToParent = getCurrentBranchNameIfManaged(anActionEvent)
         .flatMap(bn -> getManagedBranchByName(anActionEvent, bn))
         .flatMap(b -> b.isNonRoot() ? Option.some(b.asNonRoot()) : Option.none())
         .map(nrb -> nrb.getSyncToParentStatus() == SyncToParentStatus.MergedToParent)

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/ToggleListingCommitsAction.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Toggleable;
 import com.intellij.openapi.project.DumbAware;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseGitMacheteRepositoryReadyAction;
@@ -28,14 +29,14 @@ public class ToggleListingCommitsAction extends BaseGitMacheteRepositoryReadyAct
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
 
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     boolean selected = Toggleable.isSelected(presentation);
     Toggleable.setSelected(presentation, selected);
     if (!presentation.isEnabledAndVisible()) {
       return;
     }
 
-    var branchLayout = getBranchLayout(anActionEvent);
+    val branchLayout = getBranchLayout(anActionEvent);
     if (branchLayout.isEmpty()) {
       presentation.setEnabled(false);
       presentation.setDescription(getString("action.GitMachete.ToggleListingCommitsAction.description.disabled.no-branches"));
@@ -63,11 +64,11 @@ public class ToggleListingCommitsAction extends BaseGitMacheteRepositoryReadyAct
     boolean newState = !Toggleable.isSelected(anActionEvent.getPresentation());
     log().debug("Triggered with newState = ${newState}");
 
-    var graphTable = getGraphTable(anActionEvent);
+    val graphTable = getGraphTable(anActionEvent);
     graphTable.setListingCommits(newState);
     graphTable.refreshModel();
 
-    var presentation = anActionEvent.getPresentation();
+    val presentation = anActionEvent.getPresentation();
     Toggleable.setSelected(presentation, newState);
   }
 }

--- a/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/vcsmenu/OpenMacheteTabAction.java
+++ b/frontendActions/src/main/java/com/virtuslab/gitmachete/frontend/actions/vcsmenu/OpenMacheteTabAction.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.openapi.wm.ToolWindowManager;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction;
@@ -44,8 +45,8 @@ public class OpenMacheteTabAction extends BaseProjectDependentAction {
     }
 
     toolWindow.activate(() -> {
-      var contentManager = toolWindow.getContentManager();
-      var tab = contentManager.findContent("Git Machete");
+      val contentManager = toolWindow.getContentManager();
+      val tab = contentManager.findContent("Git Machete");
 
       if (tab == null) {
         LOG.debug("Machete tab does not exist");

--- a/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/project/MacheteProjectResolver.java
+++ b/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/project/MacheteProjectResolver.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.openapi.wm.ToolWindowManager;
 import io.vavr.control.Option;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.virtuslab.gitmachete.frontend.externalsystem.MacheteProjectService;
@@ -32,9 +33,9 @@ public class MacheteProjectResolver implements ExternalSystemProjectResolver<Mac
       ExternalSystemTaskNotificationListener listener)
       throws ExternalSystemException, IllegalArgumentException, IllegalStateException {
 
-    var graphTableProvider = Option.of(settings)
+    val graphTableProvider = Option.of(settings)
         .map(s -> s.getProject().getService(GraphTableProvider.class));
-    var hasSelectedGitMacheteTab = settings != null && hasSelectedGitMacheteTab(settings.getProject());
+    val hasSelectedGitMacheteTab = settings != null && hasSelectedGitMacheteTab(settings.getProject());
 
     if (graphTableProvider.isEmpty()) {
       LOG.warn("Graph table provider is undefined");
@@ -43,7 +44,7 @@ public class MacheteProjectResolver implements ExternalSystemProjectResolver<Mac
     }
 
     String projectName = new File(projectPath).getName();
-    var projectData = new ProjectData(MacheteProjectService.SYSTEM_ID, projectName, projectPath, projectPath);
+    val projectData = new ProjectData(MacheteProjectService.SYSTEM_ID, projectName, projectPath, projectPath);
     return new DataNode<>(ProjectKeys.PROJECT, projectData, /* parent */ null);
   }
 
@@ -54,12 +55,12 @@ public class MacheteProjectResolver implements ExternalSystemProjectResolver<Mac
 
   @SuppressWarnings("interning:not.interned")
   private Boolean hasSelectedGitMacheteTab(Project project) {
-    var toolWindowManager = ToolWindowManager.getInstance(project);
-    var toolWindow = toolWindowManager.getToolWindow(ToolWindowId.VCS);
+    val toolWindowManager = ToolWindowManager.getInstance(project);
+    val toolWindow = toolWindowManager.getToolWindow(ToolWindowId.VCS);
     if (toolWindow != null) {
-      var contentManager = toolWindow.getContentManagerIfCreated();
+      val contentManager = toolWindow.getContentManagerIfCreated();
       if (contentManager != null) {
-        var gitMacheteContent = contentManager.findContent("Git Machete");
+        val gitMacheteContent = contentManager.findContent("Git Machete");
         return contentManager.getSelectedContent() == gitMacheteContent;
       }
     }

--- a/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/settings/MacheteProjectSettings.java
+++ b/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/settings/MacheteProjectSettings.java
@@ -1,12 +1,13 @@
 package com.virtuslab.gitmachete.frontend.externalsystem.settings;
 
 import com.intellij.openapi.externalSystem.settings.ExternalProjectSettings;
+import lombok.val;
 
 public class MacheteProjectSettings extends ExternalProjectSettings {
   @Override
   @SuppressWarnings("superClone")
   public ExternalProjectSettings clone() {
-    var macheteProjectSettings = new MacheteProjectSettings();
+    val macheteProjectSettings = new MacheteProjectSettings();
     copyTo(macheteProjectSettings);
     return macheteProjectSettings;
   }

--- a/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/settings/MacheteSettings.java
+++ b/frontendExternalSystem/src/main/java/com/virtuslab/gitmachete/frontend/externalsystem/settings/MacheteSettings.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.externalSystem.settings.AbstractExternalSystemSettin
 import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListener;
 import com.intellij.openapi.project.Project;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 @Service
 public final class MacheteSettings
@@ -16,8 +17,8 @@ public final class MacheteSettings
 
   protected MacheteSettings(Project project) {
     super(IMacheteSettingsListener.TOPIC, project);
-    var macheteProjectSettings = new MacheteProjectSettings();
-    var projectFilePath = project.getBasePath();
+    val macheteProjectSettings = new MacheteProjectSettings();
+    val projectFilePath = project.getBasePath();
     assert projectFilePath != null : "Project path is null";
     macheteProjectSettings.setExternalProjectPath(projectFilePath);
     loadState(new MyState(macheteProjectSettings));

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.TextFieldWithAutoCompletionListProvider;
+import lombok.val;
 
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
@@ -19,7 +20,7 @@ public class MacheteCompletionContributor extends CompletionContributor implemen
   public void fillCompletionVariants(CompletionParameters parameters, CompletionResultSet result) {
     PsiFile file = parameters.getOriginalFile();
 
-    var branchNames = MacheteFileUtils.getBranchNamesForPsiFile(file);
+    val branchNames = MacheteFileUtils.getBranchNamesForPsiFile(file);
 
     if (branchNames.isEmpty()) {
       return;
@@ -35,8 +36,8 @@ public class MacheteCompletionContributor extends CompletionContributor implemen
     result.stopHere();
 
     String prefix = getCompletionPrefix(parameters);
-    var matcher = new PlainPrefixMatcher(prefix, /* prefixMatchesOnly */ true);
-    var completionResultSet = result.caseInsensitive().withPrefixMatcher(matcher);
+    val matcher = new PlainPrefixMatcher(prefix, /* prefixMatchesOnly */ true);
+    val completionResultSet = result.caseInsensitive().withPrefixMatcher(matcher);
     for (String branchName : branchNames) {
       ProgressManager.checkCanceled();
       completionResultSet.addElement(LookupElementBuilder.create(branchName));
@@ -57,7 +58,7 @@ public class MacheteCompletionContributor extends CompletionContributor implemen
     int lastSpaceIdx = text.lastIndexOf(' ', offset - 1) + 1;
     int lastTabIdx = text.lastIndexOf('\t', offset - 1) + 1;
     int lastNewLine = text.lastIndexOf(System.lineSeparator(), offset - 1) + 1;
-    var max = Math.max(Math.max(lastSpaceIdx, lastTabIdx), lastNewLine);
+    val max = Math.max(Math.max(lastSpaceIdx, lastTabIdx), lastNewLine);
     assert max <= offset : "File offset less than max indent/new line character index";
     assert offset <= text.length() : "File text length less than offset";
     return text.substring(max, offset);

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
@@ -3,6 +3,7 @@ package com.virtuslab.gitmachete.frontend.file;
 import com.intellij.psi.PsiFile;
 import git4idea.repo.GitRepositoryManager;
 import io.vavr.collection.List;
+import lombok.val;
 
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
@@ -12,9 +13,9 @@ public final class MacheteFileUtils {
 
   @UIThreadUnsafe
   public static List<String> getBranchNamesForPsiFile(PsiFile psiFile) {
-    var project = psiFile.getProject();
+    val project = psiFile.getProject();
 
-    var gitRepository = List.ofAll(GitRepositoryManager.getInstance(project).getRepositories())
+    val gitRepository = List.ofAll(GitRepositoryManager.getInstance(project).getRepositories())
         .find(repository -> GitVfsUtils.getMacheteFile(repository)
             .map(macheteFile -> macheteFile.equals(psiFile.getVirtualFile())).getOrElse(false));
 

--- a/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontendFile/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -22,6 +22,7 @@ import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.ui.GuiUtils;
 import io.vavr.control.Option;
 import lombok.Data;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.file.MacheteFileUtils;
@@ -60,7 +61,7 @@ public class MacheteAnnotator implements Annotator, DumbAware {
     MacheteGeneratedBranch branch = macheteEntry.getBranch();
 
     PsiFile file = macheteEntry.getContainingFile();
-    var branchNames = MacheteFileUtils.getBranchNamesForPsiFile(file);
+    val branchNames = MacheteFileUtils.getBranchNamesForPsiFile(file);
 
     if (branchNames.isEmpty()) {
       if (!cantGetBranchesMessageWasShown) {
@@ -70,7 +71,7 @@ public class MacheteAnnotator implements Annotator, DumbAware {
     }
     cantGetBranchesMessageWasShown = false;
 
-    var processedBranchName = branch.getText();
+    val processedBranchName = branch.getText();
 
     if (!branchNames.contains(processedBranchName)) {
       holder
@@ -88,7 +89,7 @@ public class MacheteAnnotator implements Annotator, DumbAware {
       return;
     }
 
-    var prevMacheteGeneratedEntryOption = getPrevSiblingMacheteGeneratedEntry(parent);
+    val prevMacheteGeneratedEntryOption = getPrevSiblingMacheteGeneratedEntry(parent);
     if (prevMacheteGeneratedEntryOption.isEmpty()) {
       holder.newAnnotation(HighlightSeverity.ERROR, getString("string.GitMachete.MacheteAnnotator.cannot-indent-first-entry"))
           .range(element).create();
@@ -115,17 +116,17 @@ public class MacheteAnnotator implements Annotator, DumbAware {
       indentOptions.INDENT_SIZE = indentationParameters.getIndentationWidth();
     }
 
-    var prevIndentationNodeOption = getIndentationNodeFromMacheteGeneratedEntry(prevMacheteGeneratedEntryOption.get());
+    val prevIndentationNodeOption = getIndentationNodeFromMacheteGeneratedEntry(prevMacheteGeneratedEntryOption.get());
     if (prevIndentationNodeOption.isEmpty()) {
       prevLevel = 0;
       hasPrevLevelCorrectWidth = true;
     } else {
-      var prevIndentationText = prevIndentationNodeOption.get().getText();
+      val prevIndentationText = prevIndentationNodeOption.get().getText();
       hasPrevLevelCorrectWidth = prevIndentationText.length() % indentationParameters.indentationWidth == 0;
       prevLevel = prevIndentationText.length() / indentationParameters.indentationWidth;
     }
 
-    var thisIndentationText = element.getText();
+    val thisIndentationText = element.getText();
 
     OptionalInt wrongIndentChar = thisIndentationText.chars().filter(c -> c != indentationParameters.indentationCharacter)
         .findFirst();
@@ -155,7 +156,7 @@ public class MacheteAnnotator implements Annotator, DumbAware {
   }
 
   private IndentationParameters findIndentationParameters(PsiElement currentElement) {
-    var element = getFirstMacheteGeneratedEntry(currentElement);
+    Option<MacheteGeneratedEntry> element = getFirstMacheteGeneratedEntry(currentElement);
     while (element.isDefined() && getIndentationNodeFromMacheteGeneratedEntry(element.get()).isEmpty()) {
       element = getNextSiblingMacheteGeneratedEntry(element.get());
     }
@@ -165,13 +166,13 @@ public class MacheteAnnotator implements Annotator, DumbAware {
       return new IndentationParameters(' ', 4);
     }
 
-    var indentationNodeOption = getIndentationNodeFromMacheteGeneratedEntry(element.get());
+    val indentationNodeOption = getIndentationNodeFromMacheteGeneratedEntry(element.get());
     if (indentationNodeOption.isEmpty()) {
       // Default - this also theoretically should never happen
       return new IndentationParameters(' ', 4);
     }
 
-    var indentationText = indentationNodeOption.get().getText();
+    val indentationText = indentationNodeOption.get().getText();
 
     @SuppressWarnings("index")
     // Indentation text is never empty (otherwise element does not exist)

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/paint/GraphCellPainter.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/paint/GraphCellPainter.java
@@ -13,6 +13,7 @@ import io.vavr.collection.HashMap;
 import io.vavr.collection.List;
 import io.vavr.collection.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.defs.Colors;
@@ -29,7 +30,7 @@ public class GraphCellPainter implements IGraphCellPainter {
 
   @UIEffect
   protected int getRowHeight() {
-    var font = table.getFont();
+    val font = table.getFont();
     // The font (if missing) is being retrieved from parent. In the case of parent absence it could be null.
     if (font != null) {
       // The point is to scale the graph table content (text and graph) along with the font specified by settings.

--- a/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphBuilder.java
+++ b/frontendGraphImpl/src/main/java/com/virtuslab/gitmachete/frontend/graph/impl/repository/RepositoryGraphBuilder.java
@@ -22,6 +22,7 @@ import io.vavr.collection.Map;
 import io.vavr.control.Option;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import lombok.val;
 import org.checkerframework.checker.index.qual.GTENegativeOne;
 import org.checkerframework.checker.index.qual.NonNegative;
 
@@ -63,7 +64,7 @@ public class RepositoryGraphBuilder {
     java.util.List<IGraphItem> graphItems = new ArrayList<>();
     java.util.List<java.util.List<Integer>> positionsOfVisibleEdges = new ArrayList<>();
 
-    for (var rootBranch : rootBranches) {
+    for (val rootBranch : rootBranches) {
       int currentBranchIndex = graphItems.size();
       positionsOfVisibleEdges.add(Collections.emptyList()); // root branches have no visible edges
       addRootBranch(graphItems, rootBranch);
@@ -91,12 +92,12 @@ public class RepositoryGraphBuilder {
       @GTENegativeOne int parentBranchIndex,
       @NonNegative int indentLevel) {
     boolean isFirstBranch = true;
-    var lastChildBranch = childBranches.size() > 0
+    val lastChildBranch = childBranches.size() > 0
         ? childBranches.get(childBranches.size() - 1)
         : null;
 
     int previousBranchIndex = parentBranchIndex;
-    for (var nonRootBranch : childBranches) {
+    for (val nonRootBranch : childBranches) {
       if (!isFirstBranch) {
         graphItems.get(previousBranchIndex).setNextSiblingItemIndex(graphItems.size());
       }
@@ -148,7 +149,7 @@ public class RepositoryGraphBuilder {
       @NonNegative int indentLevel) {
     List<ICommitOfManagedBranch> commits = branchGetCommitsStrategy.getCommitsOf(branch).reverse();
 
-    var syncToParentStatus = branch.getSyncToParentStatus();
+    val syncToParentStatus = branch.getSyncToParentStatus();
     GraphItemColor graphItemColor = getGraphItemColor(syncToParentStatus);
     int branchItemIndex = graphItems.size() + commits.size();
     // We are building some non root branch here so some root branch item has been added already.
@@ -161,7 +162,7 @@ public class RepositoryGraphBuilder {
       assert lastItemIndex >= 0 : "Last node index is less than 0 but shouldn't be";
       int prevSiblingItemIndex = isFirstItemInBranch ? parentBranchIndex : lastItemIndex;
       int nextSiblingItemIndex = graphItems.size() + 1;
-      var c = new CommitItem(commit, branch, graphItemColor, prevSiblingItemIndex, nextSiblingItemIndex, indentLevel);
+      val c = new CommitItem(commit, branch, graphItemColor, prevSiblingItemIndex, nextSiblingItemIndex, indentLevel);
       graphItems.add(c);
       isFirstItemInBranch = false;
     }

--- a/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/RediscoverSuggester.java
+++ b/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/RediscoverSuggester.java
@@ -12,6 +12,7 @@ import git4idea.repo.GitRepository;
 import io.vavr.control.Option;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
@@ -29,19 +30,19 @@ public class RediscoverSuggester {
 
   @UIEffect
   public void perform() {
-    var macheteFilePath = Option.of(gitRepository).map(GitVfsUtils::getMacheteFilePath).getOrNull();
+    val macheteFilePath = Option.of(gitRepository).map(GitVfsUtils::getMacheteFilePath).getOrNull();
     if (macheteFilePath == null) {
       LOG.warn("Cannot proceed with rediscover suggestion workflow - selected machete file is null");
       return;
     }
 
-    var lastModifiedTimeMillis = getFileModificationDate(macheteFilePath).getOrNull();
+    val lastModifiedTimeMillis = getFileModificationDate(macheteFilePath).getOrNull();
     if (lastModifiedTimeMillis == null) {
       LOG.warn("Cannot proceed with rediscover suggestion workflow - could not get file modification date");
       return;
     }
 
-    var daysDiff = daysDiffTillNow(lastModifiedTimeMillis);
+    val daysDiff = daysDiffTillNow(lastModifiedTimeMillis);
     LOG.info("Branch layout has not been modified within ${daysDiff} days");
     if (daysDiff > DAYS_AFTER_WHICH_TO_SUGGEST_DISCOVER) {
       LOG.info("Time diff above ${DAYS_AFTER_WHICH_TO_SUGGEST_DISCOVER}; Suggesting rediscover");
@@ -53,7 +54,7 @@ public class RediscoverSuggester {
 
   @UIEffect
   private void queueSuggestion(Path macheteFilePath) {
-    var yesNo = MessageDialogBuilder.YesNo.yesNo(
+    val yesNo = MessageDialogBuilder.YesNo.yesNo(
         getString("string.GitMachete.RediscoverSuggester.dialog.title"),
         getString("string.GitMachete.RediscoverSuggester.dialog.question"));
 
@@ -73,8 +74,8 @@ public class RediscoverSuggester {
   }
 
   private long daysDiffTillNow(long lastModifiedTimeMillis) {
-    var currentTimeMillis = System.currentTimeMillis();
-    var millisDiff = currentTimeMillis - lastModifiedTimeMillis;
+    val currentTimeMillis = System.currentTimeMillis();
+    val millisDiff = currentTimeMillis - lastModifiedTimeMillis;
     return millisDiff / (24 * 60 * 60 * 1000);
   }
 }

--- a/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/GitMachetePanel.java
+++ b/frontendUiRootImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/GitMachetePanel.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.ui.AncestorListenerAdapter;
 import com.intellij.ui.ScrollPaneFactory;
 import lombok.CustomLog;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.defs.ActionGroupIds;
@@ -37,9 +38,9 @@ public final class GitMachetePanel extends SimpleToolWindowPanel {
     LOG.debug("Instantiating");
     this.project = project;
 
-    var selectedGitRepositoryProvider = project.getService(SelectedGitRepositoryProvider.class);
-    var selectionComponent = selectedGitRepositoryProvider.getSelectionComponent();
-    var graphTable = getGraphTable();
+    val selectedGitRepositoryProvider = project.getService(SelectedGitRepositoryProvider.class);
+    val selectionComponent = selectedGitRepositoryProvider.getSelectionComponent();
+    val graphTable = getGraphTable();
 
     // This class is final, so the instance is `@Initialized` at this point.
 
@@ -51,11 +52,11 @@ public final class GitMachetePanel extends SimpleToolWindowPanel {
     addAncestorListener(new AncestorListenerAdapter() {
       @Override
       public void ancestorAdded(AncestorEvent event) {
-        var gitRepository = selectedGitRepositoryProvider.getSelectedGitRepository().getOrNull();
+        val gitRepository = selectedGitRepositoryProvider.getSelectedGitRepository().getOrNull();
         if (gitRepository != null) {
-          var macheteFilePath = getMacheteFilePath(gitRepository);
+          val macheteFilePath = getMacheteFilePath(gitRepository);
           Runnable queueDiscoverOperation = () -> graphTable.queueDiscover(macheteFilePath, () -> {});
-          var rediscoverSuggester = new RediscoverSuggester(gitRepository, queueDiscoverOperation);
+          val rediscoverSuggester = new RediscoverSuggester(gitRepository, queueDiscoverOperation);
           graphTable.queueRepositoryUpdateAndModelRefresh(() -> rediscoverSuggester.perform());
         }
       }
@@ -68,9 +69,9 @@ public final class GitMachetePanel extends SimpleToolWindowPanel {
 
   @UIEffect
   private static ActionToolbar createGitMacheteVerticalToolbar(BaseEnhancedGraphTable graphTable) {
-    var actionManager = ActionManager.getInstance();
-    var toolbarActionGroup = (ActionGroup) actionManager.getAction(ActionGroupIds.ACTION_GROUP_TOOLBAR);
-    var toolbar = actionManager.createActionToolbar(ActionPlaces.ACTION_PLACE_TOOLBAR, toolbarActionGroup,
+    val actionManager = ActionManager.getInstance();
+    val toolbarActionGroup = (ActionGroup) actionManager.getAction(ActionGroupIds.ACTION_GROUP_TOOLBAR);
+    val toolbar = actionManager.createActionToolbar(ActionPlaces.ACTION_PLACE_TOOLBAR, toolbarActionGroup,
         /* horizontal */ false);
     toolbar.setTargetComponent(graphTable);
     return toolbar;

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -33,7 +33,6 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
-import java.util.Objects;
 
 import javax.swing.JTable;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -47,6 +46,7 @@ import com.intellij.vcs.log.ui.render.LabelPainter;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.Data;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
@@ -92,10 +92,10 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
 
     assert table instanceof IGitMacheteRepositorySnapshotProvider
         : "Table variable is not instance of ${IGitMacheteRepositorySnapshotProvider.class.getSimpleName()}";
-    var gitMacheteRepositorySnapshot = ((IGitMacheteRepositorySnapshotProvider) graphTable).getGitMacheteRepositorySnapshot();
+    val gitMacheteRepositorySnapshot = ((IGitMacheteRepositorySnapshotProvider) graphTable).getGitMacheteRepositorySnapshot();
 
     assert value instanceof BranchOrCommitCell : "value is not an instance of " + BranchOrCommitCell.class.getSimpleName();
-    var cell = (BranchOrCommitCell) value;
+    val cell = (BranchOrCommitCell) value;
 
     IGraphItem graphItem = cell.getGraphItem();
     int maxGraphNodePositionInRow = getMaxGraphNodePositionInRow(graphItem);
@@ -107,7 +107,7 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
     }
     this.graphImage = getGraphImage(graphTable, maxGraphNodePositionInRow);
     Graphics2D g2 = graphImage.createGraphics();
-    var graphCellPainter = graphCellPainterFactoryInstance.create(table);
+    val graphCellPainter = graphCellPainterFactoryInstance.create(table);
     graphCellPainter.draw(g2, renderParts);
 
     this.myTableCellRenderer = new MyTableCellRenderer();
@@ -129,9 +129,9 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
 
     if (graphItem.isBranchItem() && graphItem.asBranchItem().isCurrentBranch()) {
       if (gitMacheteRepositorySnapshot != null) {
-        var ongoingRepositoryOperation = gitMacheteRepositorySnapshot.getOngoingRepositoryOperation();
+        val ongoingRepositoryOperation = gitMacheteRepositorySnapshot.getOngoingRepositoryOperation();
         if (ongoingRepositoryOperation != OngoingRepositoryOperation.NO_OPERATION) {
-          var ongoingOperationName = Match(ongoingRepositoryOperation).of(
+          val ongoingOperationName = Match(ongoingRepositoryOperation).of(
               Case($(OngoingRepositoryOperation.CHERRY_PICKING),
                   getString("string.GitMachete.BranchOrCommitCellRendererComponent.ongoing-operation.cherry-picking")),
               Case($(OngoingRepositoryOperation.MERGING),
@@ -173,7 +173,7 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
       }
 
       SyncToRemoteStatus syncToRemoteStatus = branchItem.getSyncToRemoteStatus();
-      var textAttributes = new SimpleTextAttributes(STYLE_PLAIN, getColor(syncToRemoteStatus));
+      val textAttributes = new SimpleTextAttributes(STYLE_PLAIN, getColor(syncToRemoteStatus));
       String remoteStatusLabel = getSyncToRemoteStatusBasedLabel(syncToRemoteStatus);
       append(" " + remoteStatusLabel, textAttributes);
     } else {
@@ -258,7 +258,8 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
   }
 
   private static String getSyncToRemoteStatusBasedLabel(SyncToRemoteStatus status) {
-    var remoteName = Objects.requireNonNullElse(status.getRemoteName(), "");
+    val maybeRemoteName = status.getRemoteName();
+    val remoteName = maybeRemoteName != null ? maybeRemoteName : "";
     return Match(status.getRelation()).of(
         Case($(isIn(NoRemotes, InSyncToRemote)), ""),
         Case($(Untracked),
@@ -283,8 +284,8 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
   }
 
   private static String getSyncToParentStatusBasedToolTipText(INonRootManagedBranchSnapshot branch) {
-    var currentBranchName = branch.getName();
-    var parentBranchName = branch.getParent().getName();
+    val currentBranchName = branch.getName();
+    val parentBranchName = branch.getParent().getName();
     return Match(branch.getSyncToParentStatus()).of(
         Case($(InSync),
             format(getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.in-sync"),
@@ -314,7 +315,7 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
         int row,
         int column) {
       Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-      var backgroundColor = isSelected ? UIUtil.getListSelectionBackground(table.hasFocus()) : UIUtil.getListBackground();
+      val backgroundColor = isSelected ? UIUtil.getListSelectionBackground(table.hasFocus()) : UIUtil.getListBackground();
       component.setBackground(backgroundColor);
       return component;
     }
@@ -336,8 +337,8 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
   private CellStyle getStyle(int row, int column, boolean hasFocus, boolean selected) {
     Component dummyRendererComponent = myTableCellRenderer.getTableCellRendererComponent(
         graphTable, /* value */ "", selected, hasFocus, row, column);
-    final var background = dummyRendererComponent.getBackground();
-    final var foreground = dummyRendererComponent.getForeground();
+    val background = dummyRendererComponent.getBackground();
+    val foreground = dummyRendererComponent.getForeground();
     // Theoretically the result of getBackground/getForeground can be null.
     // In our case, we have two factors that guarantee us non-null result.
     // - DefaultTableCellRenderer::getTableCellRendererComponent sets the non-null values for us

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
@@ -10,6 +10,7 @@ import io.vavr.control.Option;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.apache.commons.lang.NotImplementedException;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -37,8 +38,8 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
   private final List<IRootManagedBranchSnapshot> roots;
 
   public DemoGitMacheteRepositorySnapshot() {
-    var nullPointedCommit = new Commit("");
-    var fp = new FpCommit("Fork point commit");
+    val nullPointedCommit = new Commit("");
+    val fp = new FpCommit("Fork point commit");
     NonRoot[] nonRoots = {
         new NonRoot(/* name */ "allow-ownership-link",
             /* fullName */ "refs/heads/allow-ownership-link",
@@ -75,13 +76,13 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
             SyncToParentStatus.OutOfSync)
     };
 
-    var root = new Root(/* name */ "develop",
+    val root = new Root(/* name */ "develop",
         /* fullName */ "refs/heads/develop",
         /* customAnnotation */ "# This is a root branch, the underline indicates that it is the currently checked out branch",
         nullPointedCommit,
         /* childBranches */ List.of(nonRoots));
 
-    for (var nr : nonRoots) {
+    for (val nr : nonRoots) {
       nr.setParent(root);
     }
 

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -54,6 +54,7 @@ import io.vavr.control.Option;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UI;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -152,7 +153,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
 
   private void subscribeToSelectedGitRepositoryChange() {
     // The method reference is invoked when user changes repository in selection component menu
-    var gitRepositorySelectionProvider = getGitRepositorySelectionProvider();
+    val gitRepositorySelectionProvider = getGitRepositorySelectionProvider();
     gitRepositorySelectionProvider.addSelectionChangeObserver(() -> queueRepositoryUpdateAndModelRefresh());
   }
 
@@ -240,8 +241,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
           gitMacheteRepositorySnapshot = repositorySnapshot;
           queueRepositoryUpdateAndModelRefresh(doOnUIThreadWhenReady);
 
-          var notifier = VcsNotifier.getInstance(project);
-          var notification = VcsNotifier.STANDARD_NOTIFICATION.createNotification(
+          val notifier = VcsNotifier.getInstance(project);
+          val notification = VcsNotifier.STANDARD_NOTIFICATION.createNotification(
               getString("string.GitMachete.EnhancedGraphTable.automatic-discover.success-message"),
               NotificationType.INFORMATION);
           notification.addAction(NotificationAction.createSimple(
@@ -249,7 +250,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
                 notification.expire();
 
                 DataContext dataContext = DataManager.getInstance().getDataContext(this);
-                var actionEvent = AnActionEvent.createFromDataContext(ACTION_PLACE_VCS_NOTIFICATION, new Presentation(),
+                val actionEvent = AnActionEvent.createFromDataContext(ACTION_PLACE_VCS_NOTIFICATION, new Presentation(),
                     dataContext);
                 ActionManager.getInstance().getAction(ACTION_OPEN_MACHETE_FILE).actionPerformed(actionEvent);
               }));
@@ -269,7 +270,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
   @Override
   @UIEffect
   public void refreshModel() {
-    var gitRepositorySelectionProvider = getGitRepositorySelectionProvider();
+    val gitRepositorySelectionProvider = getGitRepositorySelectionProvider();
     Option<GitRepository> gitRepository = gitRepositorySelectionProvider.getSelectedGitRepository();
     if (gitRepository.isDefined()) {
       refreshModel(gitRepository.get(),
@@ -295,8 +296,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
 
     if (!project.isDisposed()) {
       GuiUtils.invokeLaterIfNeeded(() -> {
-        var gitRepositorySelectionProvider = getGitRepositorySelectionProvider();
-        var gitRepository = gitRepositorySelectionProvider.getSelectedGitRepository().getOrNull();
+        val gitRepositorySelectionProvider = getGitRepositorySelectionProvider();
+        val gitRepository = gitRepositorySelectionProvider.getSelectedGitRepository().getOrNull();
         if (gitRepository == null) {
           LOG.warn("Selected repository is null");
           return;
@@ -374,15 +375,15 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
       ActionManager actionManager = ActionManager.getInstance();
       if (SwingUtilities.isRightMouseButton(e)) {
         ActionGroup contextMenuActionGroup = (ActionGroup) actionManager.getAction(ActionGroupIds.ACTION_GROUP_CONTEXT_MENU);
-        var actionPopupMenu = actionManager.createActionPopupMenu(ACTION_PLACE_CONTEXT_MENU, contextMenuActionGroup);
+        val actionPopupMenu = actionManager.createActionPopupMenu(ACTION_PLACE_CONTEXT_MENU, contextMenuActionGroup);
         JPopupMenu popupMenu = actionPopupMenu.getComponent();
         popupMenu.addPopupMenuListener(popupMenuListener);
         popupMenu.show(graphTable, (int) point.getX(), (int) point.getY());
       } else if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2 && !e.isConsumed()) {
 
-        var gitMacheteRepositorySnapshot = graphTable.gitMacheteRepositorySnapshot;
+        val gitMacheteRepositorySnapshot = graphTable.gitMacheteRepositorySnapshot;
         if (gitMacheteRepositorySnapshot != null) {
-          var isSelectedEqualToCurrent = gitMacheteRepositorySnapshot
+          val isSelectedEqualToCurrent = gitMacheteRepositorySnapshot
               .getCurrentBranchIfManaged().map(b -> b.getName().equals(graphTable.selectedBranchName)).getOrElse(false);
           if (isSelectedEqualToCurrent) {
             return;
@@ -391,7 +392,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
 
         e.consume();
         DataContext dataContext = DataManager.getInstance().getDataContext(graphTable);
-        var actionEvent = AnActionEvent.createFromDataContext(ACTION_PLACE_CONTEXT_MENU, new Presentation(), dataContext);
+        val actionEvent = AnActionEvent.createFromDataContext(ACTION_PLACE_CONTEXT_MENU, new Presentation(), dataContext);
         actionManager.getAction(ACTION_CHECK_OUT).actionPerformed(actionEvent);
       }
     }

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteRepositoryDiscoverer.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteRepositoryDiscoverer.java
@@ -14,6 +14,7 @@ import com.intellij.ui.GuiUtils;
 import io.vavr.control.Try;
 import lombok.AllArgsConstructor;
 import lombok.CustomLog;
+import lombok.val;
 
 import com.virtuslab.binding.RuntimeBinding;
 import com.virtuslab.branchlayout.api.BranchLayoutException;
@@ -33,7 +34,7 @@ public class GitMacheteRepositoryDiscoverer {
   private final Consumer<IGitMacheteRepositorySnapshot> onSuccessRepositoryConsumer;
 
   public void enqueue(Path macheteFilePath) {
-    var selectedRepository = gitRepositorySelectionProvider.getSelectedGitRepository().getOrNull();
+    val selectedRepository = gitRepositorySelectionProvider.getSelectedGitRepository().getOrNull();
     if (selectedRepository == null) {
       LOG.error("Can't do automatic discover because of undefined selected repository");
       return;
@@ -44,11 +45,11 @@ public class GitMacheteRepositoryDiscoverer {
     new Task.Backgroundable(project, getString("string.GitMachete.EnhancedGraphTable.automatic-discover.task-title")) {
       @Override
       public void run(ProgressIndicator indicator) {
-        var discoverRunResult = Try.of(() -> RuntimeBinding.instantiateSoleImplementingClass(IGitMacheteRepositoryCache.class)
+        val discoverRunResult = Try.of(() -> RuntimeBinding.instantiateSoleImplementingClass(IGitMacheteRepositoryCache.class)
             .getInstance(mainDirPath, gitDirPath).discoverLayoutAndCreateSnapshot());
 
         if (discoverRunResult.isFailure()) {
-          var exception = discoverRunResult.getCause();
+          val exception = discoverRunResult.getCause();
           GuiUtils.invokeLaterIfNeeded(() -> VcsNotifier.getInstance(project).notifyError(
               getString(
                   "string.GitMachete.EnhancedGraphTable.automatic-discover.notification.title.cannot-discover-layout-error"),
@@ -56,15 +57,15 @@ public class GitMacheteRepositoryDiscoverer {
           return;
         }
 
-        var repositorySnapshot = discoverRunResult.get();
+        val repositorySnapshot = discoverRunResult.get();
 
         if (repositorySnapshot.getRootBranches().size() == 0) {
           onFailurePathConsumer.accept(macheteFilePath);
           return;
         }
 
-        var branchLayoutWriter = project.getService(BranchLayoutWriterProvider.class).getBranchLayoutWriter();
-        var branchLayout = repositorySnapshot.getBranchLayout().getOrNull();
+        val branchLayoutWriter = project.getService(BranchLayoutWriterProvider.class).getBranchLayoutWriter();
+        val branchLayout = repositorySnapshot.getBranchLayout().getOrNull();
 
         if (branchLayout == null) {
           LOG.error("Can't get branch layout from repository snapshot");

--- a/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTable.java
+++ b/frontendUiTableImpl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/SimpleGraphTable.java
@@ -5,6 +5,7 @@ import javax.swing.ListSelectionModel;
 import com.intellij.ui.ScrollingUtil;
 import com.intellij.util.ui.JBUI;
 import lombok.Getter;
+import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.binding.RuntimeBinding;
@@ -31,8 +32,8 @@ public final class SimpleGraphTable extends BaseGraphTable implements IGitMachet
   @UIEffect
   private static GraphTableModel deriveGraphTableModel(IGitMacheteRepositorySnapshot macheteRepositorySnapshot,
       boolean isListingCommitsEnabled) {
-    var repositoryGraphCache = RuntimeBinding.instantiateSoleImplementingClass(IRepositoryGraphCache.class);
-    var repositoryGraph = repositoryGraphCache.getRepositoryGraph(macheteRepositorySnapshot, isListingCommitsEnabled);
+    val repositoryGraphCache = RuntimeBinding.instantiateSoleImplementingClass(IRepositoryGraphCache.class);
+    val repositoryGraph = repositoryGraphCache.getRepositoryGraph(macheteRepositorySnapshot, isListingCommitsEnabled);
     return new GraphTableModel(repositoryGraph);
   }
 

--- a/frontendVfsUtils/src/main/java/com/virtuslab/gitmachete/frontend/vfsutils/GitVfsUtils.java
+++ b/frontendVfsUtils/src/main/java/com/virtuslab/gitmachete/frontend/vfsutils/GitVfsUtils.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitmachete.frontend.vfsutils;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 
@@ -25,7 +26,7 @@ public final class GitVfsUtils {
 
   public static Path getGitDirectoryPath(GitRepository gitRepository) {
     VirtualFile vfGitDir = getGitDirectory(gitRepository);
-    return Path.of(vfGitDir.getPath());
+    return Paths.get(vfGitDir.getPath());
   }
 
   public static VirtualFile getMainDirectory(GitRepository gitRepository) {
@@ -33,7 +34,7 @@ public final class GitVfsUtils {
   }
 
   public static Path getMainDirectoryPath(GitRepository gitRepository) {
-    return Path.of(getMainDirectory(gitRepository).getPath());
+    return Paths.get(getMainDirectory(gitRepository).getPath());
   }
 
   /**

--- a/gitCoreApi/src/main/java/com/virtuslab/gitcore/api/IGitCoreBranchSnapshot.java
+++ b/gitCoreApi/src/main/java/com/virtuslab/gitcore/api/IGitCoreBranchSnapshot.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitcore.api;
 
 import io.vavr.collection.List;
 import io.vavr.control.Try;
+import lombok.val;
 import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -37,7 +38,7 @@ public interface IGitCoreBranchSnapshot {
     } else if (!(other instanceof IGitCoreBranchSnapshot)) {
       return false;
     } else {
-      var o = (IGitCoreBranchSnapshot) other;
+      val o = (IGitCoreBranchSnapshot) other;
       return self.getFullName().equals(o.getFullName())
           && Try.of(() -> self.getPointedCommit().equals(o.getPointedCommit())).getOrElse(false);
     }

--- a/logging/build.gradle
+++ b/logging/build.gradle
@@ -1,3 +1,4 @@
+lombok()
 slf4jLambdaApi()
 vavr()
 

--- a/logging/src/main/java/com/virtuslab/logger/EnhancedLambdaLogger.java
+++ b/logging/src/main/java/com/virtuslab/logger/EnhancedLambdaLogger.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import io.vavr.collection.Stream;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import kr.pe.kwonnam.slf4jlambda.LambdaLoggerFactory;
+import lombok.val;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class EnhancedLambdaLogger implements IEnhancedLambdaLogger {
@@ -16,8 +17,9 @@ public class EnhancedLambdaLogger implements IEnhancedLambdaLogger {
   private final ThreadLocal<@Nullable Long> timerStartMillis;
 
   EnhancedLambdaLogger(Class<?> clazz) {
-    String category = clazz
-        .getPackageName()
+    Package paccage = clazz.getPackage();
+    String packageName = paccage != null ? paccage.getName() : "<no-package>";
+    String category = packageName
         .replace("com.virtuslab.", "")
         .replaceAll("\\.[^.]+$", "")
         .replaceAll("\\.impl$", "");
@@ -42,7 +44,7 @@ public class EnhancedLambdaLogger implements IEnhancedLambdaLogger {
     // #4: kr.pe.kwonnam.slf4jlambda.LambdaLogger#debug
     // #5: com.virtuslab.logger.MacheteLogger#debug
     // #6: method from which IMacheteLogger.<logMethod> was called;
-    var stackTrace = Thread.currentThread().getStackTrace();
+    val stackTrace = Thread.currentThread().getStackTrace();
     String methodName = Stream.of(stackTrace)
         .find(se -> !isInternalLoggingClass(se.getClassName()))
         .map(se -> se.getMethodName())

--- a/src/main/resources/META-INF/com.virtuslab.git-machete-withExternalSystem.xml
+++ b/src/main/resources/META-INF/com.virtuslab.git-machete-withExternalSystem.xml
@@ -1,0 +1,6 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij">
+        <externalSystemManager implementation="com.virtuslab.gitmachete.frontend.externalsystem.MacheteProjectService"/>
+        <externalIconProvider key="MACHETE" implementationClass="com.virtuslab.gitmachete.frontend.externalsystem.MacheteIconProvider"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/com.virtuslab.git-machete-withExternalSystem.xml
+++ b/src/main/resources/META-INF/com.virtuslab.git-machete-withExternalSystem.xml
@@ -1,6 +1,11 @@
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
-        <externalSystemManager implementation="com.virtuslab.gitmachete.frontend.externalsystem.MacheteProjectService"/>
         <externalIconProvider key="MACHETE" implementationClass="com.virtuslab.gitmachete.frontend.externalsystem.MacheteIconProvider"/>
+
+        <externalSystemManager implementation="com.virtuslab.gitmachete.frontend.externalsystem.MacheteProjectService"/>
+
+        <!-- See javadoc of com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil.isInProcessMode -->
+        <registryKey key="MACHETE.system.in.process" defaultValue="true"
+                     description="Whether IDEA should use 'in-process' mode for interaction with machete API"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,10 +3,12 @@
     <name>Git Machete</name>
     <vendor email="gitmachete@virtuslab.com" url="https://virtuslab.com">VirtusLab</vendor>
 
-    <depends optional="true" config-file="com.virtuslab.git-machete-withExternalSystem.xml">com.intellij.modules.externalSystem</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>
+    <!-- For some reason, out of all IntelliJ-based IDEs, externalSystem is NOT supported by Android Studio. -->
+    <!-- Without making this dependency optional, we can't be compatible with AS. -->
+    <depends optional="true" config-file="com.virtuslab.git-machete-withExternalSystem.xml">com.intellij.modules.externalSystem</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <changesViewContent tabName="Git Machete"
@@ -19,10 +21,6 @@
                                       implementationClass="com.virtuslab.gitmachete.frontend.file.MacheteFileViewProviderFactory"/>
         <completion.contributor language="Machete"
                                 implementationClass="com.virtuslab.gitmachete.frontend.file.MacheteCompletionContributor"/>
-
-        <!-- See javadoc of com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil.isInProcessMode -->
-        <registryKey key="MACHETE.system.in.process" defaultValue="true"
-                     description="Whether IDEA should use 'in-process' mode for interaction with machete API"/>
 
         <lang.parserDefinition language="Machete"
                                implementationClass="com.virtuslab.gitmachete.frontend.file.grammar.MacheteParserDefinition"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
     <name>Git Machete</name>
     <vendor email="gitmachete@virtuslab.com" url="https://virtuslab.com">VirtusLab</vendor>
 
-    <depends>com.intellij.modules.externalSystem</depends>
+    <depends optional="true" config-file="com.virtuslab.git-machete-withExternalSystem.xml">com.intellij.modules.externalSystem</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends>Git4Idea</depends>
@@ -19,12 +19,10 @@
                                       implementationClass="com.virtuslab.gitmachete.frontend.file.MacheteFileViewProviderFactory"/>
         <completion.contributor language="Machete"
                                 implementationClass="com.virtuslab.gitmachete.frontend.file.MacheteCompletionContributor"/>
-        <externalSystemManager implementation="com.virtuslab.gitmachete.frontend.externalsystem.MacheteProjectService"/>
-        <externalIconProvider key="MACHETE" implementationClass="com.virtuslab.gitmachete.frontend.externalsystem.MacheteIconProvider"/>
 
         <!-- See javadoc of com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil.isInProcessMode -->
         <registryKey key="MACHETE.system.in.process" defaultValue="true"
-                     description="Whether IDEA should use 'in-process' mode for interaction with machete api"/>
+                     description="Whether IDEA should use 'in-process' mode for interaction with machete API"/>
 
         <lang.parserDefinition language="Machete"
                                implementationClass="com.virtuslab.gitmachete.frontend.file.grammar.MacheteParserDefinition"/>
@@ -50,15 +48,15 @@
                 <override-text place="GitMacheteContextMenu"/>
             </action>
 
-            <action id="GitMachete.OverrideForkPointOfSelectedBranchAction"
-                    class="com.virtuslab.gitmachete.frontend.actions.contextmenu.OverrideForkPointOfSelectedBranchAction"
-                    icon="MacheteIcons.OVERRIDE_FORK_POINT">
-                <override-text place="GitMacheteContextMenu"/>
-            </action>
-
             <action id="GitMachete.RebaseSelectedBranchOntoParentAction"
                     class="com.virtuslab.gitmachete.frontend.actions.contextmenu.RebaseSelectedBranchOntoParentAction"
                     icon="MacheteIcons.REBASE">
+                <override-text place="GitMacheteContextMenu"/>
+            </action>
+
+            <action id="GitMachete.OverrideForkPointOfSelectedBranchAction"
+                    class="com.virtuslab.gitmachete.frontend.actions.contextmenu.OverrideForkPointOfSelectedBranchAction"
+                    icon="MacheteIcons.OVERRIDE_FORK_POINT">
                 <override-text place="GitMacheteContextMenu"/>
             </action>
 

--- a/src/test/java/com/virtuslab/archunit/ClassStructureTestSuite.java
+++ b/src/test/java/com/virtuslab/archunit/ClassStructureTestSuite.java
@@ -4,9 +4,13 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.AccessTarget;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import org.junit.Test;
+
+import com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction;
 
 public class ClassStructureTestSuite extends BaseArchUnitTestSuite {
 
@@ -25,9 +29,9 @@ public class ClassStructureTestSuite extends BaseArchUnitTestSuite {
   public void actions_overriding_onUpdate_should_call_super_onUpdate() {
     classes()
         .that()
-        .areAssignableTo(com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction.class)
+        .areAssignableTo(BaseProjectDependentAction.class)
         .and()
-        .areNotAssignableFrom(com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction.class)
+        .areNotAssignableFrom(BaseProjectDependentAction.class)
         .and(new DescribedPredicate<JavaClass>("override onUpdate method") {
           @Override
           public boolean apply(JavaClass input) {
@@ -39,8 +43,8 @@ public class ClassStructureTestSuite extends BaseArchUnitTestSuite {
             new DescribedPredicate<JavaMethodCall>("name is onUpdate and owner is the direct superclass") {
               @Override
               public boolean apply(JavaMethodCall input) {
-                var origin = input.getOrigin(); // where is the method called from?
-                var target = input.getTarget(); // where is the method declared?
+                JavaCodeUnit origin = input.getOrigin(); // where is the method called from?
+                AccessTarget.MethodCallTarget target = input.getTarget(); // where is the method declared?
 
                 if (origin.getName().equals("onUpdate") && target.getName().equals("onUpdate")) {
                   return target.getOwner().equals(origin.getOwner().getSuperClass().orNull());

--- a/testCommon/build.gradle
+++ b/testCommon/build.gradle
@@ -1,2 +1,3 @@
+commonsIO()
 junit()
 lombok()

--- a/testCommon/src/test/java/com/virtuslab/gitmachete/testcommon/BaseGitRepositoryBackedIntegrationTestSuite.java
+++ b/testCommon/src/test/java/com/virtuslab/gitmachete/testcommon/BaseGitRepositoryBackedIntegrationTestSuite.java
@@ -2,13 +2,17 @@ package com.virtuslab.gitmachete.testcommon;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 import java.util.concurrent.TimeUnit;
 
 import lombok.SneakyThrows;
+import lombok.val;
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 
 public abstract class BaseGitRepositoryBackedIntegrationTestSuite {
@@ -39,20 +43,21 @@ public abstract class BaseGitRepositoryBackedIntegrationTestSuite {
   private void copyScriptFromResources(String scriptName) {
     URL resourceUrl = getClass().getResource("/" + scriptName);
     assert resourceUrl != null : "Can't get resource";
-    Files.copy(Path.of(resourceUrl.toURI()), parentDir.resolve(scriptName), StandardCopyOption.REPLACE_EXISTING);
+    Files.copy(Paths.get(resourceUrl.toURI()), parentDir.resolve(scriptName), StandardCopyOption.REPLACE_EXISTING);
   }
 
   @SneakyThrows
   private void prepareRepoFromScript(String scriptName) {
-    var process = new ProcessBuilder()
+    val process = new ProcessBuilder()
         .command("/bin/bash", parentDir.resolve(scriptName).toString())
         .directory(parentDir.toFile())
         .start();
-    var completed = process.waitFor(5, TimeUnit.SECONDS);
+    val completed = process.waitFor(5, TimeUnit.SECONDS);
 
     if (!completed || process.exitValue() != 0) {
-      System.out.println(new String(process.getInputStream().readAllBytes()));
-      System.err.println(new String(process.getErrorStream().readAllBytes()));
+
+      System.out.println(IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8));
+      System.err.println(IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8));
     }
 
     Assert.assertTrue(completed);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3383210/108436194-4626e580-724b-11eb-8633-754b264c3d68.png)

It wasn't working so far... since Android Studio still runs on Java 8, and we were building for Java 11.

I'm still not sure tho if Marketplace will classify the plugin as compatible with Android Studio:

![image](https://user-images.githubusercontent.com/3383210/108436228-576ff200-724b-11eb-8a06-d768a0ae4221.png)

They claim it isn't due to dependency on `externalSystem`... let's see if making this dep optional changes anything.