### PR TITLE
Add scheduled job - check for new eap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,22 @@
 version: 2.1
-jobs:
-  build:
+commands:
+  reconfigure_origin_remote:
+    steps:
+      - run:
+          name: Reconfigure origin remote to https
+          # language=sh
+          command: git remote set-url origin https://${GITHUB_TOKEN}@github.com/VirtusLab/git-machete-intellij-plugin.git
+executors:
+  docker_executor:
     docker:
       - image: 'gitmachete/intellij-plugin-ci:6.1.0'
     working_directory: ~/git-machete-intellij-plugin
     resource_class: large
+
+
+jobs:
+  build:
+    executor: docker_executor
     steps:
       - checkout
       - run:
@@ -130,10 +142,7 @@ jobs:
                 # Publishing should be the first step since if it fails, we should NOT proceed with opening backport PR/GitHub release, etc.
                 name: Publish plugin to Jetbrains Marketplace
                 command: ./gradlew publishPlugin
-            - run:
-                # It was hard to make `git push`/`hub pull-request` to work with SSH repo access in CI.
-                name: Reconfigure origin remote to https
-                command: git remote set-url origin https://${GITHUB_TOKEN}@github.com/VirtusLab/git-machete-intellij-plugin.git
+            - reconfigure_origin_remote
             - run:
                 name: Push git tag
                 # language=sh
@@ -155,3 +164,49 @@ jobs:
                     --attach build/distributions/git-machete-intellij-plugin-*.zip \
                     --message "$tag"$'\n\n'"$change_notes" \
                     $tag
+
+
+  updateEapBuildNumber:
+    executor: docker_executor
+    steps:
+      - checkout
+      - run:
+          name: Configure git user information
+          # language=sh
+          command: |
+            git config user.email "gitmachete@virtuslab.com"
+            git config user.name "Git Machete Bot"
+      - reconfigure_origin_remote
+      - run:
+          name: Check if new eap build number has appeared
+          # language=sh
+          command: |
+            if ! ./gradlew updateEapBuildNumber --exit-code ; then exit 0; fi
+            newEapBuildNumber=$(grep -Po '(?<=eapOfLatestSupportedMajor=).*' intellijVersions.properties)
+            branch_name=update-eap/$newEapBuildNumber
+            if git ls-remote --exit-code --heads origin $branch_name &> /dev/null ; then exit 0; fi
+            git checkout -b "$branch_name"
+            git add intellijVersions.properties
+            git commit -m "Update EAP build number to $newEapBuildNumber"
+            git push origin "$branch_name"
+            hub pull-request \
+              --no-edit \
+              --base=develop \
+              --labels=intellij-support
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build
+  updateEapBuildNumber:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - updateEapBuildNumber

--- a/build.gradle
+++ b/build.gradle
@@ -154,20 +154,33 @@ String checkForEapWithBuildNumberHigherThan(String latestEapBuildNumber) {
   return null
 }
 
-task updateEapBuildNumber {
-  doLast {
+class UpdateEapBuildNumber extends DefaultTask {
+
+  @Input
+  @Optional
+  @Option(option = 'exit-code', description = 'Return the exit code 0 when the new eap build number is found and 1 otherwise')
+  Boolean exitCode
+
+  @TaskAction
+  void execute() {
     Properties properties = project.intellijVersionsProperties()
     File propFile = project.intellijVersionsFile()
     String latestEapBuildNumber = project.intellijVersions.eapOfLatestSupportedMajor
-    String newerEapBuildNumber = latestEapBuildNumber ? project.checkForEapWithBuildNumberHigherThan(latestEapBuildNumber.replace('-EAP-SNAPSHOT', '')) :
-            project.checkForEapWithBuildNumberHigherThan(intellijVersionToBuildNumber(project.intellijVersions.latestStable)+'.999999.999999')
+    String buildNumberThreshold = latestEapBuildNumber ? latestEapBuildNumber.replace('-EAP-SNAPSHOT', '') :
+            project.intellijVersionToBuildNumber(project.intellijVersions.latestStable)+'.999999.999999'
+    String newerEapBuildNumber = project.checkForEapWithBuildNumberHigherThan(buildNumberThreshold)
     if (newerEapBuildNumber) {
       project.logger.lifecycle("EapOfLatestSupportedMajor is updated to " + newerEapBuildNumber + " build number")
       properties.setProperty("eapOfLatestSupportedMajor", newerEapBuildNumber+"-EAP-SNAPSHOT")
       properties.store(propFile.newWriter(), /*comments*/ null)
     }
+    if (exitCode && !newerEapBuildNumber) {
+      throw new Exception("New eap build number not found")
+    }
   }
 }
+
+tasks.register('updateEapBuildNumber', UpdateEapBuildNumber)
 
 dependencyUpdates {
   def isStableVersion = { String version ->


### PR DESCRIPTION
This task is partially completed - in order to start scheduled job from develop branch It need access from GitHub level.
![](https://circleci.com/docs/assets/img/docs/github_branches_status.png). </br> Now job is starting from feature/circleCI-job-for-new-eap (because this is the only branch on which config.yaml is configured like this) and created PR doesn't look good - changes and commits from feature/circleCI-job-for-new-eap are there. Also Build on this PR is failed because of new 222 eap. </br>
[Created PR](https://github.com/VirtusLab/git-machete-intellij-plugin/pull/882)