### PR TITLE
Resolve Gradle caching issues (overlapping output directories for `generateMacheteParser` and `generateMacheteLexer`)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,15 +68,6 @@ jobs:
       - run:
           name: Run unit & integration tests
           command: ./gradlew test
-      # Unfortunately, wildcards for test result paths aren't supported by CircleCI yet.
-      - store_test_results:
-          path: branchLayout/impl/build/test-results/test/
-      - store_test_results:
-          path: backend/impl/build/test-results/test/
-      - store_test_results:
-          path: frontend/base/build/test-results/test/
-      - store_test_results:
-          path: build/test-results/test/
 
       - run:
           name: Build plugin artifact
@@ -116,11 +107,21 @@ jobs:
             mkdir -p /exception-artifacts
             for f in $(ls -d /tmp/ide-probe/screenshots/*/) ; do cd  $f/artifacts ; zip -r "/exception-artifacts/$(basename ${f}).zip" . ; done
           when: on_fail
-      - store_test_results:
-          path: build/test-results/uiTest/
       - store_artifacts:
           path: /exception-artifacts
           destination: .
+
+      # Unfortunately, wildcards for test result paths aren't supported by CircleCI yet.
+      - store_test_results:
+          path: branchLayout/impl/build/test-results/test/
+      - store_test_results:
+          path: backend/impl/build/test-results/test/
+      - store_test_results:
+          path: frontend/base/build/test-results/test/
+      - store_test_results:
+          # This include the test results of both "regular" tests and UI tests for the top-level project.
+          path: build/test-results/
+
       - when:
           condition:
             not:

--- a/backend/impl/build.gradle
+++ b/backend/impl/build.gradle
@@ -14,6 +14,8 @@ dependencies {
   api project(':backend:api')
   api project(':branchLayout:api')
 
+  // Note that we can't easily use Gradle's `testFixtures` configuration here
+  // as it doesn't seem to expose testFixtures resources in test classpath correctly.
   testImplementation project(':testCommon').sourceSets.test.output
   testRuntimeOnly project(':branchLayout:impl')
   testRuntimeOnly project(':gitCore:jGit')

--- a/build.gradle
+++ b/build.gradle
@@ -427,10 +427,13 @@ allprojects {
 
     ideProbe = { ->
       repositories {
+        // Needed for com.intellij.remoterobot:remote-robot
         maven { url 'https://packages.jetbrains.team/maven/p/ij/intellij-dependencies' }
       }
 
       dependencies {
+        // Note that we can't easily use Gradle's `testFixtures` configuration here
+        // as it doesn't seem to expose testFixtures resources in test classpath correctly.
         uiTestImplementation project(':testCommon').sourceSets.test.output
         uiTestImplementation libs.bundles.ideProbe
       }
@@ -654,18 +657,17 @@ uiTestTargets.each { version ->
     group = 'verification'
 
     testClassesDirs = uiTest.output.classesDirs
-    classpath = sourceSets.main.output + configurations.uiTestRuntimeClasspath + uiTest.output
-    // Let's keep the XML test results in a per-version directory, this makes things easier in the CI
-    // where the UI tests are executed under a couple different IDE versions one after another.
-    // The results in the default directory (build/test-results/uiTest) would get overwritten which each subsequent test.
-    reports.junitXml.destination = file("$buildDir/test-results/uiTest/${version}")
+    classpath = configurations.uiTestRuntimeClasspath + uiTest.output
 
     dependsOn ':buildPlugin'
 
     systemProperty 'ui-test.intellij.version', version
     systemProperty 'ui-test.plugin.path', buildPlugin.outputs.files[0].path
 
-    outputs.upToDateWhen { false }
+    // TODO (#945): caching of UI test results doesn't work in the CI anyway
+    if (!isCI) {
+      outputs.upToDateWhen { false }
+    }
 
     if (project.properties.tests) {
       filter {

--- a/frontend/file/build.gradle
+++ b/frontend/file/build.gradle
@@ -15,25 +15,34 @@ apply plugin: 'org.jetbrains.grammarkit'
 import org.jetbrains.grammarkit.tasks.*
 
 def grammarSourcesRoot = 'src/main/grammar'
-def generatedJavaSourcesRoot = 'build/generated'
+// Outputs of these two tasks canNOT go into the same directory,
+// as Gradle doesn't support caching of output directories when more than one task writes.
+// Let's pick non-overlapping directories for the outputs instead.
+def generatedParserJavaSourcesRoot = 'build/generated/parser'
+def generatedLexerJavaSourcesRoot = 'build/generated/lexer'
 def grammarJavaPackage = 'com.virtuslab.gitmachete.frontend.file.grammar'
 def grammarJavaPackagePath = grammarJavaPackage.replace('.', '/')
 
-sourceSets.main.java.srcDirs += generatedJavaSourcesRoot
+sourceSets.main.java.srcDirs += [generatedParserJavaSourcesRoot, generatedLexerJavaSourcesRoot]
 
 task generateMacheteParser(type: GenerateParserTask) {
+  // See https://github.com/JetBrains/gradle-grammar-kit-plugin/issues/89
+  outputs.cacheIf { true }
+
   source = "$grammarSourcesRoot/Machete.bnf"
-  targetRoot = generatedJavaSourcesRoot
+  targetRoot = generatedParserJavaSourcesRoot
   pathToParser = "/$grammarJavaPackagePath/MacheteGeneratedParser.java"
   pathToPsiRoot = "/$grammarJavaPackagePath/"
   purgeOldFiles = false
 }
 
 task generateMacheteLexer(type: GenerateLexerTask) {
+  outputs.cacheIf { true }
+
   dependsOn generateMacheteParser
 
   source = "$grammarSourcesRoot/Machete.flex"
-  targetDir = "$generatedJavaSourcesRoot/$grammarJavaPackagePath/"
+  targetDir = "$generatedLexerJavaSourcesRoot/$grammarJavaPackagePath/"
   targetClass = 'MacheteGeneratedLexer'
   purgeOldFiles = false
 }


### PR DESCRIPTION
This caused both tasks to be run with almost every build (or at least much more frequently that they needed to)