### PR TITLE
Refactor/lombok extensions method

### DIFF
--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
@@ -31,6 +31,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.With;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
@@ -136,7 +137,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
 
       Map<IBranchReference, List<IGitCoreReflogEntry>> filteredReflogByLocalBranch = localBranches
           .toMap(
-              /* keyMapper */ LocalBranchReference::of,
+              /* keyMapper */ LocalBranchReference::toLocalBranchReference,
               /* valueMapper */ this::deriveFilteredReflog);
 
       LOG.debug("Getting reflogs of remote branches");
@@ -286,7 +287,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       }
     }
   }
-
+  @ExtensionMethod(ForkPointCommitOfManagedBranch.class)
   @CustomLog
   private static class CreateGitMacheteRepositoryAux extends Aux {
 
@@ -515,7 +516,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
                 "commit (${pointedCommit.getHash().getHashString()}) but parent branch commit " +
                 "is NOT ancestor of parent-agnostic fork point (${parentAgnosticForkPointString}), " +
                 "so we assume that parent-aware fork point = parent branch commit");
-            return ForkPointCommitOfManagedBranch.fallbackToParent(parentPointedCommit);
+            return parentPointedCommit.fallbackToParent();
           }
 
         } else {
@@ -524,7 +525,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           LOG.debug(() -> "Parent branch commit (${parentPointedCommit.getHash().getHashString()}) is ancestor of " +
               "commit (${pointedCommit.getHash().getHashString()}) and parent-agnostic fork point is missing, " +
               "so we assume that parent-aware fork point = parent branch commit");
-          return ForkPointCommitOfManagedBranch.fallbackToParent(parentPointedCommit);
+          return parentPointedCommit.fallbackToParent();
         }
       }
 
@@ -615,7 +616,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         val containingBranches = forkPointAndContainingBranches._2.toList();
         LOG.debug(() -> "Commit ${forkPoint} found in filtered reflog(s) of ${containingBranches.mkString(\", \")}; " +
             "returning as fork point for branch '${branch.getFullName()}'");
-        return ForkPointCommitOfManagedBranch.inferred(forkPoint, containingBranches);
+        return forkPoint.inferred(containingBranches);
       } else {
         LOG.debug(() -> "Fork for branch '${branch.getFullName()}' not found ");
         return null;

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
@@ -31,7 +31,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.With;
-import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
@@ -287,7 +286,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       }
     }
   }
-  @ExtensionMethod(ForkPointCommitOfManagedBranch.class)
+
   @CustomLog
   private static class CreateGitMacheteRepositoryAux extends Aux {
 
@@ -516,7 +515,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
                 "commit (${pointedCommit.getHash().getHashString()}) but parent branch commit " +
                 "is NOT ancestor of parent-agnostic fork point (${parentAgnosticForkPointString}), " +
                 "so we assume that parent-aware fork point = parent branch commit");
-            return parentPointedCommit.fallbackToParent();
+            return ForkPointCommitOfManagedBranch.fallbackToParent(parentPointedCommit);
           }
 
         } else {
@@ -525,7 +524,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
           LOG.debug(() -> "Parent branch commit (${parentPointedCommit.getHash().getHashString()}) is ancestor of " +
               "commit (${pointedCommit.getHash().getHashString()}) and parent-agnostic fork point is missing, " +
               "so we assume that parent-aware fork point = parent branch commit");
-          return parentPointedCommit.fallbackToParent();
+          return ForkPointCommitOfManagedBranch.fallbackToParent(parentPointedCommit);
         }
       }
 
@@ -616,7 +615,7 @@ public class GitMacheteRepository implements IGitMacheteRepository {
         val containingBranches = forkPointAndContainingBranches._2.toList();
         LOG.debug(() -> "Commit ${forkPoint} found in filtered reflog(s) of ${containingBranches.mkString(\", \")}; " +
             "returning as fork point for branch '${branch.getFullName()}'");
-        return forkPoint.inferred(containingBranches);
+        return ForkPointCommitOfManagedBranch.inferred(forkPoint, containingBranches);
       } else {
         LOG.debug(() -> "Fork for branch '${branch.getFullName()}' not found ");
         return null;

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/LocalBranchReference.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/LocalBranchReference.java
@@ -13,7 +13,7 @@ public final class LocalBranchReference extends BaseBranchReference implements I
     super(name, fullName);
   }
 
-  static LocalBranchReference of(IGitCoreLocalBranchSnapshot coreLocalBranch) {
+  public static LocalBranchReference toLocalBranchReference(IGitCoreLocalBranchSnapshot coreLocalBranch) {
     return new LocalBranchReference(
         coreLocalBranch.getName(),
         coreLocalBranch.getFullName());

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/RemoteTrackingBranchReference.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/RemoteTrackingBranchReference.java
@@ -2,12 +2,14 @@ package com.virtuslab.gitmachete.backend.impl;
 
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.ExtensionMethod;
 
 import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitcore.api.IGitCoreRemoteBranchSnapshot;
 import com.virtuslab.gitmachete.backend.api.ILocalBranchReference;
 import com.virtuslab.gitmachete.backend.api.IRemoteTrackingBranchReference;
 
+@ExtensionMethod(LocalBranchReference.class)
 @Getter
 @ToString
 public final class RemoteTrackingBranchReference extends BaseBranchReference implements IRemoteTrackingBranchReference {
@@ -28,6 +30,6 @@ public final class RemoteTrackingBranchReference extends BaseBranchReference imp
         coreRemoteBranch.getName(),
         coreRemoteBranch.getFullName(),
         coreRemoteBranch.getRemoteName(),
-        LocalBranchReference.of(coreTrackedLocalBranch));
+        coreTrackedLocalBranch.toLocalBranchReference());
   }
 }

