### PR TITLE
Remove link to CLI reference blog post

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,0 @@
-**/build/
-.circleci/
-Dockerfile*
-.dockerignore
-docs/
-.git/
-.gradle/
-.idea/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CircleCI](https://circleci.com/gh/VirtusLab/git-machete-intellij-plugin/tree/master.svg?style=shield)](https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin?branch=master)
 [![JetBrains Plugins](https://img.shields.io/jetbrains/plugin/v/14221-git-machete.svg)](https://plugins.jetbrains.com/plugin/14221-git-machete)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/14221-git-machete.svg)](https://plugins.jetbrains.com/plugin/14221-git-machete)
+![License: MIT](https://img.shields.io/github/license/VirtusLab/git-machete-intellij-plugin)
 
 <img src="docs/logo.svg" style="width: 100%; display: block; margin-bottom: 10pt;"/>
 
@@ -187,8 +188,8 @@ Then reproduce the bug and go to `Help > Show Log in Files` to open the log file
 For additional background on what we believe are good practices take a look into our [slides presentation](http://slides.com/plipski/git-machete).
 It explains our motivations and gives you an overview of main Git Machete objectives.
 
-See also [git-machete](https://github.com/VirtusLab/git-machete#git-machete) &mdash; a CLI version of this plugin.
+For more information about the plugin,
+see the [teaser blog post](https://medium.com/virtuslab/take-a-look-at-your-repository-from-a-new-perspective-with-git-machete-plugin-e2e5e4197a0b)
+and the [complete feature list](docs/features.md).
 
-For more information about the `git machete`,
-see the [teaser blog post for this plugin](https://medium.com/virtuslab/take-a-look-at-your-repository-from-a-new-perspective-with-git-machete-plugin-e2e5e4197a0b)
-and the [reference blog post for CLI](https://medium.com/virtuslab/make-your-way-through-the-git-rebase-jungle-with-git-machete-e2ed4dbacd02).
+See also [git-machete](https://github.com/VirtusLab/git-machete#git-machete) &mdash; a CLI version of this plugin.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -183,8 +183,8 @@ Other coding conventions include:
 To push the rebuilt image, you need write access to [`gitmachete` organization on Docker Hub](https://hub.docker.com/orgs/gitmachete).
 
 ```
-docker build -t gitmachete/intellij-plugin-ci:<SEMANTIC-VERSION> .
-docker push gitmachete/intellij-plugin-ci:<SEMANTIC-VERSION>
+docker build -t gitmachete/intellij-plugin-ci:SEMANTIC-VERSION - < Dockerfile
+docker push gitmachete/intellij-plugin-ci:SEMANTIC-VERSION
 ```
 
 


### PR DESCRIPTION
Actually, docs of this plugin are pretty self-contained... pointing people to the CLI docs can only cause confusion (see issue 709).