### PR TITLE
fixing the CI in #1142

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,8 +225,8 @@ jobs:
                 # Implicit usage of ${GITHUB_TOKEN} by hub
                 # language=sh
                 command: |
-                  corresponding_milestone_title=v$(extract_version_from_current_wd)
                   source scripts/utils.sh
+                  corresponding_milestone_title=v$(extract_version_from_current_wd)
                   tag=$corresponding_milestone_title
                   change_notes=$(./gradlew getChangelog --no-header -q)
                   hub release create \


### PR DESCRIPTION
it fixes https://github.com/VirtusLab/git-machete-intellij-plugin/issues/1142
putting `extract_version_from_current_wd` after sourcing utils.sh for it to be recognised.