--- a/branchLayout/impl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileUtils.java
+++ b/branchLayout/impl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileUtils.java
@@ -35,7 +35,7 @@ public final class BranchLayoutFileUtils {
 
   public static IndentSpec deriveIndentSpec(Path path) {
     LOG.debug("Entering: branch layout file path: ${path}");
-    List<String> lines = Try.of(() -> BranchLayoutFileUtils.readFileLines(path))
+    List<String> lines = Try.of(() -> readFileLines(path))
         .getOrElse(() -> {
           LOG.debug(() -> "Failed to read branch layout file from ${path}. Falling back to default indent definition.");
           return List.empty();
@@ -55,7 +55,7 @@ public final class BranchLayoutFileUtils {
     // Redundant non-emptiness check to satisfy IndexChecker
     if (firstLineWithBlankPrefixOption.isDefined() && !firstLineWithBlankPrefixOption.get().isEmpty()) {
       indentCharacter = firstLineWithBlankPrefixOption.get().charAt(0);
-      indentWidth = BranchLayoutFileUtils.getIndentWidth(firstLineWithBlankPrefixOption.get(), indentCharacter);
+      indentWidth = getIndentWidth(firstLineWithBlankPrefixOption.get(), indentCharacter);
       // we are processing a line satisfying `line.startsWith(" ") || line.startsWith("\t")`
       assert indentWidth > 0 : "indent width is ${indentWidth} <= 0";
     }

--- a/branchLayout/impl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileWriter.java
+++ b/branchLayout/impl/src/main/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileWriter.java
@@ -9,6 +9,7 @@ import io.vavr.control.Option;
 import io.vavr.control.Try;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.index.qual.NonNegative;
 
@@ -17,6 +18,7 @@ import com.virtuslab.branchlayout.api.IBranchLayout;
 import com.virtuslab.branchlayout.api.IBranchLayoutEntry;
 import com.virtuslab.branchlayout.api.readwrite.IBranchLayoutWriter;
 
+@ExtensionMethod(BranchLayoutFileUtils.class)
 @CustomLog
 @RequiredArgsConstructor
 public class BranchLayoutFileWriter implements IBranchLayoutWriter {
@@ -26,7 +28,7 @@ public class BranchLayoutFileWriter implements IBranchLayoutWriter {
   @SuppressWarnings("regexp") // to allow for `synchronized`
   public synchronized void write(Path path, IBranchLayout branchLayout, boolean backupOldFile) throws BranchLayoutException {
     LOG.debug(() -> "Entering: path = ${path}, branchLayout = ${branchLayout}, backupOldFile = ${backupOldFile}");
-    val indentSpec = BranchLayoutFileUtils.deriveIndentSpec(path);
+    val indentSpec = path.deriveIndentSpec();
 
     val lines = printEntriesOntoStringList(branchLayout.getRootEntries(), indentSpec, /* level */ 0);
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
@@ -1,7 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions.backgroundables;
 
 import static com.intellij.notification.NotificationType.INFORMATION;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 import static git4idea.commands.GitLocalChangesWouldBeOverwrittenDetector.Operation.MERGE;
 import static git4idea.update.GitUpdateSessionKt.getBodyForUpdateNotification;
@@ -43,13 +42,16 @@ import git4idea.update.GitUpdatedRanges;
 import git4idea.util.GitUntrackedFilesHelper;
 import git4idea.util.LocalChangesWouldBeOverwrittenHelper;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.virtuslab.gitmachete.frontend.compat.UiThreadExecutionCompat;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task.Backgroundable {
 
@@ -184,8 +186,8 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
     } else {
       VcsNotifier.getInstance(project).notifyError(
           /* displayId */ null,
-          format(getString("action.GitMachete.GitCommandUpdatingCurrentBranchBackgroundable.notification.title.update-fail"),
-              getOperationName()),
+          getString("action.GitMachete.GitCommandUpdatingCurrentBranchBackgroundable.notification.title.update-fail")
+              .format(getOperationName()),
           result.getErrorOutputAsJoinedString());
       gitRepository.update();
     }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/SlideInBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/SlideInBackgroundable.java
@@ -1,7 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions.backgroundables;
 
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMacheteFilePath;
 
 import java.nio.file.Path;
 
@@ -24,9 +23,10 @@ import com.virtuslab.branchlayout.api.IBranchLayoutEntry;
 import com.virtuslab.branchlayout.api.readwrite.IBranchLayoutWriter;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.SlideInOptions;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
+import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
-@ExtensionMethod(GitMacheteBundle.class)
+@ExtensionMethod({GitVfsUtils.class, GitMacheteBundle.class})
 public class SlideInBackgroundable extends Task.Backgroundable {
 
   private final Project project;
@@ -66,7 +66,7 @@ public class SlideInBackgroundable extends Task.Backgroundable {
     // Hence we wait for the creation of the branch (with exponential backoff).
     waitForCreationOfLocalBranch();
 
-    Path macheteFilePath = getMacheteFilePath(gitRepository);
+    Path macheteFilePath = gitRepository.getMacheteFilePath();
 
     IBranchLayoutEntry childEntryByName = branchLayout.findEntryByName(slideInOptions.getName()).getOrNull();
     IBranchLayoutEntry entryToSlideIn;

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/SlideInBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/SlideInBackgroundable.java
@@ -1,6 +1,5 @@
 package com.virtuslab.gitmachete.frontend.actions.backgroundables;
 
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMacheteFilePath;
 
@@ -14,6 +13,7 @@ import git4idea.GitLocalBranch;
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import io.vavr.control.Try;
+import lombok.experimental.ExtensionMethod;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.virtuslab.branchlayout.api.BranchLayoutEntry;
@@ -23,8 +23,10 @@ import com.virtuslab.branchlayout.api.IBranchLayout;
 import com.virtuslab.branchlayout.api.IBranchLayoutEntry;
 import com.virtuslab.branchlayout.api.readwrite.IBranchLayoutWriter;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.SlideInOptions;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitMacheteBundle.class)
 public class SlideInBackgroundable extends Task.Backgroundable {
 
   private final Project project;
@@ -89,14 +91,14 @@ public class SlideInBackgroundable extends Task.Backgroundable {
       newBranchLayout = targetBranchLayout.slideIn(parentName, entryToSlideIn);
     } catch (EntryDoesNotExistException e) {
       notifyError(
-          format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.entry-does-not-exist"),
-              parentName),
+          getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.entry-does-not-exist")
+              .format(parentName),
           e);
       return;
     } catch (EntryIsDescendantOfException e) {
       notifyError(
-          format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.entry-is-descendant-of"),
-              entryToSlideIn.getName(), parentName),
+          getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.entry-is-descendant-of")
+              .format(entryToSlideIn.getName(), parentName),
           e);
       return;
     }
@@ -127,22 +129,22 @@ public class SlideInBackgroundable extends Task.Backgroundable {
     } catch (InterruptedException e) {
       VcsNotifier.getInstance(project).notifyWeakError(/* displayId */ null,
           /* title */ "",
-          format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.wait-interrupted"),
-              slideInOptions.getName()));
+          getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.wait-interrupted")
+              .format(slideInOptions.getName()));
     }
 
     if (findLocalBranch() == null) {
       VcsNotifier.getInstance(project).notifyWeakError(/* displayId */ null,
           /* title */ "",
-          format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.timeout"),
-              slideInOptions.getName()));
+          getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.timeout")
+              .format(slideInOptions.getName()));
     }
   }
 
   private void notifyError(@Nullable String message, Throwable throwable) {
     VcsNotifier.getInstance(project).notifyError(/* displayId */ null,
-        /* title */ format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.title.slide-in-fail"),
-            slideInOptions.getName()),
+        /* title */ getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.title.slide-in-fail")
+            .format(slideInOptions.getName()),
         message != null ? message : getMessageOrEmpty(throwable));
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchAction.java
@@ -24,7 +24,7 @@ import com.virtuslab.gitmachete.frontend.actions.common.MergeProps;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
-@ExtensionMethod({FetchUpToDateTimeoutStatus.class, GitMacheteBundle.class})
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -91,7 +91,7 @@ public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReady
           /* movingBranchName */ localBranch,
           /* stayingBranchName */ remoteBranch);
 
-      boolean isUpToDate = gitRepository.isUpToDate();
+      boolean isUpToDate = FetchUpToDateTimeoutStatus.isUpToDate(gitRepository);
       String fetchNotificationPrefix = isUpToDate
           ? getString("action.GitMachete.BasePullBranchAction.notification.title.no-fetch-perform")
               .format(FETCH_ALL_UP_TO_DATE_TIMEOUT_AS_STRING)
@@ -132,7 +132,7 @@ public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReady
       @UIEffect
       public void onSuccess() {
         String repoName = gitRepository.getRoot().getName();
-        repoName.update();
+        FetchUpToDateTimeoutStatus.update(repoName);
         onSuccessRunnable.run();
       }
     }.queue();

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchAction.java
@@ -2,7 +2,6 @@ package com.virtuslab.gitmachete.frontend.actions.base;
 
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.createRefspec;
 import static com.virtuslab.gitmachete.frontend.actions.common.FetchUpToDateTimeoutStatus.FETCH_ALL_UP_TO_DATE_TIMEOUT_AS_STRING;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -11,6 +10,7 @@ import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -22,7 +22,9 @@ import com.virtuslab.gitmachete.frontend.actions.common.FastForwardMerge;
 import com.virtuslab.gitmachete.frontend.actions.common.FetchUpToDateTimeoutStatus;
 import com.virtuslab.gitmachete.frontend.actions.common.MergeProps;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -91,9 +93,9 @@ public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReady
 
       boolean isUpToDate = FetchUpToDateTimeoutStatus.isUpToDate(gitRepository);
       String fetchNotificationPrefix = isUpToDate
-          ? format(getString("action.GitMachete.BasePullBranchAction.notification.title.no-fetch-perform"),
-              FETCH_ALL_UP_TO_DATE_TIMEOUT_AS_STRING)
-          : format(getString("action.GitMachete.BasePullBranchAction.notification.title.fetch-perform"));
+          ? getString("action.GitMachete.BasePullBranchAction.notification.title.no-fetch-perform")
+              .format(FETCH_ALL_UP_TO_DATE_TIMEOUT_AS_STRING)
+          : getString("action.GitMachete.BasePullBranchAction.notification.title.fetch-perform").format();
       Runnable fastForwardRunnable = () -> FastForwardMerge.perform(project, gitRepository, mergeProps,
           fetchNotificationPrefix);
 
@@ -123,9 +125,8 @@ public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReady
         remoteName,
         refspecFromRemoteRepoToOurRemoteBranch,
         taskTitle,
-        format(getString("action.GitMachete.BasePullBranchAction.notification.title.pull-fail"),
-            remoteBranch.getName()),
-        format(getString("action.GitMachete.BasePullBranchAction.notification.title.pull-success"), remoteBranch.getName())) {
+        getString("action.GitMachete.BasePullBranchAction.notification.title.pull-fail").format(remoteBranch.getName()),
+        getString("action.GitMachete.BasePullBranchAction.notification.title.pull-success").format(remoteBranch.getName())) {
 
       @Override
       @UIEffect

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchAction.java
@@ -95,7 +95,7 @@ public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReady
       String fetchNotificationPrefix = isUpToDate
           ? getString("action.GitMachete.BasePullBranchAction.notification.title.no-fetch-perform")
               .format(FETCH_ALL_UP_TO_DATE_TIMEOUT_AS_STRING)
-          : getString("action.GitMachete.BasePullBranchAction.notification.title.fetch-perform").format();
+          : getString("action.GitMachete.BasePullBranchAction.notification.title.fetch-perform");
       Runnable fastForwardRunnable = () -> FastForwardMerge.perform(project, gitRepository, mergeProps,
           fetchNotificationPrefix);
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullBranchAction.java
@@ -24,7 +24,7 @@ import com.virtuslab.gitmachete.frontend.actions.common.MergeProps;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
-@ExtensionMethod(GitMacheteBundle.class)
+@ExtensionMethod({FetchUpToDateTimeoutStatus.class, GitMacheteBundle.class})
 @CustomLog
 public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -91,7 +91,7 @@ public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReady
           /* movingBranchName */ localBranch,
           /* stayingBranchName */ remoteBranch);
 
-      boolean isUpToDate = FetchUpToDateTimeoutStatus.isUpToDate(gitRepository);
+      boolean isUpToDate = gitRepository.isUpToDate();
       String fetchNotificationPrefix = isUpToDate
           ? getString("action.GitMachete.BasePullBranchAction.notification.title.no-fetch-perform")
               .format(FETCH_ALL_UP_TO_DATE_TIMEOUT_AS_STRING)
@@ -132,7 +132,7 @@ public abstract class BasePullBranchAction extends BaseGitMacheteRepositoryReady
       @UIEffect
       public void onSuccess() {
         String repoName = gitRepository.getRoot().getName();
-        FetchUpToDateTimeoutStatus.update(repoName);
+        repoName.update();
         onSuccessRunnable.run();
       }
     }.queue();

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePushBranchAction.java
@@ -4,7 +4,6 @@ import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.AheadOfRem
 import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.DivergedFromAndNewerThanRemote;
 import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.DivergedFromAndOlderThanRemote;
 import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Untracked;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -17,6 +16,7 @@ import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -24,7 +24,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.GitPushDialog;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public abstract class BasePushBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -70,8 +72,9 @@ public abstract class BasePushBranchAction extends BaseGitMacheteRepositoryReady
     if (branchName.isDefined() && relation.isDefined() && isForcePushRequired(relation.get())) {
       if (GitSharedSettings.getInstance(project).isBranchProtected(branchName.get())) {
         Presentation presentation = anActionEvent.getPresentation();
-        presentation.setDescription(format(
-            getString("action.GitMachete.BasePushBranchAction.force-push-disabled-for-protected-branch"), branchName.get()));
+        presentation.setDescription(
+            getString("action.GitMachete.BasePushBranchAction.force-push-disabled-for-protected-branch")
+                .format(branchName.get()));
         presentation.setEnabled(false);
       }
     }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseRebaseBranchOntoParentAction.java
