### PR TITLE
windows hooks

### DIFF
--- a/backendImpl/build.gradle
+++ b/backendImpl/build.gradle
@@ -1,5 +1,6 @@
 commonsIO()
 jcabiAspects()
+jgit()
 junit()
 lombok()
 powerMock()

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/hooks/BaseHookExecutor.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/hooks/BaseHookExecutor.java
@@ -6,10 +6,12 @@ abstract class BaseHookExecutor {
   protected static final String NL = System.lineSeparator();
 
   protected final File rootDirectory;
+  protected final File mainGitDirectory;
   protected final File hookFile;
 
-  protected BaseHookExecutor(File rootDirectory, File hookFile) {
+  protected BaseHookExecutor(File rootDirectory, File mainGitDirectory, File hookFile) {
     this.rootDirectory = rootDirectory;
+    this.mainGitDirectory = mainGitDirectory;
     this.hookFile = hookFile;
   }
 }

--- a/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/hooks/PreRebaseHookExecutor.java
+++ b/backendImpl/src/main/java/com/virtuslab/gitmachete/backend/impl/hooks/PreRebaseHookExecutor.java
@@ -21,18 +21,19 @@ import com.virtuslab.gitmachete.backend.api.hooks.IExecutionResult;
 public final class PreRebaseHookExecutor extends BaseHookExecutor {
   private static final int EXECUTION_TIMEOUT_SECONDS = 10;
 
-  private PreRebaseHookExecutor(File rootDirectory, File hookFile) {
-    super(rootDirectory, hookFile);
+  private PreRebaseHookExecutor(File rootDirectory, File mainGitDirectory, File hookFile) {
+    super(rootDirectory, mainGitDirectory, hookFile);
   }
 
   public static PreRebaseHookExecutor of(IGitCoreRepository gitCoreRepository) {
     val hooksDir = gitCoreRepository.deriveConfigValue("core", "hooksPath");
     val hooksDirPath = hooksDir.map(Paths::get).getOrElse(gitCoreRepository.getMainGitDirectoryPath().resolve("hooks"));
 
+    val mainGitDirectory = gitCoreRepository.getMainGitDirectoryPath().toFile();
     val rootDirectory = gitCoreRepository.getRootDirectoryPath().toFile();
     val hookFile = hooksDirPath.resolve("machete-pre-rebase").toFile();
 
-    return new PreRebaseHookExecutor(rootDirectory, hookFile);
+    return new PreRebaseHookExecutor(rootDirectory, mainGitDirectory, hookFile);
   }
 
   /**


### PR DESCRIPTION
created just for a record. I tried jgit FS DETECT solution. It ended with `NOT_SUPPORTED` error message on windows, so...

1. we can use that anyway and 
 ➕ have a higher level handling of hook execution 
 ➖ dependency on jgit in the module
 ➖ similar or even greater amount of code
2. stick up with the current solution 

let's go for the option 2️⃣ 