### PR TITLE
Add a project property that enables to runIde with different IDE versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,8 @@ In case of spurious cache-related issues with Gradle build, try one of the follo
 To run an instance of IDE with Git Machete IntelliJ Plugin installed from the current source,
 execute `:runIde` Gradle task (`Gradle panel > Tasks > intellij > runIde` or `./gradlew runIde`).
 
-If you want to run an IDE instance of a different version than the automatically chosen one (see [IntelliJVersions](buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt))
+It's possible to use a different version of IDE than the automatically chosen one (see [IntelliJVersions](buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt))
+for building the plugin and running the IDE:
 use a project property `overrideBuildTarget` e.g. `./gradlew runIde -PoverrideBuildTarget=2022.1.4`.
 
 To watch the logs of this IntelliJ instance, run `tail -f build/idea-sandbox/system/log/idea.log`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,9 @@ In case of spurious cache-related issues with Gradle build, try one of the follo
 To run an instance of IDE with Git Machete IntelliJ Plugin installed from the current source,
 execute `:runIde` Gradle task (`Gradle panel > Tasks > intellij > runIde` or `./gradlew runIde`).
 
+If you want to run an IDE instance of a different version than the automatically chosen one (see [IntelliJVersions](buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt))
+use a project property `overrideBuildTarget` e.g. `./gradlew runIde -PoverrideBuildTarget=2022.1.4`.
+
 To watch the logs of this IntelliJ instance, run `tail -f build/idea-sandbox/system/log/idea.log`.
 
 ### Debug

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 
 project.extensions.add(
   "intellijVersions",
-  IntellijVersions(project.properties["overrideBuildTarget"] as String?, IntellijVersionHelper.getProperties())
+  IntellijVersions(IntellijVersionHelper.getProperties(), project.properties["overrideBuildTarget"] as String?)
 )
 
 apply<GradleVersionsFilterPlugin>()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,9 +24,7 @@ if (JavaVersion.current() != JavaVersion.VERSION_11 && JavaVersion.current() != 
   )
 }
 
-if (project.properties["overrideBuildTarget"] != null) {
-  IntellijVersions.overrideBuildTarget = project.properties["overrideBuildTarget"] as String?
-}
+IntellijVersions.overrideBuildTarget = project.properties["overrideBuildTarget"] as String?
 
 fun getFlagsForAddOpens(vararg packages: String, module: String): List<String> {
   return packages.toList().map { "--add-opens=$module/$it=ALL-UNNAMED" }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,10 @@ if (JavaVersion.current() != JavaVersion.VERSION_11 && JavaVersion.current() != 
   )
 }
 
+if (project.properties["overrideBuildTarget"] != null) {
+  IntellijVersions.overrideBuildTarget = project.properties["overrideBuildTarget"] as String?
+}
+
 fun getFlagsForAddOpens(vararg packages: String, module: String): List<String> {
   return packages.toList().map { "--add-opens=$module/$it=ALL-UNNAMED" }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
   scala
 }
 
+project.extensions.add("intellijVersions", IntellijVersions(project.properties["overrideBuildTarget"] as String?))
+
 apply<GradleVersionsFilterPlugin>()
 apply<VersionCatalogUpdatePlugin>()
 apply<TaskTreePlugin>()
@@ -23,8 +25,6 @@ if (JavaVersion.current() != JavaVersion.VERSION_11 && JavaVersion.current() != 
     2. codebase is Java 11-compatible, so can't be built on JDK 8"""
   )
 }
