### PR TITLE
Make ide-probe reuse IntelliJs downloaded by intellij-plugin-verifier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Use IntelliJ IDEA Community Edition/Ultimate.
 4. (optional) Install the following non-bundled plugins from Marketplace:
    * [Grammar-Kit IntelliJ plugin](https://plugins.jetbrains.com/plugin/6606-grammar-kit) can be used instead of Gradle plugin
      to manually generate grammar and lexer code from `.bnf` and `.flex` files.
+   * [HOCON plugin](https://plugins.jetbrains.com/plugin/10481-hocon) for `.conf` file support in UI tests
    * [Kotlin plugin](https://plugins.jetbrains.com/plugin/6954-kotlin) will be useful for editing certain parts of UI, esp. dialogs.
    * [PsiViewer IntelliJ plugin](https://plugins.jetbrains.com/plugin/227-psiviewer) can be helpful to see parsing result on the `machete` file
      when running IntelliJ instance with the Git Machete plugin loaded.

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
   checkerFrameworkVersion = '3.21.4'
   checkstyleToolVersion = '8.33'
   commonsIOVersion = '2.11.0'
-  ideProbeVersion = '0.24.0'
+  ideProbeVersion = '0.26.0'
   jcabiAspectsVersion = '0.23.2'
   jetbrainsAnnotationsVersion = '23.0.0'
   jgitVersion = '6.1.0.202203080745-r'
@@ -544,19 +544,26 @@ allprojects {
 }
 
 
-// Root project config
-
-// This is necessary to make sure that `buildPlugin` task puts jars of all relevant subprojects into the final zip.
-subprojects.each { subproject ->
+subprojects {
+  // This is necessary to make sure that `buildPlugin` task puts jars of all relevant subprojects into the final zip.
   // No need to include near-empty (only with META-INF/MANIFEST.MF) jars
   // for subprojects that don't have any production code.
-  if (!subproject.sourceSets.main.allSource.srcDirs.findAll { file(it).exists() }.isEmpty()) {
-    dependencies {
-      implementation(subproject)
+  if (sourceSets.main.allSource.srcDirs.findAll { file(it).exists() }) {
+    rootProject.dependencies {
+      implementation(project)
     }
   }
+
+  // By default, the jar name will be formed only from the last segment of subproject path.
+  // Since these last segments are NOT unique (there are many `api`s and `impl`s),
+  // the effective jar name will be something like api.jar, api_1.jar, api_2.jar etc.,
+  // which is suboptimal.
+  // Let's use full name like frontend-ui-api.jar instead.
+  archivesBaseName = path.replaceFirst(":", "").replaceAll(":", "-")
 }
 
+
+// Root project config
 
 group 'com.virtuslab'
 

--- a/intellijVersions.properties
+++ b/intellijVersions.properties
@@ -2,4 +2,4 @@
 latestMinorsOfOldSupportedMajors=2020.3.4,2021.1.3,2021.2.4,2021.3.3
 eapOfLatestSupportedMajor=
 earliestSupportedMajor=2020.3
-latestStable=2022.1
+latestStable=2022.1.1

--- a/scripts/verify-artifact-contents
+++ b/scripts/verify-artifact-contents
@@ -19,13 +19,15 @@ jars_in_plugin_zip=$(zipinfo -1 "$plugin_zip" | grep -Po '(?<=git-machete-intell
 
 gradle_projects=$(cat settings.gradle | grep -Po "(?<=^include ').*(?=')" | sort)
 for project in $gradle_projects; do
-  if [[ -d $project/src/main ]]; then
-    if ! grep -qx "$project.jar" <<< "$jars_in_plugin_zip"; then
-      fail "$project.jar is expected but missing from $plugin_zip"
+  project_path=${project//:/\/}
+  project_jar_name=${project//:/-}
+  if [[ -d ${project_path}/src/main ]]; then
+    if ! grep -qx "${project_jar_name}.jar" <<< "$jars_in_plugin_zip"; then
+      fail "${project_jar_name}.jar is expected but missing from $plugin_zip"
     fi
   else
-    if grep -qx "$project.jar" <<< "$jars_in_plugin_zip"; then
-      fail "$project.jar is present in $plugin_zip even though $project does not contain any production code ($project/src/main not found)"
+    if grep -qx "${project_jar_name}.jar" <<< "$jars_in_plugin_zip"; then
+      fail "${project_jar_name}.jar is present in $plugin_zip even though $project does not contain any production code (${project_path}/src/main not found)"
     fi
   fi
 done

--- a/src/uiTest/resources/UITestSuite.conf
+++ b/src/uiTest/resources/UITestSuite.conf
@@ -1,0 +1,16 @@
+probe {
+  driver {
+    vmOptions = ["-Xmx1G"]
+    check.errors = true
+  }
+
+  resolvers {
+    intellij.repositories = [
+      # Let's first try using the IntelliJs downloaded by intellij-plugin-verifier, if present
+      # They're easier to use than Gradle-downloaded IntelliJs since their paths don't contain version-dependent hashes
+      "file:///"${HOME}"/.pluginVerifier/ides/IC-[revision]/",
+
+      official
+    ]
+  }
+}

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -48,28 +48,13 @@ object UITestSuite
       .filterNot(_.isEmpty).getOrElse(throw new Exception("IntelliJ version is not provided"))
     // We're cheating here a bit since `version` might be either a build number or a release number,
     // while we're always treating it as a build number.
-    // Still, as of ide-probe 0.11.0, even when release number like `2020.3` is passed as `build`, UI tests work just fine.
+    // Still, as of ide-probe 0.26.0, even when release number like `2020.3` is passed as `build`, UI tests work just fine.
     IntelliJVersion(build = version, release = None)
   }
 
-  private val config = Config.fromString(
-    """
-      |probe {
-      |  driver {
-      |    vmOptions = ["-Xmx1G"]
-      |    check {
-      |      errors = true
-      |    }
-      |  }
-      |
-      |  resolvers.jbr.repositories = [
-      |    official
-      |  ]
-      |}
-      |""".stripMargin)
-
   override protected def baseFixture: IntelliJFixture = {
-    fixtureFromConfig(config).withVersion(intelliJVersion)
+    // By default, the config is taken from <class-name>.conf resource, see org.virtuslab.ideprobe.IdeProbeFixture.resolveConfig
+    fixtureFromConfig().withVersion(intelliJVersion)
   }
 
 }


### PR DESCRIPTION
Optimization of UI tests, as ide-probe does NOT need to re-download all tested versions of IDEs again, but can instead re-use what's already been downloaded by `gradle runPluginVerifier` 🎉 