### PR TITLE
Fix shortcut and docs for the git machete tab open on mac

### DIFF
--- a/CHANGE-NOTES.html
+++ b/CHANGE-NOTES.html
@@ -7,3 +7,5 @@
 
 <p><i>Show in Git log</i> action has been added to per-branch context menu options.
     The action points to a branch (its latest local commit) within IntelliJ's built-in Git log, as suggested by @KotlinIsland.</p>
+
+<p>Fix docs on the shortcut that opens Git Machete Tab <i>(command option shift M)</i> on Mac.</p>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,16 @@ ln -s ../../scripts/git-hooks/post-commit .git/hooks/post-commit
 ln -s ../../scripts/run-pre-build-checks .git/hooks/pre-commit
 ```
 
+#### Windows
 **The hooks do not work on Windows** (however their execution seems to be possible theoretically).
 This is because one may not be emulating bash environment in any way or doing it in some specific way.
+
+#### Mac OS
+Some hooks use `grep`. The Mac OS version of `grep` (FreeBSD) differs from GNU `grep`.
+In order to make `grep` and eventually the hooks working one must:
+1. Install `grep` via `brew` (it will not override system's `grep` - it can be executed as `ggrep`)
+2. Run `brew ls -v grep`; among the other a path like should be found `/opt/homebrew/Cellar/grep/3.7/libexec/gnubin/grep`
+3. Add the found path without `/grep` suffix to `PATH` (`/opt/homebrew/Cellar/grep/3.7/libexec/gnubin` in that case)
 
 ### (optional) Windows
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Some hooks use `grep`. The Mac OS version of `grep` (FreeBSD) differs from GNU `
 In order to make `grep` and eventually the hooks working one must:
 1. Install `grep` via `brew` (it will not override system's `grep` - it can be executed as `ggrep`)
 2. Run `brew ls -v grep`; among the other a path like should be found `/opt/homebrew/Cellar/grep/3.7/libexec/gnubin/grep`
-3. Add the found path without `/grep` suffix to `PATH` (`/opt/homebrew/Cellar/grep/3.7/libexec/gnubin` in that case)
+3. Prepend the found path without `/grep` suffix to `PATH` (`/opt/homebrew/Cellar/grep/3.7/libexec/gnubin` in that case)
 
 ### (optional) Windows
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,9 @@ ln -s ../../scripts/git-hooks/post-commit .git/hooks/post-commit
 ln -s ../../scripts/run-pre-build-checks .git/hooks/pre-commit
 ```
 
+**The hooks do not work on Windows** (however their execution seems to be possible theoretically).
+This is because one may not be emulating bash environment in any way or doing it in some specific way.
+
 ### (optional) Windows
 
 Building this project on Windows has been tested under [Git Bash](https://gitforwindows.org/).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In that case, just click `Restart IDE` and confirm that action in a message box.
 ## Where to find the plugin tab
 
 Git Machete IntelliJ Plugin is available under the `Git` tool window in the `Git Machete` tab. <br/>
-You can also use `Ctrl + Alt + Shift + M` (⌃⌥⇧M on Mac) shortcut to open it.
+You can also use `Ctrl + Alt + Shift + M` (`⌃⌥⇧M` on Mac OS) shortcut to open it.
 
 
 ## Getting started with Git Machete

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In that case, just click `Restart IDE` and confirm that action in a message box.
 ## Where to find the plugin tab
 
 Git Machete IntelliJ Plugin is available under the `Git` tool window in the `Git Machete` tab. <br/>
-You can also use `Ctrl + Alt + Shift + M` (`⌃⌥⇧M` on Mac OS) shortcut to open it.
+You can also use `Ctrl + Alt + Shift + M` (`⌘⌥⇧M` on Mac OS) shortcut to open it.
 
 
 ## Getting started with Git Machete

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,7 +3,7 @@
 ## Where to find the plugin tab
 
 Git Machete IntelliJ Plugin is available under the `Git` tool window in the `Git Machete` tab.
-You can also use `Ctrl + Alt + Shift + M` (`Ctrl + Option + Shift + M` on Mac OS) shortcut to open it.
+You can also use `Ctrl + Alt + Shift + M` (`Command + Option + Shift + M` on Mac OS) shortcut to open it.
 
 ![](open_git_machete.gif)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,7 +3,7 @@
 ## Where to find the plugin tab
 
 Git Machete IntelliJ Plugin is available under the `Git` tool window in the `Git Machete` tab.
-You can also use `Ctrl + Alt + Shift + M` shortcut to open it.
+You can also use `Ctrl + Alt + Shift + M` (`Ctrl + Option + Shift + M` on Mac OS) shortcut to open it.
 
 ![](open_git_machete.gif)
 

--- a/docs/plugins.jetbrains.com/general_usage_instructions.html
+++ b/docs/plugins.jetbrains.com/general_usage_instructions.html
@@ -6,7 +6,7 @@
     Open Git Machete tab:
     <ul>
       <li>Navigate <b>Git</b> (tool window) -> <b>Git Machete</b> (tab)</li>
-      <li>Or use key shortcut: Ctrl + Alt + Shift + M (Ctrl + Option + Shift + M on Mac OS)</li>
+      <li>Or use key shortcut: Ctrl + Alt + Shift + M (Command + Option + Shift + M on Mac OS)</li>
     </ul>
     Branch layout will be automatically discovered and a tree-shaped graph of branches will show up.
   </li>

--- a/docs/plugins.jetbrains.com/general_usage_instructions.html
+++ b/docs/plugins.jetbrains.com/general_usage_instructions.html
@@ -6,7 +6,7 @@
     Open Git Machete tab:
     <ul>
       <li>Navigate <b>Git</b> (tool window) -> <b>Git Machete</b> (tab)</li>
-      <li>Or use key shortcut: Ctrl + Alt + Shift + M</li>
+      <li>Or use key shortcut: Ctrl + Alt + Shift + M (Ctrl + Option + Shift + M on Mac OS)</li>
     </ul>
     Branch layout will be automatically discovered and a tree-shaped graph of branches will show up.
   </li>

--- a/scripts/prohibit-java-class-name-hardcode-in-strings
+++ b/scripts/prohibit-java-class-name-hardcode-in-strings
@@ -5,7 +5,7 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/utils.sh
 
-class_names=$(git ls-files '*.java' | xargs basename -s .java | sort | paste -sd'|')
+class_names=$(git ls-files '*.java' | xargs basename -s .java | sort | tr '\n' '|' | sed 's/.$//')
 
 # Let's allow for class names preceded with `action.GitMachete.` (for property keys).
 if git grep -PHn '^[^"]*"[^"$]*(?<!(action|string)\.GitMachete\.)\b('"$class_names"')\b' -- '*.java' ':!frontendDefs' ':!frontendResourceBundles'; then

--- a/scripts/prohibit-non-ascii-characters
+++ b/scripts/prohibit-non-ascii-characters
@@ -11,7 +11,7 @@ source "$self_dir"/utils.sh
 # Excluding tab (detected in a separate script for a clearer error message and a different set of whitelisted files).
 # gradlew is whitelisted since it contains e.g. a copyright character.
 # README.md is whitelisted since it contains emojis.
-# CONTRIBUTING.md is whitelisted since it contains Mac key symbols.
+# CONTRIBUTING.md is whitelisted since it contains Mac OS key symbols.
 if LC_ALL=C git grep -PIn '[^\x09\x20-\x7F]' -- ':!gradlew' ':!README.md' ':!CONTRIBUTING.md'; then
   die 'The above lines contain character(s) outside of 0x20-0x7F range, please tidy up'
 fi

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -193,8 +193,6 @@
                  We can consider `VcsGroups` that seems to be more stable and place this action in VCS menu -->
             <add-to-group group-id="GitRepositoryActions" anchor="last"/>
             <keyboard-shortcut keymap="$default" first-keystroke="control alt shift M" />
-            <keyboard-shortcut first-keystroke="control alt shift M" keymap="Mac OS X" replace-all="true"/>
-            <keyboard-shortcut first-keystroke="control alt shift M" keymap="Mac OS X 10.5+" replace-all="true"/>
         </action>
     </actions>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -192,6 +192,7 @@
             <!-- In future IntelliJ releases this group-id will probably be `Git.MainMenu`
                  We can consider `VcsGroups` that seems to be more stable and place this action in VCS menu -->
             <add-to-group group-id="GitRepositoryActions" anchor="last"/>
+            <!-- In $default keymap `control` key (Windows/Linux) corresponds to `cmd` key on Mac OS -->
             <keyboard-shortcut keymap="$default" first-keystroke="control alt shift M" />
         </action>
     </actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,6 +8,7 @@
     <depends>Git4Idea</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+<!--        todo (#825): drop support for 2021.1 -->
         <changesViewContent tabName="Git Machete"
                             className="com.virtuslab.gitmachete.frontend.ui.impl.root.GitMacheteContentProvider"
                             predicateClassName="com.virtuslab.gitmachete.frontend.ui.impl.root.GitMacheteVisibilityPredicate"/>
@@ -192,6 +193,8 @@
                  We can consider `VcsGroups` that seems to be more stable and place this action in VCS menu -->
             <add-to-group group-id="GitRepositoryActions" anchor="last"/>
             <keyboard-shortcut keymap="$default" first-keystroke="control alt shift M" />
+            <keyboard-shortcut first-keystroke="control alt shift M" keymap="Mac OS X" replace-all="true"/>
+            <keyboard-shortcut first-keystroke="control alt shift M" keymap="Mac OS X 10.5+" replace-all="true"/>
         </action>
     </actions>
 


### PR DESCRIPTION
Open Git Machete Tab:
Linux/Windows - `Ctrl + Alt + Shift + M`
Mac OS - `Ctrl + Option + Shift + M`
 