@@ -1,7 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions.base;
 
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.getQuotedStringOrCurrent;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 import static io.vavr.API.$;
 import static io.vavr.API.Case;
@@ -26,6 +25,7 @@ import io.vavr.control.Option;
 import io.vavr.control.Try;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
@@ -37,8 +37,10 @@ import com.virtuslab.gitmachete.backend.api.hooks.IExecutionResult;
 import com.virtuslab.gitmachete.frontend.actions.contextmenu.CheckoutSelectedBranchAction;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -86,8 +88,9 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
           Case($(), ": " + state.get().name().toLowerCase()));
 
       presentation.setEnabled(false);
-      presentation.setDescription(format(
-          getString("action.GitMachete.BaseRebaseBranchOntoParentAction.description.disabled.repository.status"), stateName));
+      presentation.setDescription(
+          getString("action.GitMachete.BaseRebaseBranchOntoParentAction.description.disabled.repository.status")
+              .format(stateName));
     } else {
 
       val branchName = getNameOfBranchUnderAction(anActionEvent).getOrNull();
@@ -97,15 +100,15 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
 
       if (branch == null) {
         presentation.setEnabled(false);
-        presentation.setDescription(format(getString("action.GitMachete.description.disabled.undefined.machete-branch"),
-            "Rebase", getQuotedStringOrCurrent(branchName)));
+        presentation.setDescription(getString("action.GitMachete.description.disabled.undefined.machete-branch")
+            .format("Rebase", getQuotedStringOrCurrent(branchName)));
       } else if (branch.isRoot()) {
 
         if (anActionEvent.getPlace().equals(ActionPlaces.ACTION_PLACE_TOOLBAR)) {
           presentation.setEnabled(false);
           presentation.setDescription(
-              format(getString("action.GitMachete.BaseRebaseBranchOntoParentAction.description.disabled.root-branch"),
-                  branch.getName()));
+              getString("action.GitMachete.BaseRebaseBranchOntoParentAction.description.disabled.root-branch")
+                  .format(branch.getName()));
         } else { //contextmenu
           // in case of root branch we do not want to show this option at all
           presentation.setEnabledAndVisible(false);
@@ -114,8 +117,8 @@ public abstract class BaseRebaseBranchOntoParentAction extends BaseGitMacheteRep
       } else if (branch.isNonRoot()) {
         val nonRootBranch = branch.asNonRoot();
         IManagedBranchSnapshot upstream = nonRootBranch.getParent();
-        presentation.setDescription(format(getString("action.GitMachete.BaseRebaseBranchOntoParentAction.description"),
-            branch.getName(), upstream.getName()));
+        presentation.setDescription(getString("action.GitMachete.BaseRebaseBranchOntoParentAction.description")
+            .format(branch.getName(), upstream.getName()));
       }
 
       val isRebasingCurrent = branch != null && getCurrentBranchNameIfManaged(anActionEvent)

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -2,7 +2,6 @@ package com.virtuslab.gitmachete.frontend.actions.base;
 
 import static com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackgroundable.LOCAL_REPOSITORY_NAME;
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.createRefspec;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getRootDirectory;
 import static git4idea.commands.GitLocalChangesWouldBeOverwrittenDetector.Operation.RESET;
@@ -32,6 +31,7 @@ import io.vavr.collection.List;
 import io.vavr.control.Option;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -42,8 +42,10 @@ import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 import com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackgroundable;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.ResetBranchToRemoteInfoDialog;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -153,7 +155,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
 
       final int okCancelDialogResult = MessageUtil.showOkCancelDialog(
           getString("action.GitMachete.BaseResetBranchToRemoteAction.info-dialog.title"),
-          format(getString("action.GitMachete.BaseResetBranchToRemoteAction.info-dialog.message"),
+          getString("action.GitMachete.BaseResetBranchToRemoteAction.info-dialog.message").format(
               branchName,
               remoteTrackingBranch.getName(),
               currentCommitSha),
@@ -192,10 +194,10 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
         refspecFromRemoteToLocal,
         getString("action.GitMachete.BaseResetBranchToRemoteAction.task-title"),
         getString("action.GitMachete.BaseResetBranchToRemoteAction.task-subtitle"),
-        format(getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.title.reset-fail"),
-            localBranch.getName()),
-        format(getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.title.reset-success"),
-            localBranch.getName()))
+        getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.title.reset-fail")
+            .format(localBranch.getName()),
+        getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.title.reset-success")
+            .format(localBranch.getName()))
                 .queue();
   }
 
@@ -231,8 +233,8 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
           if (result.success()) {
             VcsNotifier.getInstance(project).notifySuccess( /* displayId */ null,
                 /* title */ "",
-                format(getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.title.reset-success"),
-                    localBranchName));
+                getString("action.GitMachete.BaseResetBranchToRemoteAction.notification.title.reset-success")
+                    .format(localBranchName));
             log().debug(() -> "Branch '${localBranchName}' has been reset to '${remoteTrackingBranchName}");
 
           } else if (localChangesDetector.wasMessageDetected()) {

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetBranchToRemoteAction.java
@@ -3,7 +3,6 @@ package com.virtuslab.gitmachete.frontend.actions.base;
 import static com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackgroundable.LOCAL_REPOSITORY_NAME;
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.createRefspec;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getRootDirectory;
 import static git4idea.commands.GitLocalChangesWouldBeOverwrittenDetector.Operation.RESET;
 import static org.checkerframework.checker.i18nformatter.qual.I18nConversionCategory.GENERAL;
 
@@ -43,9 +42,10 @@ import com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackground
 import com.virtuslab.gitmachete.frontend.actions.dialogs.ResetBranchToRemoteInfoDialog;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
+import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
-@ExtensionMethod(GitMacheteBundle.class)
+@ExtensionMethod({GitVfsUtils.class, GitMacheteBundle.class})
 @CustomLog
 public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -250,7 +250,7 @@ public abstract class BaseResetBranchToRemoteAction extends BaseGitMacheteReposi
                 result.getErrorOutputAsHtmlString());
           }
 
-          val repositoryRoot = getRootDirectory(gitRepository);
+          val repositoryRoot = gitRepository.getRootDirectory();
           GitRepositoryManager.getInstance(project).updateRepository(repositoryRoot);
           VfsUtil.markDirtyAndRefresh(/* async */ false, /* recursive */ true, /* reloadChildren */ false, repositoryRoot);
         }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBranchBelowAction.java
@@ -3,7 +3,6 @@ package com.virtuslab.gitmachete.frontend.actions.base;
 import static com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackgroundable.LOCAL_REPOSITORY_NAME;
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.createRefspec;
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.getQuotedStringOrCurrent;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 import static git4idea.ui.branch.GitBranchPopupActions.RemoteBranchActions.CheckoutRemoteBranchAction.checkoutRemoteBranch;
 
@@ -21,6 +20,7 @@ import io.vavr.collection.List;
 import io.vavr.control.Option;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -29,7 +29,9 @@ import com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackground
 import com.virtuslab.gitmachete.frontend.actions.backgroundables.SlideInBackgroundable;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.SlideInDialog;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -61,11 +63,11 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
       presentation.setDescription(getString("action.GitMachete.BaseSlideInBranchBelowAction.description.disabled.no-parent"));
     } else if (branch == null) {
       presentation.setEnabled(false);
-      presentation.setDescription(format(getString("action.GitMachete.description.disabled.undefined.machete-branch"),
-          "Slide In", getQuotedStringOrCurrent(branchName)));
+      presentation.setDescription(getString("action.GitMachete.description.disabled.undefined.machete-branch")
+          .format("Slide In", getQuotedStringOrCurrent(branchName)));
     } else {
       presentation.setDescription(
-          format(getString("action.GitMachete.BaseSlideInBranchBelowAction.description"), branchName));
+          getString("action.GitMachete.BaseSlideInBranchBelowAction.description").format(branchName));
     }
   }
 
@@ -91,7 +93,7 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
     if (parentName.equals(slideInOptions.getName())) {
       // @formatter:off
       VcsNotifier.getInstance(project).notifyError(/* displayId */ null,
-          /* title */ format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.title.slide-in-fail"), slideInOptions.getName()),
+          /* title */ getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.title.slide-in-fail").format(slideInOptions.getName()),
           /* message */ getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.slide-in-under-itself-or-its-descendant"));
       // @formatter:on
       return;
@@ -108,8 +110,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
         val branchNameFromNewBranchDialog = branchName != null ? branchName : "no name provided";
         VcsNotifier.getInstance(project).notifyWeakError(/* displayId */ null,
             /* title */ "",
-            format(getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.mismatched-names"),
-                slideInOptions.getName(), branchNameFromNewBranchDialog));
+            getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.mismatched-names")
+                .format(slideInOptions.getName(), branchNameFromNewBranchDialog));
         return;
       }
     }
