### PR TITLE
Set up autoformatter (scalafmt via spotless) for Scala code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,7 @@ dependencyUpdates {
 
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 allprojects {
   repositories {
@@ -269,10 +270,24 @@ allprojects {
       removeUnusedImports()
       targetExclude '**/build/generated/**/*.*'
     }
+    kotlin {
+      ktfmt()
+    }
+    scala {
+      scalafmt().configFile("$rootDir/scalafmt.conf")
+    }
   }
 
   if (!isCI) {
-    compileJava.dependsOn 'spotlessApply'
+    tasks.withType(JavaCompile) {
+      dependsOn 'spotlessJavaApply'
+    }
+    tasks.withType(KotlinCompile) {
+      dependsOn 'spotlessKotlinApply'
+    }
+    tasks.withType(ScalaCompile) {
+      dependsOn 'spotlessScalaApply'
+    }
   }
 
 
@@ -434,12 +449,6 @@ allprojects {
         kotlinOptions.freeCompilerArgs += '-Xskip-metadata-version-check'
 
         kotlinOptions.jvmTarget = javaMajorVersion
-      }
-
-      spotless {
-        kotlin {
-          ktfmt()
-        }
       }
     }
 

--- a/scalafmt.conf
+++ b/scalafmt.conf
@@ -1,0 +1,2 @@
+runner.dialect = scala213
+maxColumn = 120

--- a/src/uiTest/resources/project.rhino.js
+++ b/src/uiTest/resources/project.rhino.js
@@ -14,7 +14,6 @@ importClass(com.intellij.openapi.actionSystem.impl.ActionToolbarImpl);
 importClass(com.intellij.openapi.application.ModalityState);
 importClass(com.intellij.openapi.wm.ToolWindowId);
 importClass(com.intellij.openapi.wm.ToolWindowManager);
-importClass(com.intellij.toolWindow.ToolWindowPane);
 importClass(com.intellij.ui.GuiUtils);
 
 importClass(org.assertj.swing.fixture.JComboBoxFixture);

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/RunningIntelliJFixtureExtension.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/RunningIntelliJFixtureExtension.scala
@@ -12,8 +12,10 @@ import org.virtuslab.ideprobe.robot.RobotPluginExtension
 trait RunningIntelliJFixtureExtension extends RobotPluginExtension { this: IdeProbeFixture =>
 
   private val machetePlugin: Plugin = {
-    val pluginPath = sys.props.get("ui-test.plugin.path")
-      .filterNot(_.isEmpty).getOrElse(throw new Exception("Plugin path is not provided"))
+    val pluginPath = sys.props
+      .get("ui-test.plugin.path")
+      .filterNot(_.isEmpty)
+      .getOrElse(throw new Exception("Plugin path is not provided"))
     Plugin.Direct(Paths.get(pluginPath).toUri)
   }
 

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UIScenarioSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UIScenarioSuite.scala
@@ -9,7 +9,6 @@ import org.virtuslab.ideprobe.ProbeDriver
 
 object UIScenarioSuite extends UISuite {}
 
-
 @RunWith(classOf[JUnit4])
 class UIScenarioSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_README_SCENARIOS) {
   import UIScenarioSuite._

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UISuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UISuite.scala
@@ -3,15 +3,13 @@ package com.virtuslab.gitmachete.uitest
 import org.virtuslab.ideprobe.dependencies.IntelliJVersion
 import org.virtuslab.ideprobe.{IdeProbeFixture, IntelliJFixture}
 
-
-trait UISuite
-  extends RunningIntelliJPerSuite
-    with IdeProbeFixture
-    with RunningIntelliJFixtureExtension {
+trait UISuite extends RunningIntelliJPerSuite with IdeProbeFixture with RunningIntelliJFixtureExtension {
 
   lazy val intelliJVersion: IntelliJVersion = {
-    val version = sys.props.get("ui-test.intellij.version")
-      .filterNot(_.isEmpty).getOrElse(throw new Exception("IntelliJ version is not provided"))
+    val version = sys.props
+      .get("ui-test.intellij.version")
+      .filterNot(_.isEmpty)
+      .getOrElse(throw new Exception("IntelliJ version is not provided"))
     // We're cheating here a bit since `version` might be either a build number or a release number,
     // while we're always treating it as a build number.
     // Still, as of ide-probe 0.26.0, even when release number like `2020.3` is passed as `build`, UI tests work just fine.
@@ -22,7 +20,6 @@ trait UISuite
     // By default, the config is taken from <class-name>.conf resource, see org.virtuslab.ideprobe.IdeProbeFixture.resolveConfig
     fixtureFromConfig().withVersion(intelliJVersion)
   }
-
 
   def waitAndCloseProject() = {
     intelliJ.probe.await()

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -37,7 +37,7 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
   }
 
   @Test def skipNonExistentBranches_toggleListingCommits_slideOutRoot(): Unit = {
-    //TODO (#830): try ... catch block to discover why the SocketTimeoutException occurs
+    // TODO (#830): try ... catch block to discover why the SocketTimeoutException occurs
     try {
       project.openGitMacheteTab()
       overwriteMacheteFile(
@@ -55,7 +55,8 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
       // Non-existent branches should be skipped while causing no error (only a low-severity notification).
       Assert.assertEquals(
         Seq("allow-ownership-link", "build-chain", "call-ws", "develop", "hotfix/add-trigger", "master"),
-        managedBranches.toSeq.sorted)
+        managedBranches.toSeq.sorted
+      )
       project.toggleListingCommits()
       var branchAndCommitRowsCount = project.refreshModelAndGetRowCount()
       // 6 branch rows + 7 commit rows


### PR DESCRIPTION
Setting this up with Gradle is smoother than with Scala's dedicated build tool, `sbt` :trollface: 