### PR TITLE
Improve error message to diagnose spurious BranchLayoutException in UI tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,19 +24,9 @@ RUN set -x \
   && dir=/root/.local/share/JetBrains/consentOptions \
   && mkdir -p "$dir" \
   && echo -n "rsch.send.usage.stat:1.1:0:$(date +%s)000" > "$dir/accepted"
-# Accept End User Agreement/privacy policy
-RUN set -x \
-  && dir="/root/.java/.userPrefs/jetbrains/_!(!!cg\"p!(}!}@\"j!(k!|w\"w!'8!b!\"p!':!e@==" \
-  && mkdir -p "$dir" \
-  && echo '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n\
-<!DOCTYPE map SYSTEM "http://java.sun.com/dtd/preferences.dtd">\n\
-<map MAP_XML_VERSION="1.0">\n\
-  <entry key="accepted_version" value="2.4"/>\n\
-  <entry key="eua_accepted_version" value="1.2"/>\n\
-  <entry key="ij_euaeap_accepted_version" value="3.0"/>\n\
-  <entry key="privacyeap_accepted_version" value="2.1"/>\n\
-</map>' > "$dir/prefs.xml" \
-  && cat "$dir/prefs.xml"
+# Note that if we were to run `./gradlew runIdeForUiTests`,
+# we'd need to populate /root/.java/.userPrefs/jetbrains/.../prefs.xml to accept End User Agreement/privacy policy.
+# But in our setup, it's sorted out by ide-probe instead (org.virtuslab.ideprobe.ide.intellij.IntellijPrivacyPolicy).
 
 # Tools necessary to run non-headless UI tests in the screen-less environment of CI
 RUN set -x \

--- a/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReader.java
+++ b/branchLayoutImpl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReader.java
@@ -136,7 +136,7 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
       }
 
       int lineIndentWidth = BranchLayoutFileUtils.getIndentWidth(line, indentSpec.getIndentCharacter());
