### PR TITLE
Update CLI outputs for backend:impl tests to git-machete v3.11.3

### DIFF
--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
@@ -141,7 +141,7 @@ public class StatusAndDiscoverIntegrationTestSuite extends BaseGitRepositoryBack
 
     sb.append("  ");
     sb.append(prefix);
-    sb.append("| ");
+    sb.append("|");
     sb.append(System.lineSeparator());
 
     val commits = branch.getCommits().reverse();

--- a/backend/impl/src/test/resources/setup-for-diverged-and-older-than.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-for-diverged-and-older-than.sh-discover.txt
@@ -1,13 +1,13 @@
   master (behind origin)
-  | 
+  |
   | HOTFIX Add the trigger (amended)
   o-hotfix/add-trigger * (diverged from origin)
 
   develop (ahead of origin)
-  | 
+  |
   | Allow ownership links
   | 1st round of fixes
   x-allow-ownership-link (diverged from & older than origin)
-    | 
+    |
     | Build arbitrarily long chains
     x-build-chain (untracked)

--- a/backend/impl/src/test/resources/setup-for-diverged-and-older-than.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-for-diverged-and-older-than.sh-status.txt
@@ -1,15 +1,15 @@
   develop (ahead of origin)
-  | 
+  |
   | Allow ownership links
   | 1st round of fixes
   x-allow-ownership-link  PR #123 (diverged from & older than origin)
-  | | 
+  | |
   | | Build arbitrarily long chains
   | x-build-chain (untracked)
-  | 
+  |
   m-call-ws  PR #124 (ahead of origin)
 
   master (behind origin)
-  | 
+  |
   | HOTFIX Add the trigger (amended)
   o-hotfix/add-trigger * (diverged from origin)

--- a/backend/impl/src/test/resources/setup-for-overridden-fork-point.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-for-overridden-fork-point.sh-discover.txt
@@ -1,7 +1,7 @@
   develop
-  | 
+  |
   | Allow ownership links
   o-allow-ownership-link (untracked)
-    | 
+    |
     | Build arbitrarily long chains
     o-build-chain *

--- a/backend/impl/src/test/resources/setup-for-overridden-fork-point.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-for-overridden-fork-point.sh-status.txt
@@ -1,4 +1,4 @@
   develop
-  | 
+  |
   | Build arbitrarily long chains
   o-build-chain *

--- a/backend/impl/src/test/resources/setup-for-squash-merge.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-for-squash-merge.sh-status.txt
@@ -1,3 +1,3 @@
   develop
-  | 
+  |
   m-allow-ownership-link *  PR #123

--- a/backend/impl/src/test/resources/setup-for-yellow-edges.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-for-yellow-edges.sh-discover.txt
@@ -1,22 +1,22 @@
   master
-  | 
+  |
   o-behind/hotfix/add-trigger (untracked)
-  | 
+  |
   | HOTFIX Add the trigger (amended)
   o-hotfix/add-trigger * (diverged from origin)
 
   develop (untracked)
-  | 
+  |
   | Allow ownership links
   o-allow-ownership-link
-    | 
+    |
     | Build arbitrarily long chains
     o-build-chain (untracked)
-      | 
+      |
       | Call web service
       | 1st round of fixes
       | 2nd round of fixes
       o-call-ws (ahead of origin)
-        | 
+        |
         | Drop unneeded SQL constraints
         x-drop-constraint (untracked)

--- a/backend/impl/src/test/resources/setup-for-yellow-edges.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-for-yellow-edges.sh-status.txt
@@ -1,9 +1,9 @@
   develop (untracked)
-  | 
+  |
   | Allow ownership links -> fork point ??? commit 8ca0987 seems to be a part of the unique history of allow-ownership-link
   | Build arbitrarily long chains
   ?-build-chain (untracked)
-  | 
+  |
   | Allow ownership links
   | Build arbitrarily long chains -> fork point ??? commit a8d7750 seems to be a part of the unique history of build-chain
   | Call web service
@@ -12,8 +12,8 @@
   ?-call-ws  PR #124 (ahead of origin)
 
   master
-  | 
+  |
   | HOTFIX Add the trigger (amended)
   o-hotfix/add-trigger * (diverged from origin)
-    | 
+    |
     x-behind/hotfix/add-trigger (untracked)

--- a/backend/impl/src/test/resources/setup-with-multiple-remotes.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-with-multiple-remotes.sh-discover.txt
@@ -1,21 +1,21 @@
   master
-  | 
+  |
   | HOTFIX Add the trigger (amended)
   o-hotfix/add-trigger * (diverged from remote2)
 
   develop
-  | 
+  |
   | Allow ownership links
   | 1st round of fixes
   x-allow-ownership-link (ahead of remote1)
-  | | 
+  | |
   | | Build arbitrarily long chains
   | x-build-chain (untracked)
-  | 
+  |
   | Call web service
   | 1st round of fixes
   | 2nd round of fixes
   o-call-ws (ahead of remote1)
-    | 
+    |
     | Drop unneeded SQL constraints
     x-drop-constraint (untracked)

