### PR TITLE
Bump version-catalog-update Gradle plugin to v0.5.3 to fix the error in `versionCatalogUpdate` task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,8 +159,7 @@ docker run --rm -e UID=$(id -u) -e GID=$(id -g) \
 ## Update version catalog
 
 ```shell
-# TODO (#1011): `|| true` should not be needed
-(./gradlew versionCatalogUpdate || true; cd buildSrc; ../gradlew versionCatalogUpdate || true)
+(./gradlew versionCatalogUpdate; cd buildSrc; ../gradlew versionCatalogUpdate)
 ```
 
 See [version catalog in Gradle docs](https://docs.gradle.org/current/userguide/platforms.html)

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    // For nl.littlerobots.version-catalog-update
+    mavenCentral()
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,5 +61,5 @@ jetbrains-intellij = { id = "org.jetbrains.intellij", version.ref = "plugins-jet
 jetbrains-kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "plugins-jetbrains-kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "plugins-spotless" }
 taskTree = "com.dorongold.task-tree:2.1.0"
-versionCatalogUpdate = "nl.littlerobots.version-catalog-update:0.5.1"
+versionCatalogUpdate = "nl.littlerobots.version-catalog-update:0.5.3"
 versions = "com.github.ben-manes.versions:0.42.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,8 @@
 pluginManagement {
-  dependencyResolutionManagement {
-    repositories {
-      // For nl.littlerobots.version-catalog-update
-      mavenCentral()
-    }
+  repositories {
+    gradlePluginPortal()
+    // For nl.littlerobots.version-catalog-update
+    mavenCentral()
   }
 }
 


### PR DESCRIPTION
https://github.com/littlerobots/version-catalog-update-plugin/pull/62

![image](https://user-images.githubusercontent.com/3383210/181799005-88831486-bdaf-48c4-b636-14d487a695d3.png)