@@ -149,8 +151,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
     val repositories = java.util.Collections.singletonList(gitRepository);
     val gitNewBranchDialog = new GitNewBranchDialog(project,
         repositories,
-        /* title */ format(getString("action.GitMachete.BaseSlideInBranchBelowAction.dialog.create-new-branch.title"),
-            startPoint),
+        /* title */ getString("action.GitMachete.BaseSlideInBranchBelowAction.dialog.create-new-branch.title")
+            .format(startPoint),
         initialName,
         /* showCheckOutOption */ true,
         /* showResetOption */ true,
@@ -185,11 +187,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
           LOCAL_REPOSITORY_NAME,
           refspec,
           "Fetching Remote Branch",
-          format(
-              getString("action.GitMachete.BasePullBranchAction.notification.title.pull-fail"), branchName),
-          format(
-              getString("action.GitMachete.BasePullBranchAction.notification.title.pull-success"), branchName))
-                  .queue();
+          getString("action.GitMachete.BasePullBranchAction.notification.title.pull-fail").format(branchName),
+          getString("action.GitMachete.BasePullBranchAction.notification.title.pull-success").format(branchName)).queue();
 
     } else if (remoteBranch == null) {
       preSlideInRunnable = () -> {
@@ -237,9 +236,8 @@ public abstract class BaseSlideInBranchBelowAction extends BaseGitMacheteReposit
     val chosen = remotesWithBranch.head();
     if (remotesWithBranch.size() > 1) {
       val title = getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.title.multiple-remotes");
-      val message = format(
-          getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.multiple-remotes"),
-          chosen._2().getName(), chosen._1().getName());
+      val message = getString("action.GitMachete.BaseSlideInBranchBelowAction.notification.message.multiple-remotes")
+          .format(chosen._2().getName(), chosen._1().getName());
       VcsNotifier.getInstance(project).notifyInfo(/* displayId */ null, title, message);
     }
     return chosen._2();

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
@@ -2,7 +2,6 @@ package com.virtuslab.gitmachete.frontend.actions.base;
 
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.getQuotedStringOrCurrent;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMacheteFilePath;
 
 import java.nio.file.Path;
 import java.util.Collections;
@@ -32,9 +31,10 @@ import com.virtuslab.gitmachete.frontend.actions.dialogs.DeleteBranchOnSlideOutS
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.compat.UiThreadExecutionCompat;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
+import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
-@ExtensionMethod(GitMacheteBundle.class)
+@ExtensionMethod({GitVfsUtils.class, GitMacheteBundle.class})
 @CustomLog
 public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -173,7 +173,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
     val newBranchLayout = branchLayout.slideOut(branchName);
 
     try {
-      Path macheteFilePath = getMacheteFilePath(gitRepository);
+      Path macheteFilePath = gitRepository.getMacheteFilePath();
       LOG.info("Writing new branch layout into ${macheteFilePath}");
       branchLayoutWriter.write(macheteFilePath, newBranchLayout, /* backupOldLayout */ true);
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutBranchAction.java
@@ -1,7 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions.base;
 
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.getQuotedStringOrCurrent;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMacheteFilePath;
 
@@ -23,6 +22,7 @@ import git4idea.repo.GitRepository;
 import io.vavr.control.Option;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
@@ -31,8 +31,10 @@ import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.DeleteBranchOnSlideOutSuggestionDialog;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.compat.UiThreadExecutionCompat;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -63,11 +65,10 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
 
     if (branch == null) {
       presentation.setEnabled(false);
-      presentation.setDescription(format(getString("action.GitMachete.description.disabled.undefined.machete-branch"),
-          "Slide out", getQuotedStringOrCurrent(branchName)));
+      presentation.setDescription(getString("action.GitMachete.description.disabled.undefined.machete-branch")
+          .format("Slide out", getQuotedStringOrCurrent(branchName)));
     } else {
-      presentation.setDescription(
-          format(getString("action.GitMachete.BaseSlideOutBranchAction.description"), branch.getName()));
+      presentation.setDescription(getString("action.GitMachete.BaseSlideOutBranchAction.description").format(branch.getName()));
     }
   }
 
@@ -113,9 +114,8 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
       getGraphTable(anActionEvent).queueRepositoryUpdateAndModelRefresh();
       VcsNotifier.getInstance(project).notifySuccess(/* displayId */ null,
           /* title */ "",
-          format(
-              getString("action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-success.of-current"),
-              branchName));
+          getString("action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-success.of-current")
+              .format(branchName));
 
     } else if (gitRepository != null) {
       val root = gitRepository.getRoot();
@@ -152,8 +152,8 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
           }
         } else {
           val title = getString("action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-info.canceled");
-          val message = format(
-              getString("action.GitMachete.BaseSlideOutBranchAction.notification.message.slide-out-info.canceled"), branchName);
+          val message = getString("action.GitMachete.BaseSlideOutBranchAction.notification.message.slide-out-info.canceled")
+              .format(branchName);
           VcsNotifier.getInstance(project).notifyInfo(/* displayId */ null, title, message);
         }
       }
@@ -183,7 +183,7 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
           (exceptionMessage == null ? "" : ": " + exceptionMessage);
       LOG.error(errorMessage);
       VcsNotifier.getInstance(project).notifyError(/* displayId */ null,
-          format(getString("action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-fail"), branchName),
+          getString("action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-fail").format(branchName),
           exceptionMessage == null ? "" : exceptionMessage);
     }
   }
@@ -196,17 +196,14 @@ public abstract class BaseSlideOutBranchAction extends BaseGitMacheteRepositoryR
       GitBrancher.getInstance(project).deleteBranch(branchName, Collections.singletonList(gitRepository));
       VcsNotifier.getInstance(project).notifySuccess(/* displayId */ null,
           /* title */ "",
-          format(
-              getString("action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-success.with-delete"),
-              branchName));
+          getString("action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-success.with-delete")
+              .format(branchName));
       return;
     } else {
       VcsNotifier.getInstance(project).notifySuccess(/* displayId */ null,
           /* title */ "",
-          format(
-              getString(
-                  "action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-success.without-delete"),
-              branchName));
+          getString("action.GitMachete.BaseSlideOutBranchAction.notification.title.slide-out-success.without-delete")
+              .format(branchName));
     }
     getGraphTable(anActionEvent).queueRepositoryUpdateAndModelRefresh();
   }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/FastForwardMerge.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/FastForwardMerge.java
@@ -2,17 +2,19 @@ package com.virtuslab.gitmachete.frontend.actions.common;
 
 import static com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackgroundable.LOCAL_REPOSITORY_NAME;
 import static com.virtuslab.gitmachete.frontend.actions.common.ActionUtils.createRefspec;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import com.intellij.openapi.project.Project;
 import git4idea.repo.GitRepository;
 import io.vavr.control.Option;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 
 import com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackgroundable;
 import com.virtuslab.gitmachete.frontend.actions.backgroundables.MergeCurrentBranchFastForwardOnlyBackgroundable;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
+@ExtensionMethod(GitMacheteBundle.class)
 public final class FastForwardMerge {
 
   private FastForwardMerge() {}
@@ -32,11 +34,11 @@ public final class FastForwardMerge {
     val stayingName = mergeProps.getStayingBranch().getName();
     val movingName = mergeProps.getMovingBranch().getName();
     val successFFMergeNotification = fetchNotificationPrefix
-        + format(getString("action.GitMachete.BaseFastForwardMergeBranchToParentAction.notification.title.ff-fail"),
-            stayingName, movingName);
+        + getString("action.GitMachete.BaseFastForwardMergeBranchToParentAction.notification.title.ff-fail")
+            .format(stayingName, movingName);
     val failFFMergeNotification = fetchNotificationPrefix
-        + format(getString("action.GitMachete.BaseFastForwardMergeBranchToParentAction.notification.title.ff-success"),
-            stayingName, movingName);
+        + getString("action.GitMachete.BaseFastForwardMergeBranchToParentAction.notification.title.ff-success")
+            .format(stayingName, movingName);
     new FetchBackgroundable(
         project,
         gitRepository,

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedBranchAction.java
@@ -1,6 +1,5 @@
 package com.virtuslab.gitmachete.frontend.actions.contextmenu;
 
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import java.util.Collections;
@@ -15,13 +14,16 @@ import git4idea.commands.Git;
 import git4idea.repo.GitRepository;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseGitMacheteRepositoryReadyAction;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -56,12 +58,12 @@ public class CheckoutSelectedBranchAction extends BaseGitMacheteRepositoryReadyA
     if (currentBranchName.isDefined() && currentBranchName.get().equals(selectedBranchName.get())) {
       presentation.setEnabled(false);
       presentation.setDescription(
-          format(getString("action.GitMachete.CheckoutSelectedBranchAction.description.disabled.currently-checked-out"),
-              selectedBranchName.get()));
+          getString("action.GitMachete.CheckoutSelectedBranchAction.description.disabled.currently-checked-out")
+              .format(selectedBranchName.get()));
 
     } else {
       presentation.setDescription(
-          format(getString("action.GitMachete.CheckoutSelectedBranchAction.description.precise"), selectedBranchName.get()));
+          getString("action.GitMachete.CheckoutSelectedBranchAction.description.precise").format(selectedBranchName.get()));
     }
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/ShowSelectedBranchInGitLogAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/ShowSelectedBranchInGitLogAction.java
@@ -1,6 +1,5 @@
 package com.virtuslab.gitmachete.frontend.actions.contextmenu;
 
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import java.util.Objects;
@@ -17,12 +16,15 @@ import com.intellij.vcs.log.impl.VcsProjectLog;
 import git4idea.branch.GitBranchesCollection;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseGitMacheteRepositoryReadyAction;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public class ShowSelectedBranchInGitLogAction extends BaseGitMacheteRepositoryReadyAction
     implements
@@ -53,7 +55,7 @@ public class ShowSelectedBranchInGitLogAction extends BaseGitMacheteRepositoryRe
     }
 
     presentation.setDescription(
-        format(getString("action.GitMachete.ShowSelectedBranchInGitLogAction.description.precise"), selectedBranchName.get()));
+        getString("action.GitMachete.ShowSelectedBranchInGitLogAction.description.precise").format(selectedBranchName.get()));
   }
 
   @Override

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
@@ -59,9 +59,9 @@ public class DiscoverAction extends BaseProjectDependentAction {
       return;
     }
 
-    val rootDirPath = GitVfsUtils.getRootDirectoryPath(gitRepository).toAbsolutePath();
-    val mainGitDirPath = GitVfsUtils.getMainGitDirectoryPath(gitRepository).toAbsolutePath();
-    val worktreeGitDirPath = GitVfsUtils.getWorktreeGitDirectoryPath(gitRepository).toAbsolutePath();
+    val rootDirPath = gitRepository.getRootDirectoryPath().toAbsolutePath();
+    val mainGitDirPath = gitRepository.getMainGitDirectoryPath().toAbsolutePath();
+    val worktreeGitDirPath = gitRepository.getWorktreeGitDirectoryPath().toAbsolutePath();
 
     val graphTable = getGraphTable(anActionEvent);
     val branchLayoutWriter = getBranchLayoutWriter(anActionEvent);