--- a/backend/impl/src/test/resources/setup-with-multiple-remotes.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-with-multiple-remotes.sh-status.txt
@@ -1,18 +1,18 @@
   develop
-  | 
+  |
   | Allow ownership links
   | 1st round of fixes
   x-allow-ownership-link  PR #123 (ahead of remote1)
-  | | 
+  | |
   | | Build arbitrarily long chains
   | x-build-chain (untracked)
-  | 
+  |
   | Call web service
   | 1st round of fixes
   | 2nd round of fixes
   o-call-ws  PR #124 (ahead of remote1)
 
   master
-  | 
+  |
   | HOTFIX Add the trigger (amended)
   o-hotfix/add-trigger * (diverged from remote2)

--- a/backend/impl/src/test/resources/setup-with-no-remotes.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-with-no-remotes.sh-discover.txt
@@ -1,34 +1,34 @@
   develop *
-  | 
+  |
   | Allow ownership links
   | 1st round of fixes
   x-allow-ownership-link
-  | | 
+  | |
   | | Build arbitrarily long chains
   | x-build-chain
-  | | 
+  | |
   | | Kill the process after 10 seconds
   | o-kill-process
-  | 
+  |
   | Call web service
   | 1st round of fixes
   | 2nd round of fixes
   o-call-ws
-    | 
+    |
     | Drop unneeded SQL constraints
     x-drop-constraint
-    | 
+    |
     | Evict conflicting dependencies
     o-evict-deps
-      | 
+      |
       | Fix component labels
       o-fix/component-labels
-        | 
+        |
         | Introduce global context
         o-global-context
-          | 
+          |
           | Enable Scala/Python interoperability
           o-interop-scala-python
-            | 
+            |
             | Enforce the use of Java 11
             o-java-11-enforce

--- a/backend/impl/src/test/resources/setup-with-no-remotes.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-with-no-remotes.sh-status.txt
@@ -1,16 +1,16 @@
   develop *
-  | 
+  |
   | Allow ownership links
   | 1st round of fixes
   x-allow-ownership-link  PR #123
-  | | 
+  | |
   | | Build arbitrarily long chains
   | x-build-chain
-  | 
+  |
   | Call web service
   | 1st round of fixes
   | 2nd round of fixes
   o-call-ws  PR #124
-    | 
+    |
     | Drop unneeded SQL constraints
     x-drop-constraint

--- a/backend/impl/src/test/resources/setup-with-single-remote.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-with-single-remote.sh-discover.txt
@@ -1,25 +1,25 @@
   master
-  | 
+  |
   | HOTFIX Add the trigger
   | HOTFIX Add the trigger - fixes
   o-hotfix/add-trigger (diverged from & older than origin)
 
   develop
-  | 
+  |
   | Allow ownership links
   x-allow-ownership-link (behind origin)
-  | | 
+  | |
   | | 1st round of fixes -> fork point ??? commit 9d422de seems to be a part of the unique history of allow-ownership-link
   | | Use new icons
   | ?-update-icons (behind origin)
-  |   | 
+  |   |
   |   | Build arbitrarily long chains
   |   o-build-chain (untracked)
-  | 
+  |
   | Call web service
   | 1st round of fixes
   | 2nd round of fixes
   o-call-ws (ahead of origin)
-    | 
+    |
     | Drop unneeded SQL constraints
     x-drop-constraint (untracked)

--- a/backend/impl/src/test/resources/setup-with-single-remote.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-with-single-remote.sh-status.txt
@@ -1,24 +1,24 @@
   develop
-  | 
+  |
   | Allow ownership links
   x-allow-ownership-link  PR #123 (behind origin)
-  | | 
+  | |
   | | 1st round of fixes -> fork point ??? commit 9d422de seems to be a part of the unique history of allow-ownership-link
   | | Use new icons
   | ?-update-icons (behind origin)
-  | | 
+  | |
   | | 1st round of fixes
   | | Use new icons -> fork point ??? commit 89fd9a5 seems to be a part of the unique history of update-icons
   | | Build arbitrarily long chains
   | ?-build-chain (untracked)
-  | 
+  |
   | Call web service
   | 1st round of fixes
   | 2nd round of fixes
   o-call-ws  PR #124 (ahead of origin)
 
   master
-  | 
+  |
   | HOTFIX Add the trigger
   | HOTFIX Add the trigger - fixes
   o-hotfix/add-trigger (diverged from & older than origin)

--- a/backend/impl/src/test/resources/version.txt
+++ b/backend/impl/src/test/resources/version.txt
@@ -1,1 +1,1 @@
-git-machete version 3.9.0
+git-machete version 3.11.3

--- a/scripts/prohibit-trailing-whitespace
+++ b/scripts/prohibit-trailing-whitespace
@@ -5,6 +5,6 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/utils.sh
 
-if git grep -EIn '\s+$' -- ':!backend/impl/src/test/resources/*.txt'; then
+if git grep -EIn '\s+$'; then
   die 'The above lines contain trailing whitespace, please tidy up'
 fi


### PR DESCRIPTION
The CLI outputs slightly changed (no more trailing whitespace) after @amalota's PR https://github.com/VirtusLab/git-machete/pull/575 (released within v3.11.2)