### PR TITLE
Draft: add `probe.paths.logExport` config to have logs after tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,33 @@ jobs:
           name: Check Javadoc correctness
           command: ./gradlew --max-workers=4 javadoc
 
+      - when:
+          condition:
+            matches:
+              pattern: "^(.*ide(-)?probe.*)$"
+              value: << pipeline.git.branch >>
+          steps:
+            - run:
+                name: Install sbt
+                # language=sh
+                command: |
+                  apt update
+                  apt-get install apt-transport-https gnupg -yqq
+                  echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
+                  echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list
+                  curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import
+                  chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
+                  apt-get update
+                  apt-get install sbt
+            - run:
+                name: Publish ide-probe snapshots locally
+                # language=sh
+                command: |
+                  cd ..
+                  git clone https://github.com/LukaszKontowski/ide-probe.git -b fix/make_idea_logs_accessible_after_shutdown
+                  cd ide-probe/
+                  sbt api_2_13/publishM2 driver_2_13/publishM2 junit-driver_2_13/publishM2 robot-driver_2_13/publishM2 probe-plugin_2_13/publishM2
+
       - run:
           name: Compile tests
           command: ./gradlew compileTestJava compileUiTestScala
@@ -127,7 +154,7 @@ jobs:
             # once both binary compatibility checks and UI tests for latest versions passed is close to zero.
             # Hence, to speed up the builds, we only run them for develop/master/hotfix/release and not on PRs.
             matches:
-              pattern: "^(develop|hotfix/.+|master|release/.+|.*ui-test.*)$"
+              pattern: "^(develop|hotfix/.+|.*ide(-)?probe.*|master|release/.+|.*ui(-)?test.*)$"
               value: << pipeline.git.branch >>
           steps:
             - run:

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
@@ -14,6 +14,7 @@ fun Project.configureUiTests() {
 
   val sourceSets = extensions["sourceSets"] as SourceSetContainer
   val uiTest = sourceSets["uiTest"]
+  val uiTestsDir = "${System.getProperty("user.home")}/.ideprobe-uitests"
 
   val uiTestTargets: List<String> =
     if (project.properties["against"] != null) {
@@ -47,12 +48,14 @@ fun Project.configureUiTests() {
         environment("IDEPROBE_DISPLAY", "xvfb")
         environment(
           "IDEPROBE_PATHS_SCREENSHOTS",
-          "${System.getProperty("user.home")}/.ideprobe-uitests/artifacts/uiTest$version/screenshots"
+          "${uiTestsDir}/artifacts/uiTest$version/screenshots"
         )
         if (isCI) {
-          environment("IDEPROBE_PATHS_BASE", "${System.getProperty("user.home")}/.ideprobe-uitests/")
+          environment("IDEPROBE_PATHS_BASE", uiTestsDir)
         }
       }
+
+      environment("IDEPROBE_PATHS_LOG_EXPORT", "${uiTestsDir}/idea-logs")
 
       testLogging {
         events.addAll(listOf(TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR))

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
@@ -48,14 +48,14 @@ fun Project.configureUiTests() {
         environment("IDEPROBE_DISPLAY", "xvfb")
         environment(
           "IDEPROBE_PATHS_SCREENSHOTS",
-          "${uiTestsDir}/artifacts/uiTest$version/screenshots"
+          "$uiTestsDir/artifacts/uiTest$version/screenshots"
         )
         if (isCI) {
           environment("IDEPROBE_PATHS_BASE", uiTestsDir)
         }
       }
 
-      environment("IDEPROBE_PATHS_LOG_EXPORT", "${uiTestsDir}/idea-logs")
+      environment("IDEPROBE_PATHS_LOG_EXPORT", "$uiTestsDir/idea-logs")
 
       testLogging {
         events.addAll(listOf(TestLogEvent.STANDARD_OUT, TestLogEvent.STANDARD_ERROR))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # see https://docs.gradle.org/current/samples/sample_convention_plugins.html#things_to_note
 [versions]
 checker = "3.24.0"
-ideProbe = "0.42.0"
+ideProbe = "0.42.0+7-c55fa6a1-SNAPSHOT"
 powerMock = "2.0.9"
 
 [libraries]

--- a/src/uiTest/resources/ideprobe.conf
+++ b/src/uiTest/resources/ideprobe.conf
@@ -2,6 +2,7 @@ probe {
   paths {
     base = ${?IDEPROBE_PATHS_BASE}
     screenshots = ${?IDEPROBE_PATHS_SCREENSHOTS}
+    logExport = ${?IDEPROBE_PATHS_LOG_EXPORT}
   }
 
   driver {


### PR DESCRIPTION
Related to https://github.com/VirtusLab/ide-probe/issues/226
work in progess

To be updated and merged after `0.44.0` release of ide-probe - if the release will have https://github.com/VirtusLab/ide-probe/pull/266 changes included.