-
-IntellijVersions.overrideBuildTarget = project.properties["overrideBuildTarget"] as String?
 
 fun getFlagsForAddOpens(vararg packages: String, module: String): List<String> {
   return packages.toList().map { "--add-opens=$module/$it=ALL-UNNAMED" }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,10 @@ plugins {
   scala
 }
 
-project.extensions.add("intellijVersions", IntellijVersions(project.properties["overrideBuildTarget"] as String?))
+project.extensions.add(
+  "intellijVersions",
+  IntellijVersions(project.properties["overrideBuildTarget"] as String?, IntellijVersionHelper.getProperties())
+)
 
 apply<GradleVersionsFilterPlugin>()
 apply<VersionCatalogUpdatePlugin>()

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
@@ -66,7 +66,7 @@ fun Project.addIntellijToCompileClasspath(withGit4Idea: Boolean) {
   }
 
   configure<IntelliJPluginExtension> {
-    version.set(IntellijVersions.getBuildTarget())
+    version.set(rootProject.extensions.getByType<IntellijVersions>().buildTarget)
     // No need to instrument Java classes with nullability assertions, we've got this covered much
     // better by Checker (and we don't plan to expose any part of the plugin as an API for other plugins).
     instrumentCode.set(false)

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
@@ -66,7 +66,7 @@ fun Project.addIntellijToCompileClasspath(withGit4Idea: Boolean) {
   }
 
   configure<IntelliJPluginExtension> {
-    version.set(IntellijVersions.buildTarget)
+    version.set(IntellijVersions.getBuildTarget())
     // No need to instrument Java classes with nullability assertions, we've got this covered much
     // better by Checker (and we don't plan to expose any part of the plugin as an API for other plugins).
     instrumentCode.set(false)

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijPlugin.kt
@@ -18,11 +18,12 @@ fun Project.configureIntellijPlugin() {
   val pluginSignPrivateKey: String? by rootProject.extra
   val pluginSignCertificateChain: String? by rootProject.extra
   val pluginSignPrivateKeyPass: String? by rootProject.extra
+  val intellijVersions = rootProject.extensions.getByType<IntellijVersions>()
 
   configure<IntelliJPluginExtension> {
     instrumentCode.set(false)
     pluginName.set("git-machete-intellij-plugin")
-    version.set(IntellijVersions.getBuildTarget())
+    version.set(intellijVersions.buildTarget)
     plugins.set(listOf("git4idea")) // Needed solely for ArchUnit
   }
 
@@ -48,12 +49,12 @@ fun Project.configureIntellijPlugin() {
   tasks.withType<PatchPluginXmlTask> {
     // `sinceBuild` is exclusive when we are using `*` in version but inclusive when without `*`
     sinceBuild.set(
-      IntellijVersionHelper.toBuildNumber(IntellijVersions.earliestSupportedMajor)
+      IntellijVersionHelper.toBuildNumber(intellijVersions.earliestSupportedMajor)
     )
 
     // In `untilBuild` situation is inverted: it's inclusive when using `*` but exclusive when without `*`
     untilBuild.set(
-      IntellijVersionHelper.toBuildNumber(IntellijVersions.latestSupportedMajor) + ".*"
+      IntellijVersionHelper.toBuildNumber(intellijVersions.latestSupportedMajor) + ".*"
     )
 
     // Note that the first line of the description should be self-contained since it is placed into embeddable card:
@@ -71,12 +72,12 @@ fun Project.configureIntellijPlugin() {
 
   tasks.withType<RunPluginVerifierTask> {
     val maybeEap = listOfNotNull(
-      IntellijVersions.eapOfLatestSupportedMajor?.replace("-EAP-(CANDIDATE-)?SNAPSHOT".toRegex(), "")
+      intellijVersions.eapOfLatestSupportedMajor?.replace("-EAP-(CANDIDATE-)?SNAPSHOT".toRegex(), "")
     )
 
     ideVersions.set(
-      IntellijVersions.latestMinorsOfOldSupportedMajors +
-        IntellijVersions.latestStable +
+      intellijVersions.latestMinorsOfOldSupportedMajors +
+        intellijVersions.latestStable +
         maybeEap
     )
 

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijPlugin.kt
@@ -22,7 +22,7 @@ fun Project.configureIntellijPlugin() {
   configure<IntelliJPluginExtension> {
     instrumentCode.set(false)
     pluginName.set("git-machete-intellij-plugin")
-    version.set(IntellijVersions.buildTarget)
+    version.set(IntellijVersions.getBuildTarget())
     plugins.set(listOf("git4idea")) // Needed solely for ArchUnit
   }
 

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionHelper.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionHelper.kt
@@ -2,32 +2,8 @@ package com.virtuslab.gitmachete.buildsrc
 
 import java.io.File
 import java.util.*
-import kotlin.reflect.full.memberProperties
 
 object IntellijVersionHelper {
-  /**
-   * @param versionKey Either release number (like 2020.3) or key of intellijVersions (like
-   * eapOfLatestSupportedMajor)
-   * @returns Corresponding release numbers.
-   */
-  fun resolveIntelliJVersions(versionKey: String?, intellijVersions: IntellijVersions): List<String> {
-    if (versionKey == null) {
-      return emptyList()
-    }
-    val regex = "^[0-9].*$".toRegex()
-    if (regex.matches(versionKey)) {
-      return listOf(versionKey)
-    }
-
-    val propertiesList = listOfNotNull(
-      IntellijVersions::class.memberProperties
-        .single { it.name == versionKey }
-        .get(intellijVersions)
-    )
-
-    return propertiesList.flatMap { if (it is List<*>) it else listOf(it) }.map { it as String }
-  }
-
   fun getFromBuildNumber(buildNumber: String): String {
     return "20${buildNumber.substring(0, 2)}.${buildNumber.substring(2, 3)}"
   }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionHelper.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionHelper.kt
@@ -10,7 +10,7 @@ object IntellijVersionHelper {
    * eapOfLatestSupportedMajor)
    * @returns Corresponding release numbers.
    */
-  fun resolveIntelliJVersions(versionKey: String?): List<String> {
+  fun resolveIntelliJVersions(versionKey: String?, intellijVersions: IntellijVersions): List<String> {
     if (versionKey == null) {
       return emptyList()
     }
@@ -22,7 +22,7 @@ object IntellijVersionHelper {
     val propertiesList = listOfNotNull(
       IntellijVersions::class.memberProperties
         .single { it.name == versionKey }
-        .get(IntellijVersions::class.objectInstance!!)
+        .get(intellijVersions)
     )
 
     return propertiesList.flatMap { if (it is List<*>) it else listOf(it) }.map { it as String }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -1,9 +1,11 @@
 package com.virtuslab.gitmachete.buildsrc
 
 import com.virtuslab.gitmachete.buildsrc.IntellijVersionHelper.getPropertyOrNullIfEmpty
+import org.gradle.api.reflect.HasPublicType
+import org.gradle.api.reflect.TypeOf
 
 // See https://www.jetbrains.com/intellij-repository/releases/ -> Ctrl+F .idea
-object IntellijVersions {
+public class IntellijVersions(overrideBuildTarget: String?) : HasPublicType {
 
   private val intellijVersionsProp = IntellijVersionHelper.getProperties()
 
@@ -39,13 +41,11 @@ object IntellijVersions {
     IntellijVersionHelper.getMajorPart(latestStable)
   }
 
-  private val buildTarget: String = eapOfLatestSupportedMajor ?: latestStable
-
-  // This getter allows to change the target IntelliJ version
+  // This allows to change the target IntelliJ version
   // by using a project property 'overrideBuildTarget' while running tasks like runIde
-  public fun getBuildTarget(): String {
-    return overrideBuildTarget ?: buildTarget
-  }
+  val buildTarget: String = overrideBuildTarget ?: eapOfLatestSupportedMajor ?: latestStable
 
-  var overrideBuildTarget: String? = null
+  override fun getPublicType(): TypeOf<*> {
+    return TypeOf.typeOf((this::class.java))
+  }
 }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -39,5 +39,11 @@ object IntellijVersions {
     IntellijVersionHelper.getMajorPart(latestStable)
   }
 
-  val buildTarget: String = eapOfLatestSupportedMajor ?: latestStable
+  private val buildTarget: String = eapOfLatestSupportedMajor ?: latestStable
+
+  public fun getBuildTarget(): String {
+    return overrideBuildTarget ?: buildTarget
+  }
+
+  var overrideBuildTarget: String? = null
 }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -41,6 +41,8 @@ object IntellijVersions {
 
   private val buildTarget: String = eapOfLatestSupportedMajor ?: latestStable
 
+  // This getter allows to change the target IntelliJ version
+  // by using a project property 'overrideBuildTarget' while running tasks like runIde
   public fun getBuildTarget(): String {
     return overrideBuildTarget ?: buildTarget
   }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -1,12 +1,10 @@
 package com.virtuslab.gitmachete.buildsrc
 
 import com.virtuslab.gitmachete.buildsrc.IntellijVersionHelper.getPropertyOrNullIfEmpty
-import org.gradle.api.reflect.HasPublicType
-import org.gradle.api.reflect.TypeOf
 import java.util.Properties
 
 // See https://www.jetbrains.com/intellij-repository/releases/ -> Ctrl+F .idea
-public class IntellijVersions(overrideBuildTarget: String?, intellijVersionsProperties: Properties) : HasPublicType {
+public class IntellijVersions(overrideBuildTarget: String?, intellijVersionsProperties: Properties) {
   // When this value is updated, remember to update:
   // 1. the minimum required IDEA version in README.md,
   // 2. version of Gradle Kotlin plugin in gradle/libs.versions.toml
@@ -42,8 +40,4 @@ public class IntellijVersions(overrideBuildTarget: String?, intellijVersionsProp
   // This allows to change the target IntelliJ version
   // by using a project property 'overrideBuildTarget' while running tasks like runIde
   val buildTarget: String = overrideBuildTarget ?: eapOfLatestSupportedMajor ?: latestStable
-
-  override fun getPublicType(): TypeOf<*> {
-    return TypeOf.typeOf((this::class.java))
-  }
 }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -3,12 +3,10 @@ package com.virtuslab.gitmachete.buildsrc
 import com.virtuslab.gitmachete.buildsrc.IntellijVersionHelper.getPropertyOrNullIfEmpty
 import org.gradle.api.reflect.HasPublicType
 import org.gradle.api.reflect.TypeOf
+import java.util.Properties
 
 // See https://www.jetbrains.com/intellij-repository/releases/ -> Ctrl+F .idea
-public class IntellijVersions(overrideBuildTarget: String?) : HasPublicType {
-
-  private val intellijVersionsProp = IntellijVersionHelper.getProperties()
-
+public class IntellijVersions(overrideBuildTarget: String?, intellijVersionsProperties: Properties) : HasPublicType {
   // When this value is updated, remember to update:
   // 1. the minimum required IDEA version in README.md,
   // 2. version of Gradle Kotlin plugin in gradle/libs.versions.toml
@@ -18,13 +16,13 @@ public class IntellijVersions(overrideBuildTarget: String?) : HasPublicType {
   // since most likely some plugin version will still be downloadable (however not the latest).
   // Marking a release version as hidden is a way to forbid its download
   // (see https://plugins.jetbrains.com/plugin/14221-git-machete/versions).
-  val earliestSupportedMajor: String = intellijVersionsProp.getProperty("earliestSupportedMajor")
+  val earliestSupportedMajor: String = intellijVersionsProperties.getProperty("earliestSupportedMajor")
 
   // Most recent minor versions of all major releases between earliest supported (incl.)
   // and latest stable (excl.), used for binary compatibility checks and UI tests
-  val latestMinorsOfOldSupportedMajors: List<String> = intellijVersionsProp.getProperty("latestMinorsOfOldSupportedMajors").split(",")
+  val latestMinorsOfOldSupportedMajors: List<String> = intellijVersionsProperties.getProperty("latestMinorsOfOldSupportedMajors").split(",")
 
-  val latestStable: String = intellijVersionsProp.getProperty("latestStable")
+  val latestStable: String = intellijVersionsProperties.getProperty("latestStable")
 
   // Note that we have to use a "fixed snapshot" version X.Y.Z-EAP-SNAPSHOT (e.g. 211.4961.33-EAP-SNAPSHOT)
   // rather than a "rolling snapshot" X-EAP-SNAPSHOT (e.g. 211-EAP-SNAPSHOT)
@@ -33,7 +31,7 @@ public class IntellijVersions(overrideBuildTarget: String?) : HasPublicType {
   // but for some reason aren't resolved in UI tests.
   // Generally, see https://www.jetbrains.com/intellij-repository/snapshots/ -> Ctrl+F .idea
   // Use `null` if the latest supported major has a stable release (and not just EAPs).
-  val eapOfLatestSupportedMajor: String? = intellijVersionsProp.getPropertyOrNullIfEmpty("eapOfLatestSupportedMajor")
+  val eapOfLatestSupportedMajor: String? = intellijVersionsProperties.getPropertyOrNullIfEmpty("eapOfLatestSupportedMajor")
 
   val latestSupportedMajor: String = if (eapOfLatestSupportedMajor != null) {
     IntellijVersionHelper.getFromBuildNumber(eapOfLatestSupportedMajor)

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
@@ -12,6 +12,7 @@ import org.gradle.kotlin.dsl.register
 
 fun Project.configureUiTests() {
   val isCI: Boolean by rootProject.extra
+  val intellijVersions = rootProject.extensions.getByType<IntellijVersions>()
 
   val sourceSets = extensions["sourceSets"] as SourceSetContainer
   val uiTest = sourceSets["uiTest"]
@@ -19,9 +20,9 @@ fun Project.configureUiTests() {
 
   val uiTestTargets: List<String> =
     if (project.properties["against"] != null) {
-      IntellijVersionHelper.resolveIntelliJVersions(project.properties["against"] as String)
+      IntellijVersionHelper.resolveIntelliJVersions(project.properties["against"] as String, intellijVersions)
     } else {
-      listOf(rootProject.extensions.getByType<IntellijVersions>().buildTarget)
+      listOf(intellijVersions.buildTarget)
     }
 
   uiTestTargets.onEach { version ->

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
@@ -20,7 +20,7 @@ fun Project.configureUiTests() {
     if (project.properties["against"] != null) {
       IntellijVersionHelper.resolveIntelliJVersions(project.properties["against"] as String)
     } else {
-      listOf(IntellijVersions.buildTarget)
+      listOf(IntellijVersions.getBuildTarget())
     }
 
   uiTestTargets.onEach { version ->

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.register
 
@@ -20,7 +21,7 @@ fun Project.configureUiTests() {
     if (project.properties["against"] != null) {
       IntellijVersionHelper.resolveIntelliJVersions(project.properties["against"] as String)
     } else {
-      listOf(IntellijVersions.getBuildTarget())
+      listOf(rootProject.extensions.getByType<IntellijVersions>().buildTarget)
     }
 
   uiTestTargets.onEach { version ->

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UiTests.kt
@@ -20,7 +20,7 @@ fun Project.configureUiTests() {
 
   val uiTestTargets: List<String> =
     if (project.properties["against"] != null) {
-      IntellijVersionHelper.resolveIntelliJVersions(project.properties["against"] as String, intellijVersions)
+      intellijVersions.resolveIntelliJVersions(project.properties["against"] as String)
     } else {
       listOf(intellijVersions.buildTarget)
     }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UpdateIntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UpdateIntellijVersions.kt
@@ -6,6 +6,8 @@ import com.virtuslab.gitmachete.buildsrc.IntellijVersionHelper.toBuildNumber
 import com.virtuslab.gitmachete.buildsrc.IntellijVersionHelper.versionIsNewerThan
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.getByType
 import org.jsoup.Jsoup
 
 open class UpdateIntellijVersions : DefaultTask() {
@@ -67,10 +69,11 @@ open class UpdateIntellijVersions : DefaultTask() {
 
   @TaskAction
   fun execute() {
+    val intellijVersions = project.rootProject.extensions.getByType<IntellijVersions>()
     val properties = IntellijVersionHelper.getProperties()
     val originalProperties = IntellijVersionHelper.getProperties()
-    val latestStable = IntellijVersions.latestStable
-    val latestMinorsList = IntellijVersions.latestMinorsOfOldSupportedMajors
+    val latestStable = intellijVersions.latestStable
+    val latestMinorsList = intellijVersions.latestMinorsOfOldSupportedMajors
       .map { findLatestMinorOfVersion(it) }
 
     properties.setProperty("latestMinorsOfOldSupportedMajors", latestMinorsList.joinToString(separator = ","))


### PR DESCRIPTION
This took much longer than expected, as gradle has does some unexpected caching of IntellijVersions class when code does not change but only different things between exceuting `runIde` is the projectProperty. That's why right now the property is always being set even when it is null.