@@ -104,7 +104,7 @@ public class DiscoverAction extends BaseProjectDependentAction {
 
   @UIEffect
   private static void openMacheteFile(Project project, GitRepository gitRepository) {
-    val file = GitVfsUtils.getMacheteFile(gitRepository);
+    val file = gitRepository.getMacheteFile();
     if (file.isDefined()) {
       OpenFileAction.openFile(file.get(), project);
     } else {

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
@@ -1,7 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions.toolbar;
 
 import static com.intellij.openapi.application.ModalityState.NON_MODAL;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import java.nio.file.Path;
@@ -20,6 +19,7 @@ import io.vavr.control.Try;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
 import lombok.SneakyThrows;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UI;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
@@ -31,10 +31,12 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 import com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.GraphTableDialog;
 import com.virtuslab.gitmachete.frontend.compat.UiThreadExecutionCompat;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.gitmachete.frontend.ui.api.table.BaseEnhancedGraphTable;
 import com.virtuslab.gitmachete.frontend.ui.providerservice.SelectedGitRepositoryProvider;
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 
+@ExtensionMethod({GitMacheteBundle.class, GitVfsUtils.class})
 @CustomLog
 public class DiscoverAction extends BaseProjectDependentAction {
 
@@ -90,13 +92,13 @@ public class DiscoverAction extends BaseProjectDependentAction {
   private Consumer<IGitMacheteRepositorySnapshot> saveAndDoNotOpenMacheteFileSnapshotConsumer(GitRepository gitRepository,
       Project project, BaseEnhancedGraphTable graphTable, IBranchLayoutWriter branchLayoutWriter) {
     return repositorySnapshot -> saveDiscoveredLayout(repositorySnapshot,
-        GitVfsUtils.getMacheteFilePath(gitRepository), project, graphTable, branchLayoutWriter, () -> {});
+        gitRepository.getMacheteFilePath(), project, graphTable, branchLayoutWriter, () -> {});
   }
 
   private Consumer<IGitMacheteRepositorySnapshot> saveAndOpenMacheteFileSnapshotConsumer(GitRepository gitRepository,
       Project project, BaseEnhancedGraphTable graphTable, IBranchLayoutWriter branchLayoutWriter) {
     return repositorySnapshot -> saveDiscoveredLayout(repositorySnapshot,
-        GitVfsUtils.getMacheteFilePath(gitRepository), project, graphTable,
+        gitRepository.getMacheteFilePath(), project, graphTable,
         branchLayoutWriter, () -> openMacheteFile(project, gitRepository));
   }
 
@@ -109,9 +111,8 @@ public class DiscoverAction extends BaseProjectDependentAction {
       VcsNotifier.getInstance(project).notifyError(
           /* displayId */ null,
           /* title */ getString("action.GitMachete.OpenMacheteFileAction.notification.title.machete-file-not-found"),
-          /* message */ format(
-              getString("action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found"),
-              gitRepository.getRoot().getPath()));
+          /* message */ getString("action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found")
+              .format(gitRepository.getRoot().getPath()));
     }
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
@@ -9,6 +9,7 @@ import git4idea.fetch.GitFetchResult;
 import git4idea.fetch.GitFetchSupport;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -17,6 +18,7 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction
 import com.virtuslab.gitmachete.frontend.actions.common.FetchUpToDateTimeoutStatus;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(FetchUpToDateTimeoutStatus.class)
 @CustomLog
 public class FetchAllRemotesAction extends BaseProjectDependentAction {
 
@@ -69,7 +71,7 @@ public class FetchAllRemotesAction extends BaseProjectDependentAction {
         result = GitFetchSupport.fetchSupport(project).fetchAllRemotes(gitRepository.toJavaList());
         if (gitRepository.isDefined()) {
           val repoName = gitRepository.get().getRoot().getName();
-          FetchUpToDateTimeoutStatus.update(repoName);
+          repoName.update();
         }
       }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
@@ -9,7 +9,6 @@ import git4idea.fetch.GitFetchResult;
 import git4idea.fetch.GitFetchSupport;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
-import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -18,7 +17,6 @@ import com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction
 import com.virtuslab.gitmachete.frontend.actions.common.FetchUpToDateTimeoutStatus;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
-@ExtensionMethod(FetchUpToDateTimeoutStatus.class)
 @CustomLog
 public class FetchAllRemotesAction extends BaseProjectDependentAction {
 
@@ -71,7 +69,7 @@ public class FetchAllRemotesAction extends BaseProjectDependentAction {
         result = GitFetchSupport.fetchSupport(project).fetchAllRemotes(gitRepository.toJavaList());
         if (gitRepository.isDefined()) {
           val repoName = gitRepository.get().getRoot().getName();
-          repoName.update();
+          FetchUpToDateTimeoutStatus.update(repoName);
         }
       }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
@@ -1,6 +1,5 @@
 package com.virtuslab.gitmachete.frontend.actions.toolbar;
 
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import com.intellij.dvcs.DvcsUtil;
@@ -15,12 +14,15 @@ import git4idea.config.GitVcsSettings;
 import io.vavr.control.Try;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseProjectDependentAction;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public class OpenMacheteFileAction extends BaseProjectDependentAction {
 
@@ -59,8 +61,8 @@ public class OpenMacheteFileAction extends BaseProjectDependentAction {
     if (macheteFile.isEmpty()) {
       VcsNotifier.getInstance(project).notifyError(/* displayId */ null,
           /* title */ getString("action.GitMachete.OpenMacheteFileAction.notification.title.machete-file-not-found"),
-          /* message */ format(getString("action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found"),
-              gitDir.get().getPath()));
+          /* message */ getString("action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found")
+              .format(gitDir.get().getPath()));
     } else {
       VirtualFile file = macheteFile.get();
       if (file.isDirectory()) {

--- a/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
+++ b/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
@@ -22,7 +22,7 @@ public class MacheteCompletionContributor extends CompletionContributor implemen
   public void fillCompletionVariants(CompletionParameters parameters, CompletionResultSet result) {
     PsiFile file = parameters.getOriginalFile();
 
-    val branchNames = file.getBranchNamesForPsiFile();
+    val branchNames = file.getBranchNamesForPsiMacheteFile();
 
     if (branchNames.isEmpty()) {
       return;

--- a/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
+++ b/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteCompletionContributor.java
@@ -9,10 +9,12 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.TextFieldWithAutoCompletionListProvider;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod({MacheteFileUtils.class})
 public class MacheteCompletionContributor extends CompletionContributor implements DumbAware {
 
   @Override
@@ -20,7 +22,7 @@ public class MacheteCompletionContributor extends CompletionContributor implemen
   public void fillCompletionVariants(CompletionParameters parameters, CompletionResultSet result) {
     PsiFile file = parameters.getOriginalFile();
 
-    val branchNames = MacheteFileUtils.getBranchNamesForPsiFile(file);
+    val branchNames = file.getBranchNamesForPsiFile();
 
     if (branchNames.isEmpty()) {
       return;

--- a/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
+++ b/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
@@ -3,11 +3,13 @@ package com.virtuslab.gitmachete.frontend.file;
 import com.intellij.psi.PsiFile;
 import git4idea.repo.GitRepositoryManager;
 import io.vavr.collection.List;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitVfsUtils.class)
 public final class MacheteFileUtils {
   private MacheteFileUtils() {}
 
@@ -31,7 +33,7 @@ public final class MacheteFileUtils {
     val project = psiFile.getProject();
 
     val gitRepository = List.ofAll(GitRepositoryManager.getInstance(project).getRepositories())
-        .find(repository -> GitVfsUtils.getMacheteFile(repository)
+        .find(repository -> repository.getMacheteFile()
             .map(macheteFile -> macheteFile.equals(psiFile.getVirtualFile())).getOrElse(false));
 
     if (gitRepository.isEmpty()) {

--- a/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
+++ b/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileUtils.java
@@ -29,7 +29,7 @@ public final class MacheteFileUtils {
   }
 
   @UIThreadUnsafe
-  public static List<String> getBranchNamesForPsiFile(PsiFile psiFile) {
+  public static List<String> getBranchNamesForPsiMacheteFile(PsiFile psiFile) {
     val project = psiFile.getProject();
 
     val gitRepository = List.ofAll(GitRepositoryManager.getInstance(project).getRepositories())

--- a/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -1,7 +1,6 @@
 package com.virtuslab.gitmachete.frontend.file.highlighting;
 
 import static com.intellij.openapi.application.ModalityState.NON_MODAL;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import java.util.OptionalInt;
@@ -18,6 +17,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import io.vavr.control.Option;
 import lombok.Data;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
@@ -27,8 +27,10 @@ import com.virtuslab.gitmachete.frontend.file.grammar.MacheteFile;
 import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedBranch;
 import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedElementTypes;
 import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedEntry;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitMacheteBundle.class)
 public class MacheteAnnotator implements Annotator, DumbAware {
   private boolean cantGetBranchesMessageWasShown = false;
 
@@ -73,7 +75,7 @@ public class MacheteAnnotator implements Annotator, DumbAware {
     if (!branchNames.contains(processedBranchName)) {
       holder
           .newAnnotation(HighlightSeverity.ERROR,
-              format(getString("string.GitMachete.MacheteAnnotator.cannot-find-local-branch-in-repo"), processedBranchName))
+              getString("string.GitMachete.MacheteAnnotator.cannot-find-local-branch-in-repo").format(processedBranchName))
           .range(branch).create();
     }
   }
@@ -115,9 +117,9 @@ public class MacheteAnnotator implements Annotator, DumbAware {
         .findFirst();
     if (wrongIndentChar.isPresent()) {
       holder.newAnnotation(HighlightSeverity.ERROR,
-          format(getString("string.GitMachete.MacheteAnnotator.indent-char-not-match"),
-              indentCharToName((char) wrongIndentChar.getAsInt()),
-              indentCharToName(indentationParameters.indentationCharacter)))
+          getString("string.GitMachete.MacheteAnnotator.indent-char-not-match")
+              .format(indentCharToName((char) wrongIndentChar.getAsInt()),
+                  indentCharToName(indentationParameters.indentationCharacter)))
           .range(element).create();
       return;
     }
@@ -125,8 +127,8 @@ public class MacheteAnnotator implements Annotator, DumbAware {
     if (thisIndentationText.length() % indentationParameters.indentationWidth != 0) {
       holder
           .newAnnotation(HighlightSeverity.ERROR,
-              format(getString("string.GitMachete.MacheteAnnotator.indent-width-not-match"),
-                  String.valueOf(indentationParameters.indentationWidth)))
+              getString("string.GitMachete.MacheteAnnotator.indent-width-not-match")
+                  .format(String.valueOf(indentationParameters.indentationWidth)))
           .range(element).create();
     }
 

--- a/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -60,7 +60,7 @@ public class MacheteAnnotator implements Annotator, DumbAware {
     MacheteGeneratedBranch branch = macheteEntry.getBranch();
 
     PsiFile file = macheteEntry.getContainingFile();
-    val branchNames = file.getBranchNamesForPsiFile();
+    val branchNames = file.getBranchNamesForPsiMacheteFile();
 
     if (branchNames.isEmpty()) {
       if (!cantGetBranchesMessageWasShown) {

--- a/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
+++ b/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/highlighting/MacheteAnnotator.java
@@ -30,7 +30,7 @@ import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedEntry;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
-@ExtensionMethod(GitMacheteBundle.class)
+@ExtensionMethod({GitMacheteBundle.class, MacheteFileUtils.class})
 public class MacheteAnnotator implements Annotator, DumbAware {
   private boolean cantGetBranchesMessageWasShown = false;
 
@@ -60,7 +60,7 @@ public class MacheteAnnotator implements Annotator, DumbAware {
     MacheteGeneratedBranch branch = macheteEntry.getBranch();
 
     PsiFile file = macheteEntry.getContainingFile();
-    val branchNames = MacheteFileUtils.getBranchNamesForPsiFile(file);
+    val branchNames = file.getBranchNamesForPsiFile();
 
     if (branchNames.isEmpty()) {
       if (!cantGetBranchesMessageWasShown) {

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/RediscoverSuggester.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/RediscoverSuggester.java
@@ -1,8 +1,6 @@
 package com.virtuslab.gitmachete.frontend.ui.impl;
 
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getFileModificationDate;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.setFileModificationDate;
 
 import java.nio.file.Path;
 
@@ -12,11 +10,13 @@ import git4idea.repo.GitRepository;
 import io.vavr.control.Option;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 
+@ExtensionMethod(GitVfsUtils.class)
 @CustomLog
 @RequiredArgsConstructor
 public class RediscoverSuggester {
@@ -36,7 +36,7 @@ public class RediscoverSuggester {
       return;
     }
 
-    val lastModifiedTimeMillis = getFileModificationDate(macheteFilePath).getOrNull();
+    val lastModifiedTimeMillis = macheteFilePath.getFileModificationDate().getOrNull();
     if (lastModifiedTimeMillis == null) {
       LOG.warn("Cannot proceed with rediscover suggestion workflow - could not get file modification date");
       return;
@@ -65,7 +65,7 @@ public class RediscoverSuggester {
         break;
       case Messages.NO : // closing dialog goes here too
         LOG.info("Rediscover declined from dialog");
-        setFileModificationDate(macheteFilePath, System.currentTimeMillis());
+        macheteFilePath.setFileModificationDate(System.currentTimeMillis());
         break;
       default :
         LOG.info("Unknown response message");

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -18,7 +18,6 @@ import static com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus.Untracked;
 import static com.virtuslab.gitmachete.frontend.defs.Colors.ORANGE;
 import static com.virtuslab.gitmachete.frontend.defs.Colors.RED;
 import static com.virtuslab.gitmachete.frontend.defs.Colors.TRANSPARENT;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 import static io.vavr.API.$;
 import static io.vavr.API.Case;
@@ -47,6 +46,7 @@ import com.intellij.vcs.log.ui.render.LabelPainter;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.Data;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.index.qual.NonNegative;
@@ -66,8 +66,10 @@ import com.virtuslab.gitmachete.frontend.graph.api.items.IGraphItem;
 import com.virtuslab.gitmachete.frontend.graph.api.paint.IGraphCellPainterFactory;
 import com.virtuslab.gitmachete.frontend.graph.api.paint.PaintParameters;
 import com.virtuslab.gitmachete.frontend.graph.api.render.parts.IRenderPart;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.gitmachete.frontend.ui.impl.table.IGitMacheteRepositorySnapshotProvider;
 
+@ExtensionMethod(GitMacheteBundle.class)
 public final class BranchOrCommitCellRendererComponent extends SimpleColoredRenderer {
   private static final String CELL_TEXT_FRAGMENTS_SPACING = "   ";
   private static final String HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW = "\u2794";
@@ -272,22 +274,19 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
         Case($(Untracked),
             getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.untracked")),
         Case($(AheadOfRemote),
-            format(
-                getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.ahead-of-remote"),
-                remoteName)),
+            getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.ahead-of-remote")
+                .format(remoteName)),
         Case($(BehindRemote),
-            format(getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.behind-remote"),
-                remoteName)),
+            getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.behind-remote")
+                .format(remoteName)),
         Case($(DivergedFromAndNewerThanRemote),
-            format(
-                getString(
-                    "string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.diverged-from-and-newer-than-remote"),
-                remoteName)),
+            getString(
+                "string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.diverged-from-and-newer-than-remote")
+                    .format(remoteName)),
         Case($(DivergedFromAndOlderThanRemote),
-            format(
-                getString(
-                    "string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.diverged-from-and-older-than-remote"),
-                remoteName)));
+            getString(
+                "string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-remote-status-text.diverged-from-and-older-than-remote")
+                    .format(remoteName)));
   }
 
   @UIEffect
@@ -304,25 +303,23 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
     val parentBranchName = branch.getParent().getName();
     return Match(branch.getSyncToParentStatus()).of(
         Case($(InSync),
-            format(getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.in-sync"),
-                currentBranchName, parentBranchName)),
+            getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.in-sync")
+                .format(currentBranchName, parentBranchName)),
         Case($(InSyncButForkPointOff),
-            format(getString(
-                "string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.in-sync-but-fork-point-off"),
-                currentBranchName, parentBranchName)),
+            getString(
+                "string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.in-sync-but-fork-point-off")
+                    .format(currentBranchName, parentBranchName)),
         Case($(OutOfSync),
-            format(getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.out-of-sync"),
-                currentBranchName, parentBranchName)),
+            getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.out-of-sync")
+                .format(currentBranchName, parentBranchName)),
         Case($(MergedToParent),
-            format(
-                getString(
-                    "string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.merged-to-parent"),
-                currentBranchName, parentBranchName)));
+            getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.merged-to-parent")
+                .format(currentBranchName, parentBranchName)));
   }
 
   private static String getRootToolTipText(IRootManagedBranchSnapshot branch) {
-    return format(getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.root"),
-        branch.getName());
+    return getString("string.GitMachete.BranchOrCommitCellRendererComponent.sync-to-parent-status-tooltip.root")
+        .format(branch.getName());
   }
 
   private static class MyTableCellRenderer extends DefaultTableCellRenderer {

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/GitMachetePanel.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/root/GitMachetePanel.java
@@ -1,7 +1,5 @@
 package com.virtuslab.gitmachete.frontend.ui.impl.root;
 
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMacheteFilePath;
-
 import java.awt.BorderLayout;
 
 import javax.swing.Box;
@@ -22,6 +20,7 @@ import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.ui.AncestorListenerAdapter;
 import com.intellij.ui.ScrollPaneFactory;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
@@ -32,7 +31,9 @@ import com.virtuslab.gitmachete.frontend.ui.api.table.BaseEnhancedGraphTable;
 import com.virtuslab.gitmachete.frontend.ui.impl.RediscoverSuggester;
 import com.virtuslab.gitmachete.frontend.ui.providerservice.GraphTableProvider;
 import com.virtuslab.gitmachete.frontend.ui.providerservice.SelectedGitRepositoryProvider;
+import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 
+@ExtensionMethod(GitVfsUtils.class)
 @CustomLog
 public final class GitMachetePanel extends SimpleToolWindowPanel {
 
@@ -75,7 +76,7 @@ public final class GitMachetePanel extends SimpleToolWindowPanel {
       public void ancestorAdded(AncestorEvent event) {
         val gitRepository = selectedGitRepositoryProvider.getSelectedGitRepository().getOrNull();
         if (gitRepository != null) {
-          val macheteFilePath = getMacheteFilePath(gitRepository);
+          val macheteFilePath = gitRepository.getMacheteFilePath();
           Runnable queueDiscoverOperation = () -> graphTable.queueDiscover(macheteFilePath, () -> {});
           val rediscoverSuggester = new RediscoverSuggester(gitRepository, queueDiscoverOperation);
           graphTable.queueRepositoryUpdateAndModelRefresh(() -> rediscoverSuggester.perform());

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -7,7 +7,6 @@ import static com.virtuslab.gitmachete.frontend.defs.ActionIds.ACTION_OPEN_MACHE
 import static com.virtuslab.gitmachete.frontend.defs.ActionPlaces.ACTION_PLACE_CONTEXT_MENU;
 import static com.virtuslab.gitmachete.frontend.defs.ActionPlaces.ACTION_PLACE_VCS_NOTIFICATION;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMacheteFilePath;
 import static io.vavr.API.$;
 import static io.vavr.API.Case;
 import static io.vavr.API.Match;
@@ -87,7 +86,7 @@ import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
  *  repository for actions
  */
 // TODO (#99): consider applying SpeedSearch for branches and commits
-@ExtensionMethod(GitMacheteBundle.class)
+@ExtensionMethod({GitMacheteBundle.class, GitVfsUtils.class})
 @CustomLog
 public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     implements
@@ -181,7 +180,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
 
     // A bit of a shortcut: we're accessing filesystem even though we're on the UI thread here;
     // this shouldn't ever be a heavyweight operation, however.
-    Path macheteFilePath = getMacheteFilePath(gitRepository);
+    Path macheteFilePath = gitRepository.getMacheteFilePath();
     boolean isMacheteFilePresent = Files.isRegularFile(macheteFilePath);
 
     LOG.debug(() -> "Entering: macheteFilePath = ${macheteFilePath}, isMacheteFilePresent = ${isMacheteFilePresent}, " +
@@ -262,7 +261,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     }
 
     try {
-      Path macheteFilePath = getMacheteFilePath(gitRepository);
+      Path macheteFilePath = gitRepository.getMacheteFilePath();
       LOG.info("Writing new branch layout into ${macheteFilePath}");
       branchLayoutWriter.write(macheteFilePath, newBranchLayout, /* backupOldLayout */ true);
 
@@ -369,7 +368,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
         LOG.debug("Queuing repository update onto a non-UI thread");
         new GitMacheteRepositoryUpdateBackgroundable(project, gitRepository, branchLayoutReader, doRefreshModel).queue();
 
-        GitVfsUtils.getMacheteFile(gitRepository).forEach(macheteFile -> VfsUtil.markDirtyAndRefresh(/* async */ true,
+        gitRepository.getMacheteFile().forEach(macheteFile -> VfsUtil.markDirtyAndRefresh(/* async */ true,
             /* recursive */ false, /* reloadChildren */ false, macheteFile));
       });
     } else {

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -6,7 +6,6 @@ import static com.virtuslab.gitmachete.frontend.defs.ActionIds.ACTION_CHECK_OUT;
 import static com.virtuslab.gitmachete.frontend.defs.ActionIds.ACTION_OPEN_MACHETE_FILE;
 import static com.virtuslab.gitmachete.frontend.defs.ActionPlaces.ACTION_PLACE_CONTEXT_MENU;
 import static com.virtuslab.gitmachete.frontend.defs.ActionPlaces.ACTION_PLACE_VCS_NOTIFICATION;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMacheteFilePath;
 import static io.vavr.API.$;
@@ -54,6 +53,7 @@ import io.vavr.control.Option;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UI;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
@@ -73,6 +73,7 @@ import com.virtuslab.gitmachete.frontend.graph.api.items.IGraphItem;
 import com.virtuslab.gitmachete.frontend.graph.api.repository.IRepositoryGraph;
 import com.virtuslab.gitmachete.frontend.graph.api.repository.IRepositoryGraphCache;
 import com.virtuslab.gitmachete.frontend.graph.api.repository.NullRepositoryGraph;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.gitmachete.frontend.ui.api.gitrepositoryselection.IGitRepositorySelectionProvider;
 import com.virtuslab.gitmachete.frontend.ui.api.table.BaseEnhancedGraphTable;
 import com.virtuslab.gitmachete.frontend.ui.impl.cell.BranchOrCommitCell;
@@ -86,6 +87,7 @@ import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
  *  repository for actions
  */
 // TODO (#99): consider applying SpeedSearch for branches and commits
+@ExtensionMethod(GitMacheteBundle.class)
 @CustomLog
 public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     implements
@@ -197,8 +199,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
           return;
         } else {
           setTextForEmptyTable(
-              format(getString("string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file"),
-                  macheteFilePath.toString()));
+              getString("string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file")
+                  .format(macheteFilePath.toString()));
         }
       }
     }
@@ -237,8 +239,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
   private Notification getSkippedBranchesNotification(IGitMacheteRepositorySnapshot repositorySnapshot,
       GitRepository gitRepository) {
     val notification = VcsNotifier.STANDARD_NOTIFICATION.createNotification(
-        format(getString("string.GitMachete.EnhancedGraphTable.skipped-branches-text"),
-            String.join(", ", repositorySnapshot.getSkippedBranchNames())),
+        getString("string.GitMachete.EnhancedGraphTable.skipped-branches-text")
+            .format(String.join(", ", repositorySnapshot.getSkippedBranchNames())),
         NotificationType.WARNING);
     notification.addAction(NotificationAction.createSimple(
         () -> getString("action.GitMachete.EnhancedGraphTable.automatic-discover.slide-out-skipped"), () -> {
@@ -310,8 +312,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
   private Consumer<Path> getUnsuccessfulDiscoverMacheteFilePathConsumer() {
     return (Path macheteFilePath) -> UiThreadExecutionCompat.invokeLaterIfNeeded(NON_MODAL,
         () -> setTextForEmptyTable(
-            format(getString("string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout"),
-                macheteFilePath.toString())));
+            getString("string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout")
+                .format(macheteFilePath.toString())));
   }
 
   @Override

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteRepositoryDiscoverer.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteRepositoryDiscoverer.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.vcs.VcsNotifier;
 import io.vavr.control.Try;
 import lombok.AllArgsConstructor;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 
 import com.virtuslab.binding.RuntimeBinding;
@@ -24,6 +25,7 @@ import com.virtuslab.gitmachete.frontend.ui.api.gitrepositoryselection.IGitRepos
 import com.virtuslab.gitmachete.frontend.ui.providerservice.BranchLayoutWriterProvider;
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 
+@ExtensionMethod(GitVfsUtils.class)
 @AllArgsConstructor
 @CustomLog
 public class GitMacheteRepositoryDiscoverer {
@@ -39,9 +41,9 @@ public class GitMacheteRepositoryDiscoverer {
       LOG.error("Can't do automatic discover because of undefined selected repository");
       return;
     }
-    Path rootDirPath = GitVfsUtils.getRootDirectoryPath(selectedRepository).toAbsolutePath();
-    Path mainGitDirPath = GitVfsUtils.getMainGitDirectoryPath(selectedRepository).toAbsolutePath();
-    Path worktreeGitDirPath = GitVfsUtils.getWorktreeGitDirectoryPath(selectedRepository).toAbsolutePath();
+    Path rootDirPath = selectedRepository.getRootDirectoryPath().toAbsolutePath();
+    Path mainGitDirPath = selectedRepository.getMainGitDirectoryPath().toAbsolutePath();
+    Path worktreeGitDirPath = selectedRepository.getWorktreeGitDirectoryPath().toAbsolutePath();
 
     new Task.Backgroundable(project, getString("string.GitMachete.EnhancedGraphTable.automatic-discover.task-title")) {
       @Override

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteRepositoryUpdateBackgroundable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/GitMacheteRepositoryUpdateBackgroundable.java
@@ -2,10 +2,6 @@ package com.virtuslab.gitmachete.frontend.ui.impl.table;
 
 import static com.intellij.openapi.application.ModalityState.NON_MODAL;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMacheteFilePath;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getMainGitDirectoryPath;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getRootDirectoryPath;
-import static com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils.getWorktreeGitDirectoryPath;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,6 +15,7 @@ import git4idea.repo.GitRepository;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
 import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
 import org.checkerframework.checker.guieffect.qual.UI;
 import org.checkerframework.checker.index.qual.Positive;
 
@@ -30,7 +27,9 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositoryCache;
 import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 import com.virtuslab.gitmachete.backend.api.MacheteFileReaderException;
 import com.virtuslab.gitmachete.frontend.compat.UiThreadExecutionCompat;
+import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 
+@ExtensionMethod(GitVfsUtils.class)
 @CustomLog
 public final class GitMacheteRepositoryUpdateBackgroundable extends Task.Backgroundable {
 
@@ -75,10 +74,10 @@ public final class GitMacheteRepositoryUpdateBackgroundable extends Task.Backgro
    * This method is heavyweight and must never be invoked on the UI thread.
    */
   private Option<IGitMacheteRepositorySnapshot> updateRepositorySnapshot() {
-    Path rootDirectoryPath = getRootDirectoryPath(gitRepository);
-    Path mainGitDirectoryPath = getMainGitDirectoryPath(gitRepository);
-    Path worktreeGitDirectoryPath = getWorktreeGitDirectoryPath(gitRepository);
-    Path macheteFilePath = getMacheteFilePath(gitRepository);
+    Path rootDirectoryPath = gitRepository.getRootDirectoryPath();
+    Path mainGitDirectoryPath = gitRepository.getMainGitDirectoryPath();
+    Path worktreeGitDirectoryPath = gitRepository.getWorktreeGitDirectoryPath();
+    Path macheteFilePath = gitRepository.getMacheteFilePath();
     boolean isMacheteFilePresent = Files.isRegularFile(macheteFilePath);
 
     LOG.debug(() -> "Entering: rootDirectoryPath = ${rootDirectoryPath}, mainGitDirectoryPath = ${mainGitDirectoryPath}, " +

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommit.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommit.java
@@ -3,6 +3,7 @@ package com.virtuslab.gitcore.impl.jgit;
 import java.time.Instant;
 
 import lombok.Getter;
+import lombok.experimental.ExtensionMethod;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.aliasing.qual.NonLeaked;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -11,6 +12,7 @@ import com.virtuslab.gitcore.api.IGitCoreCommit;
 import com.virtuslab.gitcore.api.IGitCoreCommitHash;
 import com.virtuslab.gitcore.api.IGitCoreTreeHash;
 
+@ExtensionMethod(GitCoreTreeHash.class)
 @Getter
 public class GitCoreCommit implements IGitCoreCommit {
   private final String shortMessage;
@@ -22,7 +24,7 @@ public class GitCoreCommit implements IGitCoreCommit {
     this.shortMessage = commit.getShortMessage();
     this.commitTime = Instant.ofEpochSecond(commit.getCommitTime());
     this.hash = GitCoreCommitHash.of(commit.getId());
-    this.treeHash = GitCoreTreeHash.of(commit.getTree().getId());
+    this.treeHash = commit.getTree().getId().of();
   }
 
   @Override

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommit.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommit.java
@@ -12,7 +12,7 @@ import com.virtuslab.gitcore.api.IGitCoreCommit;
 import com.virtuslab.gitcore.api.IGitCoreCommitHash;
 import com.virtuslab.gitcore.api.IGitCoreTreeHash;
 
-@ExtensionMethod(GitCoreTreeHash.class)
+@ExtensionMethod({GitCoreCommitHash.class, GitCoreTreeHash.class})
 @Getter
 public class GitCoreCommit implements IGitCoreCommit {
   private final String shortMessage;
@@ -23,8 +23,8 @@ public class GitCoreCommit implements IGitCoreCommit {
   public GitCoreCommit(@NonLeaked RevCommit commit) {
     this.shortMessage = commit.getShortMessage();
     this.commitTime = Instant.ofEpochSecond(commit.getCommitTime());
-    this.hash = GitCoreCommitHash.of(commit.getId());
-    this.treeHash = commit.getTree().getId().of();
+    this.hash = commit.getId().toGitCoreCommitHash();
+    this.treeHash = commit.getTree().getId().toGitCoreTreeHash();
   }
 
   @Override

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommitHash.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommitHash.java
@@ -11,12 +11,12 @@ public final class GitCoreCommitHash extends GitCoreObjectHash implements IGitCo
     super(objectId);
   }
 
-  public static GitCoreCommitHash of(ObjectId objectId) {
+  public static GitCoreCommitHash toGitCoreCommitHash(ObjectId objectId) {
     return new GitCoreCommitHash(objectId);
   }
 
-  public static Option<IGitCoreCommitHash> ofZeroable(ObjectId objectId) {
-    return objectId.equals(ObjectId.zeroId()) ? Option.none() : Option.some(of(objectId));
+  public static Option<IGitCoreCommitHash> toOptionable(ObjectId objectId) {
+    return objectId.equals(ObjectId.zeroId()) ? Option.none() : Option.some(toGitCoreCommitHash(objectId));
   }
 
   @Override

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommitHash.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommitHash.java
@@ -15,7 +15,7 @@ public final class GitCoreCommitHash extends GitCoreObjectHash implements IGitCo
     return new GitCoreCommitHash(objectId);
   }
 
-  public static Option<IGitCoreCommitHash> toOptionable(ObjectId objectId) {
+  public static Option<IGitCoreCommitHash> toGitCoreCommitHashOption(ObjectId objectId) {
     return objectId.equals(ObjectId.zeroId()) ? Option.none() : Option.some(toGitCoreCommitHash(objectId));
   }
 

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommitHash.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreCommitHash.java
@@ -11,11 +11,11 @@ public final class GitCoreCommitHash extends GitCoreObjectHash implements IGitCo
     super(objectId);
   }
 
-  static GitCoreCommitHash of(ObjectId objectId) {
+  public static GitCoreCommitHash of(ObjectId objectId) {
     return new GitCoreCommitHash(objectId);
   }
 
-  static Option<IGitCoreCommitHash> ofZeroable(ObjectId objectId) {
+  public static Option<IGitCoreCommitHash> ofZeroable(ObjectId objectId) {
     return objectId.equals(ObjectId.zeroId()) ? Option.none() : Option.some(of(objectId));
   }
 

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreLocalBranchSnapshot.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreLocalBranchSnapshot.java
@@ -1,5 +1,7 @@
 package com.virtuslab.gitcore.impl.jgit;
 
+import static com.virtuslab.gitcore.impl.jgit.BranchFullNameUtils.getLocalBranchFullName;
+
 import io.vavr.collection.List;
 import io.vavr.control.Option;
 import org.eclipse.jgit.annotations.Nullable;
@@ -28,7 +30,7 @@ public class GitCoreLocalBranchSnapshot extends BaseGitCoreBranchSnapshot implem
 
   @Override
   public String getFullName() {
-    return BranchFullNameUtils.getLocalBranchFullName(shortName);
+    return getLocalBranchFullName(shortName);
   }
 
   @Override

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreReflogEntry.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreReflogEntry.java
@@ -37,13 +37,13 @@ public class GitCoreReflogEntry implements IGitCoreReflogEntry {
   @Override
   @ToString.Include(name = "oldCommitHash")
   public Option<IGitCoreCommitHash> getOldCommitHash() {
-    return reflogEntry.getOldId().ofZeroable();
+    return reflogEntry.getOldId().toOptionable();
   }
 
   @Override
   @ToString.Include(name = "newCommitHash")
   public IGitCoreCommitHash getNewCommitHash() {
-    return reflogEntry.getNewId().of();
+    return reflogEntry.getNewId().toGitCoreCommitHash();
   }
 
   @Override

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreReflogEntry.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreReflogEntry.java
@@ -6,6 +6,7 @@ import io.vavr.control.Option;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import lombok.experimental.ExtensionMethod;
 import org.checkerframework.checker.interning.qual.UsesObjectEquals;
 import org.eclipse.jgit.lib.ReflogEntry;
 
@@ -14,6 +15,7 @@ import com.virtuslab.gitcore.api.IGitCoreCommitHash;
 import com.virtuslab.gitcore.api.IGitCoreReflogEntry;
 
 @RequiredArgsConstructor(access = AccessLevel.MODULE)
+@ExtensionMethod(GitCoreCommitHash.class)
 @ToString(onlyExplicitlyIncluded = true)
 @UsesObjectEquals
 public class GitCoreReflogEntry implements IGitCoreReflogEntry {
@@ -35,13 +37,13 @@ public class GitCoreReflogEntry implements IGitCoreReflogEntry {
   @Override
   @ToString.Include(name = "oldCommitHash")
   public Option<IGitCoreCommitHash> getOldCommitHash() {
-    return GitCoreCommitHash.ofZeroable(reflogEntry.getOldId());
+    return reflogEntry.getOldId().ofZeroable();
   }
 
   @Override
   @ToString.Include(name = "newCommitHash")
   public IGitCoreCommitHash getNewCommitHash() {
-    return GitCoreCommitHash.of(reflogEntry.getNewId());
+    return reflogEntry.getNewId().of();
   }
 
   @Override

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreReflogEntry.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreReflogEntry.java
@@ -37,7 +37,7 @@ public class GitCoreReflogEntry implements IGitCoreReflogEntry {
   @Override
   @ToString.Include(name = "oldCommitHash")
   public Option<IGitCoreCommitHash> getOldCommitHash() {
-    return reflogEntry.getOldId().toOptionable();
+    return reflogEntry.getOldId().toGitCoreCommitHashOption();
   }
 
   @Override

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
@@ -388,7 +388,7 @@ public final class GitCoreRepository implements IGitCoreRepository {
       LOG.debug(() -> "Detected merge base for ${c1.getHash().getHashString()} " +
           "and ${c2.getHash().getHashString()} is " + (mergeBase != null ? mergeBase.getId().getName() : "<none>"));
       if (mergeBase != null) {
-        return Option.some(mergeBase.getId().of());
+        return Option.some(mergeBase.getId().toGitCoreCommitHash());
       } else {
         return Option.none();
       }

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
@@ -26,6 +26,7 @@ import lombok.CustomLog;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.ToString;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.eclipse.jgit.lib.Constants;
@@ -52,6 +53,7 @@ import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitcore.api.IGitCoreReflogEntry;
 import com.virtuslab.gitcore.api.IGitCoreRepository;
 
+@ExtensionMethod(GitCoreCommitHash.class)
 @CustomLog
 @ToString(onlyExplicitlyIncluded = true)
 public final class GitCoreRepository implements IGitCoreRepository {
@@ -386,7 +388,7 @@ public final class GitCoreRepository implements IGitCoreRepository {
       LOG.debug(() -> "Detected merge base for ${c1.getHash().getHashString()} " +
           "and ${c2.getHash().getHashString()} is " + (mergeBase != null ? mergeBase.getId().getName() : "<none>"));
       if (mergeBase != null) {
-        return Option.some(GitCoreCommitHash.of(mergeBase.getId()));
+        return Option.some(mergeBase.getId().of());
       } else {
         return Option.none();
       }

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreTreeHash.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreTreeHash.java
@@ -10,7 +10,7 @@ public final class GitCoreTreeHash extends GitCoreObjectHash implements IGitCore
     super(objectId);
   }
 
-  static IGitCoreTreeHash of(ObjectId objectId) {
+  public static IGitCoreTreeHash of(ObjectId objectId) {
     return new GitCoreTreeHash(objectId);
   }
 

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreTreeHash.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreTreeHash.java
@@ -10,7 +10,7 @@ public final class GitCoreTreeHash extends GitCoreObjectHash implements IGitCore
     super(objectId);
   }
 
-  public static IGitCoreTreeHash of(ObjectId objectId) {
+  public static IGitCoreTreeHash toGitCoreTreeHash(ObjectId objectId) {
     return new GitCoreTreeHash(objectId);
   }
 


### PR DESCRIPTION
It was hard to decide in which place @ExtensionMethod should be used. For GitMacheteBundle it was clear because format(getString(..))is not readable and used in many places. Do you think that e.q.  places like in the picture below @ExtensionMethod should also be used ? (`invokeLaterIfNeeded`)
<img width="745" alt="Screenshot 2022-05-30 at 13 03 00" src="https://user-images.githubusercontent.com/33667003/170979324-5c1062c5-58ed-48e6-a6f8-2679d87def2a.png">
 