### PR TITLE
Bump ide-probe to 0.36.1 to get rid of Ktor/Netty spam in logs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 checker = "3.22.2"
-ideProbe = "0.36.0"
+ideProbe = "0.36.1"
 powerMock = "2.0.9"
 
 [libraries]

--- a/src/uiTest/resources/ideprobe.conf
+++ b/src/uiTest/resources/ideprobe.conf
@@ -3,22 +3,9 @@ probe {
     base = ${?IDEPROBE_PATHS_BASE}
     screenshots = ${?IDEPROBE_PATHS_SCREENSHOTS}
   }
+
   driver {
-    vmOptions = [
-      # TODO (JetBrains/intellij-ui-test-robot#191): turn off DEBUG logs from Ktor & Netty completely
-
-      # To supress `java.lang.IllegalAccessException: class io.netty.util.internal.PlatformDependent0$6 cannot access class jdk.internal.misc.Unsafe
-      #   (in module java.base) because module java.base does not export jdk.internal.misc`
-      "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED",
-      # To suppress `java.lang.UnsatisfiedLinkError: no netty_transport_native_epoll in java.library.path`,
-      # see source code for io.netty.channel.epoll.Epoll (as it's undocumented otherwise).
-      "-Dio.netty.transport.noNative=true",
-      # To suppress `java.lang.UnsupportedOperationException: Reflective setAccessible(true) disabled`
-      # from io.netty.util.internal.ReflectionUtil#trySetAccessible
-      "-Dio.netty.tryReflectionSetAccessible=true",
-
-      "-Xmx1G"
-    ]
+    vmOptions = ["-Xmx1G"]
     check {
       errors {
         enabled = true


### PR DESCRIPTION
See https://github.com/JetBrains/intellij-ui-test-robot/issues/191 and https://github.com/JetBrains/intellij-ui-test-robot/issues/190

Was:

![image](https://user-images.githubusercontent.com/3383210/177879295-078a9730-f796-448b-af1e-cd0bdabce7e6.png)

Is:

![image](https://user-images.githubusercontent.com/3383210/177879546-d8b8a331-d48f-4d67-9a3c-2f04a146f36d.png)