-      int level = getIndentLevel(path, indentSpec, lineIndentWidth, realLineNumber);
+      int level = getIndentLevel(path, indentSpec, line, lineIndentWidth, realLineNumber);
 
       if (level - previousLevel > 1) {
         throw new BranchLayoutException(realLineNumber + 1,
@@ -159,7 +159,7 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
     return lineIndexToIndentLevelAndParentLineIndex;
   }
 
-  private @NonNegative int getIndentLevel(Path path, IndentSpec indentSpec, @NonNegative int indent,
+  private @NonNegative int getIndentLevel(Path path, IndentSpec indentSpec, String line, @NonNegative int indent,
       @NonNegative int lineNumber)
       throws BranchLayoutException {
     if (indent == 0) {
@@ -168,7 +168,8 @@ public class BranchLayoutFileReader implements IBranchLayoutReader {
 
     if (indent % indentSpec.getIndentWidth() != 0) {
       throw new BranchLayoutException(lineNumber + 1,
-          "Levels of indentation are not matching in branch layout file (${path.toAbsolutePath()})");
+          "Levels of indentation are not matching in branch layout file (${path.toAbsolutePath()}): " +
+              "line `${line}` has ${indent} indent characters, but expected a multiply of ${indentSpec.getIndentWidth()}");
     }
 
     return indent / indentSpec.getIndentWidth();

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ ext {
     // EAP-CANDIDATE-SNAPSHOTs can be used for binary compatibility checks,
     // but for some reason aren't resolved in UI tests.
     // Generally, see https://www.jetbrains.com/intellij-repository/snapshots/ -> Ctrl+F idea
-    eapOfLatestSupportedMajor: '211.6693.14-EAP-SNAPSHOT'
+    eapOfLatestSupportedMajor: '211.6693.65-EAP-SNAPSHOT'
   ]
 
   intellijVersions.latestSupportedMajor = intellijVersions.eapOfLatestSupportedMajor
@@ -46,7 +46,7 @@ ext {
   checkerFrameworkVersion = '3.11.0'
   checkstyleToolVersion = '8.33'
   commonsIOVersion = '2.5'
-  ideProbeVersion = '0.5.0+11-c291a948-SNAPSHOT'
+  ideProbeVersion = '0.5.0+12-ce9efc96-SNAPSHOT'
   jetbrainsAnnotationsVersion = '19.0.0' // version effectively enforced by the IntelliJ plugin
   jgitVersion = '5.11.0.202103091610-r'
   junitVersion = '4.13.2'


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin/4018/workflows/5c85e873-e944-43fa-b702-71a49330eda4/jobs/4227, first time I've seen anything like that lol

From `com.virtuslab.gitmachete.uitest.UITestSuite > skipNonExistentBranches_toggleListingCommits_slideOutRoot`:

```
    [intellij-stderr] 2021-03-31 15:05:40,489 [ 236110]  ERROR -         gitmachete.frontend.ui - GitMacheteRepositoryUpdateBackgroundable#handleUpdateRepositoryException: Unable to create Git Machete repository
    [intellij-stderr] com.virtuslab.gitmachete.backend.api.MacheteFileReaderException: Error occurred while parsing machete file in line 2
    [intellij-stderr] 	at com.virtuslab.gitmachete.frontend.ui.impl.table.GitMacheteRepositoryUpdateBackgroundable.readBranchLayout(GitMacheteRepositoryUpdateBackgroundable.java:103)
    [intellij-stderr] 	at com.virtuslab.gitmachete.frontend.ui.impl.table.GitMacheteRepositoryUpdateBackgroundable.lambda$updateRepositorySnapshot$4b6e116c$1(GitMacheteRepositoryUpdateBackgroundable.java:88)
    [intellij-stderr] 	at io.vavr.control.Try.of(Try.java:75)
    [intellij-stderr] 	at com.virtuslab.gitmachete.frontend.ui.impl.table.GitMacheteRepositoryUpdateBackgroundable.updateRepositorySnapshot(GitMacheteRepositoryUpdateBackgroundable.java:87)
    [intellij-stderr] 	at com.virtuslab.gitmachete.frontend.ui.impl.table.GitMacheteRepositoryUpdateBackgroundable.run(GitMacheteRepositoryUpdateBackgroundable.java:63)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:962)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressAsync$5(CoreProgressManager.java:472)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$3(ProgressRunner.java:235)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:178)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:658)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:610)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:65)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:165)
    [intellij-stderr] 	at com.intellij.openapi.progress.impl.ProgressRunner.lambda$submit$4(ProgressRunner.java:235)
    [intellij-stderr] 	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
    [intellij-stderr] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    [intellij-stderr] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    [intellij-stderr] 	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
    [intellij-stderr] 	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
    [intellij-stderr] 	at java.base/java.security.AccessController.doPrivileged(Native Method)
    [intellij-stderr] 	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
    [intellij-stderr] 	at java.base/java.lang.Thread.run(Thread.java:834)
    [intellij-stderr] Caused by: com.virtuslab.branchlayout.api.BranchLayoutException: Levels of indentation are not matching in branch layout file (/tmp/machete-tests-5019309205189326351/machete-sandbox/.git/machete). Problematic line number: 2
    [intellij-stderr] 	at com.virtuslab.branchlayout.impl.readwrite.BranchLayoutFileReader.getIndentLevel(BranchLayoutFileReader.java:7)
    [intellij-stderr] 	at com.virtuslab.branchlayout.impl.readwrite.BranchLayoutFileReader.parseToArrayRepresentation(BranchLayoutFileReader.java:139)
    [intellij-stderr] 	at com.virtuslab.branchlayout.impl.readwrite.BranchLayoutFileReader.read(BranchLayoutFileReader.java:40)
    [intellij-stderr] 	at com.virtuslab.branchlayout.impl.readwrite.BranchLayoutFileReader.read(BranchLayoutFileReader.java:20)
    [intellij-stderr] 	at com.virtuslab.gitmachete.frontend.ui.impl.table.GitMacheteRepositoryUpdateBackgroundable.readBranchLayout(GitMacheteRepositoryUpdateBackgroundable.java:99)
    [intellij-stderr] 	... 21 more
    [intellij-stderr]  
```