### PR TITLE
Move to previous next parent

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -5,6 +5,7 @@
 ## v3.1.0
 - Added support for IntelliJ 2022.3.
 - Fixed spurious `NullPointerException` thrown when opening Machete file, as reported by @oksana-cherniavskaia.
+- Added branch navigation allowing to checking out the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` in the machete layout.
 
 ## v3.0.3
 - Enabled Ctrl + left-click to work as a right-click for macOS users, for displaying the machete actions on a branch.

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -5,7 +5,12 @@
 ## v3.1.0
 - Added support for IntelliJ 2022.3.
 - Fixed spurious `NullPointerException` thrown when opening Machete file, as reported by @oksana-cherniavskaia.
-- Added branch navigation allowing to check out the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` when Git Machete tab is opened, and has focus. Note that `option` key is an `alt` key counterpart in macOS.
+- Added branch navigation allowing to check out:
+  * previous branch with `alt + up-arrow`,
+  * next branch with `alt + down-arrow`,
+  * parent branch with `alt + left-arrow`,
+  * first child branch `alt + right-arrow`
+  when Git Machete tab is opened, and has focus. Note that `option` key is an `alt` key counterpart in macOS.
 
 ## v3.0.3
 - Enabled Ctrl + left-click to work as a right-click for macOS users, for displaying the machete actions on a branch.

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -5,7 +5,7 @@
 ## v3.1.0
 - Added support for IntelliJ 2022.3.
 - Fixed spurious `NullPointerException` thrown when opening Machete file, as reported by @oksana-cherniavskaia.
-- Added branch navigation allowing to checking out the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` in the machete layout.
+- Added branch navigation allowing to check out the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` when Git Machete tab is opened, and has focus.
 
 ## v3.0.3
 - Enabled Ctrl + left-click to work as a right-click for macOS users, for displaying the machete actions on a branch.

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -4,13 +4,15 @@
 
 ## v3.1.0
 - Added support for IntelliJ 2022.3.
-- Fixed spurious `NullPointerException` thrown when opening Machete file, as reported by @oksana-cherniavskaia.
+- Fixed spurious `NullPointerException` thrown when opening machete file via toolbar, as reported by @oksana-cherniavskaia.
 - Added branch navigation allowing to check out:
   * previous branch with `alt + up-arrow`,
   * next branch with `alt + down-arrow`,
   * parent branch with `alt + left-arrow`,
-  * first child branch `alt + right-arrow`
-  when Git Machete tab is opened, and has focus. Note that `option` key is an `alt` key counterpart in macOS.
+  * first child branch with `alt + right-arrow`
+  when Git Machete tab is opened, and has focus.
+
+  Note that `option` key is the equivalent of `alt` in macOS.
 
 ## v3.0.3
 - Enabled Ctrl + left-click to work as a right-click for macOS users, for displaying the machete actions on a branch.

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -5,7 +5,7 @@
 ## v3.1.0
 - Added support for IntelliJ 2022.3.
 - Fixed spurious `NullPointerException` thrown when opening Machete file, as reported by @oksana-cherniavskaia.
-- Added branch navigation allowing to check out the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` when Git Machete tab is opened, and has focus.
+- Added branch navigation allowing to check out the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` when Git Machete tab is opened, and has focus. You would need to use the `option` key instead of `alt` in MacOS.
 
 ## v3.0.3
 - Enabled Ctrl + left-click to work as a right-click for macOS users, for displaying the machete actions on a branch.

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -5,7 +5,7 @@
 ## v3.1.0
 - Added support for IntelliJ 2022.3.
 - Fixed spurious `NullPointerException` thrown when opening Machete file, as reported by @oksana-cherniavskaia.
-- Added branch navigation allowing to check out the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` when Git Machete tab is opened, and has focus. You would need to use the `option` key instead of `alt` in MacOS.
+- Added branch navigation allowing to check out the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` when Git Machete tab is opened, and has focus. Note that `option` key is an `alt` key counterpart in macOS.
 
 ## v3.0.3
 - Enabled Ctrl + left-click to work as a right-click for macOS users, for displaying the machete actions on a branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,7 @@ Other coding conventions include:
 * Properties in `GitMacheteBundle.properties` that use HTML should be wrapped in tags `<html>` ... `</html>`.
   Additionally, their keys should have a `.HTML` suffix.
 * `@Tainted` and `@Untainted` annotations are used in the context of method parameters that may or may not use HTML. Those annotated with `@Untainted` should not contain HTML tags, whereas values annotated with
-  `@Tainted` can contain HTML (but they don't have to).
+  `@Tainted` can contain HTML (but they don't have to). Please note that you need to use `org.checkerframework.checker.tainting.qual.Tainted` or `org.checkerframework.checker.tainting.qual.Untainted` annotations, rather than the `javax.annotation` ones.
 * Avoid `Branch` word in action class names and action ids to keep them shorter.
   Some exceptions are allowed (e.g. the backgroundable task classes).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,12 +113,13 @@ Local (non-CI) builds by default skip most of [Checker Framework's](https://chec
 To make local builds more aligned with CI builds (at the expense of ~2x longer compilation from scratch),
 set `runAllCheckers` Gradle project property (e.g. `./gradlew -PrunAllCheckers build`).
 
-In case of spurious cache-related issues with Gradle build, try one of the following:
-* `./gradlew --stop` to shut down gradle daemon
+In case of spurious cache-related issues with Gradle build, try the following remedies (in the order from the least intrusive to the most):
+* `./gradlew --stop` to shut down Gradle daemon
+* `pkill -e -9 -f '.*Gradle.*'` to kill all Gradle processes
 * `./gradlew clean` and re-run the failing `./gradlew` command with `--no-build-cache`
 * remove .gradle/ directory in the project directory
 * remove ~/.gradle/caches/ (or even the entire ~/.gradle/) directory
-* reinstall gradle AND remove the entire ~/.gradle/ directory
+* reinstall Gradle AND remove the entire ~/.gradle/ directory
 
 
 ## Run

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -36,8 +36,7 @@ data class IntellijVersions(
       // Note that we have to use a "fixed snapshot" version X.Y.Z-EAP-SNAPSHOT (e.g. 211.4961.33-EAP-SNAPSHOT)
       // rather than a "rolling snapshot" X-EAP-SNAPSHOT (e.g. 211-EAP-SNAPSHOT)
       // to ensure that the builds are reproducible.
-      // EAP-CANDIDATE-SNAPSHOTs can be used for binary compatibility checks,
-      // but for some reason aren't resolved in UI tests.
+      // EAP-CANDIDATE-SNAPSHOTs apparently canNOT be used for either binary compatibility checks or UI tests.
       // Generally, see https://www.jetbrains.com/intellij-repository/snapshots/ -> Ctrl+F .idea
       // Use `null` if the latest supported major has a stable release (and not just EAPs).
       val eapOfLatestSupportedMajor: String? = intellijVersionsProperties.getPropertyOrNullIfEmpty("eapOfLatestSupportedMajor")

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,8 +34,14 @@ The current branch is underlined in a branch layout.
 
 ![](checkout.gif)
 
-On the Git Machete tab, you can checkout the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` in the machete layout.
+If Git Machete tab is opened & focused, branch navigation with keyboard shortcuts is available.
+Check out:
+* previous branch with `alt + up-arrow`,
+* next branch with `alt + down-arrow`,
+* parent branch with `alt + left-arrow`,
+* first child branch with `alt + right-arrow`.
 
+Note that `option` key is the equivalent of `alt` in macOS.
 
 ## Toggle listing commits
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,6 +34,8 @@ The current branch is underlined in a branch layout.
 
 ![](checkout.gif)
 
+On the Git Machete tab, you can checkout the next branch with `alt + down-arrow` or `alt + right-arrow`, previous branch with `alt + up-arrow`, and parent branch with `alt + left-arrow` in the machete layout.
+
 
 ## Toggle listing commits
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseCheckoutAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseCheckoutAction.java
@@ -1,0 +1,110 @@
+package com.virtuslab.gitmachete.frontend.actions.base;
+
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
+
+import java.util.Collections;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import git4idea.branch.GitBranchUiHandlerImpl;
+import git4idea.branch.GitBranchWorker;
+import git4idea.commands.Git;
+import git4idea.repo.GitRepository;
+import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
+import lombok.CustomLog;
+import lombok.experimental.ExtensionMethod;
+import lombok.val;
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
+import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+
+@ExtensionMethod({GitVfsUtils.class, GitMacheteBundle.class})
+@CustomLog
+public abstract class BaseCheckoutAction extends BaseGitMacheteRepositoryReadyAction
+    implements
+      IExpectsKeySelectedBranchName {
+
+  @Override
+  public LambdaLogger log() {
+    return LOG;
+  }
+
+  protected abstract @Nullable String getTargetBranchName(AnActionEvent anActionEvent);
+
+  protected abstract @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent);
+
+  @Override
+  @UIEffect
+  protected void onUpdate(AnActionEvent anActionEvent) {
+    super.onUpdate(anActionEvent);
+
+    val presentation = anActionEvent.getPresentation();
+    if (!presentation.isEnabledAndVisible()) {
+      return;
+    }
+
+    val targetBranchName = getTargetBranchName(anActionEvent);
+
+    // It's very unlikely that targetBranchName is empty at this point since it's assigned directly before invoking this
+    // action in EnhancedGraphTable.EnhancedGraphTableMouseAdapter#mouseClicked; still, it's better to be safe.
+    if (targetBranchName == null || targetBranchName.isEmpty()) {
+      presentation.setEnabled(false);
+      presentation.setDescription(getNonExistentBranchMessage(anActionEvent));
+      return;
+    }
+
+    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+
+    if (currentBranchName != null && currentBranchName.equals(targetBranchName)) {
+      presentation.setEnabled(false);
+      presentation.setDescription(
+          getNonHtmlString("action.GitMachete.BaseCheckoutAction.description.disabled.currently-checked-out")
+              .format(targetBranchName));
+
+    } else {
+      presentation.setDescription(
+          getNonHtmlString("action.GitMachete.BaseCheckoutAction.description.precise")
+              .format(targetBranchName));
+    }
+  }
+
+  @Override
+  @UIEffect
+  public void actionPerformed(AnActionEvent anActionEvent) {
+    val targetBranchName = getTargetBranchName(anActionEvent);
+    if (targetBranchName == null || targetBranchName.isEmpty()) {
+      return;
+    }
+
+    val project = getProject(anActionEvent);
+    val gitRepository = getSelectedGitRepository(anActionEvent);
+
+    if (gitRepository != null) {
+
+      log().debug(() -> "Queuing '${targetBranchName}' branch checkout background task");
+      new Task.Backgroundable(project, getString("action.GitMachete.BaseCheckoutAction.task-title")) {
+        @Override
+        @UIThreadUnsafe
+        public void run(ProgressIndicator indicator) {
+          doCheckout(project, indicator, targetBranchName, gitRepository);
+        }
+      }.queue();
+    }
+  }
+
+  @UIThreadUnsafe
+  public static void doCheckout(Project project, ProgressIndicator indicator, String branchToCheckoutName,
+      GitRepository gitRepository) {
+    val uiHandler = new GitBranchUiHandlerImpl(project, indicator);
+    new GitBranchWorker(project, Git.getInstance(), uiHandler)
+        .checkout(branchToCheckoutName, /* detach */ false, Collections.singletonList(gitRepository));
+  }
+}

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedAction.java
@@ -1,33 +1,22 @@
 package com.virtuslab.gitmachete.frontend.actions.contextmenu;
 
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-
-import java.util.Collections;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.progress.Task;
-import com.intellij.openapi.project.Project;
-import git4idea.branch.GitBranchUiHandlerImpl;
-import git4idea.branch.GitBranchWorker;
-import git4idea.commands.Git;
-import git4idea.repo.GitRepository;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
-import lombok.NonNull;
 import lombok.experimental.ExtensionMethod;
-import lombok.val;
-import org.checkerframework.checker.guieffect.qual.UIEffect;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.tainting.qual.Untainted;
 
-import com.virtuslab.gitmachete.frontend.actions.base.BaseGitMacheteRepositoryReadyAction;
+import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
-import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 
-@ExtensionMethod(GitMacheteBundle.class)
+@ExtensionMethod({GitVfsUtils.class, GitMacheteBundle.class})
 @CustomLog
-public class CheckoutSelectedAction extends BaseGitMacheteRepositoryReadyAction
+public class CheckoutSelectedAction extends BaseCheckoutAction
     implements
       IExpectsKeySelectedBranchName {
 
@@ -37,68 +26,12 @@ public class CheckoutSelectedAction extends BaseGitMacheteRepositoryReadyAction
   }
 
   @Override
-  @UIEffect
-  protected void onUpdate(AnActionEvent anActionEvent) {
-    super.onUpdate(anActionEvent);
-
-    val presentation = anActionEvent.getPresentation();
-    if (!presentation.isEnabledAndVisible()) {
-      return;
-    }
-
-    val selectedBranchName = getSelectedBranchName(anActionEvent);
-    // It's very unlikely that selectedBranchName is empty at this point since it's assigned directly before invoking this
-    // action in GitMacheteGraphTable.GitMacheteGraphTableMouseAdapter.mouseClicked; still, it's better to be safe.
-    if (selectedBranchName == null || selectedBranchName.isEmpty()) {
-      presentation.setEnabled(false);
-      presentation.setDescription(getNonHtmlString("action.GitMachete.CheckoutSelectedAction.undefined.branch-name"));
-      return;
-    }
-
-    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
-
-    if (currentBranchName != null && currentBranchName.equals(selectedBranchName)) {
-      presentation.setEnabled(false);
-      presentation.setDescription(
-          getNonHtmlString("action.GitMachete.CheckoutSelectedAction.description.disabled.currently-checked-out")
-              .format(selectedBranchName));
-
-    } else {
-      presentation.setDescription(
-          getNonHtmlString("action.GitMachete.CheckoutSelectedAction.description.precise")
-              .format(selectedBranchName));
-    }
+  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+    return getSelectedBranchName(anActionEvent);
   }
 
   @Override
-  @UIEffect
-  public void actionPerformed(AnActionEvent anActionEvent) {
-    val selectedBranchName = getSelectedBranchName(anActionEvent);
-    if (selectedBranchName == null || selectedBranchName.isEmpty()) {
-      return;
-    }
-
-    val project = getProject(anActionEvent);
-    val gitRepository = getSelectedGitRepository(anActionEvent);
-
-    if (gitRepository != null) {
-      log().debug(() -> "Queuing '${selectedBranchName}' branch checkout background task");
-      new Task.Backgroundable(project, getString("action.GitMachete.CheckoutSelectedAction.task-title")) {
-        @Override
-        @UIThreadUnsafe
-        public void run(ProgressIndicator indicator) {
-          doCheckout(project, indicator, selectedBranchName, gitRepository);
-        }
-        // TODO (#95): on success, refresh only indication of the current branch
-      }.queue();
-    }
-  }
-
-  @UIThreadUnsafe
-  public static void doCheckout(Project project, @NonNull ProgressIndicator indicator, String branchToCheckoutName,
-      GitRepository gitRepository) {
-    val uiHandler = new GitBranchUiHandlerImpl(project, indicator);
-    new GitBranchWorker(project, Git.getInstance(), uiHandler)
-        .checkout(branchToCheckoutName, /* detach */ false, Collections.singletonList(gitRepository));
+  protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
+    return getNonHtmlString("action.GitMachete.CheckoutSelectedAction.undefined.branch-name");
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutFirstChildAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutFirstChildAction.java
@@ -13,7 +13,7 @@ import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelecte
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
 @ExtensionMethod(GitMacheteBundle.class)
-public class CheckoutParentAction extends BaseCheckoutAction
+public class CheckoutFirstChildAction extends BaseCheckoutAction
     implements
       IExpectsKeySelectedBranchName {
 
@@ -21,7 +21,7 @@ public class CheckoutParentAction extends BaseCheckoutAction
   protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
     val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
     return currentBranchName != null
-        ? getNonHtmlString("action.GitMachete.CheckoutParentAction.undefined.branch-name").format(currentBranchName)
+        ? getNonHtmlString("action.GitMachete.CheckoutFirstChildAction.undefined.branch-name").format(currentBranchName)
         : getNonHtmlString("action.GitMachete.BaseCheckoutAction.undefined.current-branch");
   }
 
@@ -29,9 +29,12 @@ public class CheckoutParentAction extends BaseCheckoutAction
   protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
     val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
     val currentBranch = getManagedBranchByName(anActionEvent, currentBranchName);
-    if (currentBranch != null && currentBranch.isNonRoot()) {
-      val nonRootBranch = currentBranch.asNonRoot();
-      return nonRootBranch.getParent().getName();
+    if (currentBranch != null) {
+      val childBranches = currentBranch.getChildren();
+      if (childBranches.nonEmpty()) {
+        val targetBranch = childBranches.get(0);
+        return targetBranch.getName();
+      }
     }
     return null;
   }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutNextAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutNextAction.java
@@ -1,0 +1,38 @@
+package com.virtuslab.gitmachete.frontend.actions.navigation;
+
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import lombok.experimental.ExtensionMethod;
+import lombok.val;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
+import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
+
+@ExtensionMethod(GitMacheteBundle.class)
+public class CheckoutNextAction extends BaseCheckoutAction
+    implements
+      IExpectsKeySelectedBranchName {
+
+  @Override
+  protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
+    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    return currentBranchName != null
+        ? getNonHtmlString("action.GitMachete.CheckoutNextAction.undefined.branch-name").format(currentBranchName)
+        : getNonHtmlString("action.GitMachete.BaseCheckoutAction.undefined.current-branch");
+  }
+
+  @Override
+  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    val branchLayout = getBranchLayout(anActionEvent);
+    if (branchLayout != null && currentBranchName != null) {
+      val nextEntry = branchLayout.findNextEntry(currentBranchName);
+      return nextEntry != null ? nextEntry.getName() : null;
+    }
+    return null;
+  }
+}

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutParentAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutParentAction.java
@@ -1,0 +1,39 @@
+package com.virtuslab.gitmachete.frontend.actions.navigation;
+
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import lombok.experimental.ExtensionMethod;
+import lombok.val;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
+import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
+
+@ExtensionMethod(GitMacheteBundle.class)
+public class CheckoutParentAction extends BaseCheckoutAction
+    implements
+      IExpectsKeySelectedBranchName {
+
+  @Override
+  protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
+    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    return currentBranchName != null
+        ? getNonHtmlString("action.GitMachete.CheckoutParentAction.undefined.branch-name").format(currentBranchName)
+        : getNonHtmlString("action.GitMachete.BaseCheckoutAction.undefined.current-branch");
+  }
+
+  @Override
+  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+    val gitRepository = getSelectedGitRepository(anActionEvent);
+    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    val currentBranch = getManagedBranchByName(anActionEvent, currentBranchName);
+    if (currentBranch != null && currentBranch.isNonRoot()) {
+      val nonRootBranch = currentBranch.asNonRoot();
+      return nonRootBranch.getParent().getName();
+    }
+    return null;
+  }
+}

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutPreviousAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutPreviousAction.java
@@ -1,0 +1,39 @@
+package com.virtuslab.gitmachete.frontend.actions.navigation;
+
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import lombok.experimental.ExtensionMethod;
+import lombok.val;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
+import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
+
+@ExtensionMethod(GitMacheteBundle.class)
+public class CheckoutPreviousAction extends BaseCheckoutAction
+    implements
+      IExpectsKeySelectedBranchName {
+
+  @Override
+  protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
+    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    return currentBranchName != null
+        ? getNonHtmlString("action.GitMachete.CheckoutPreviousAction.undefined.branch-name").format(currentBranchName)
+        : getNonHtmlString("action.GitMachete.BaseCheckoutAction.undefined.current-branch");
+  }
+
+  @Override
+  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+    val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
+    val branchLayout = getBranchLayout(anActionEvent);
+    if (branchLayout != null && currentBranchName != null) {
+      val previousEntry = branchLayout.findPreviousEntry(currentBranchName);
+      return previousEntry != null ? previousEntry.getName() : null;
+    }
+    return null;
+  }
+
+}

--- a/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
@@ -441,3 +441,7 @@ action.GitMachete.CheckoutPreviousAction.undefined.branch-name=No branches befor
 action.GitMachete.CheckoutParentAction.text=Git Machete: Checkout Parent Branch
 action.GitMachete.CheckoutParentAction.description=Checkout parent branch (''{0}'')
 action.GitMachete.CheckoutParentAction.undefined.branch-name=Branch (''{0}'') does not have a parent in the branch layout
+
+action.GitMachete.CheckoutFirstChildAction.text=Git Machete: Checkout First Child Branch
+action.GitMachete.CheckoutFirstChildAction.description=Checkout first child branch (''{0}'')
+action.GitMachete.CheckoutFirstChildAction.undefined.branch-name=Branch (''{0}'') does not have any children in the branch layout

--- a/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
@@ -194,12 +194,12 @@ action.GitMachete.ISyncToRemoteStatusDependentAction.description.enabled={0} bra
 
 action.GitMachete.CheckoutSelectedAction.text=Git Machete: Checkout Selected Branch
 action.GitMachete.CheckoutSelectedAction.GitMacheteContextMenu.text=_Checkout
-action.GitMachete.CheckoutSelectedAction.description=Checkout this branch
 action.GitMachete.CheckoutSelectedAction.undefined.branch-name=Checkout disabled due to undefined branch name
 
-action.GitMachete.CheckoutSelectedAction.description.disabled.currently-checked-out=Branch ''{0}'' is currently checked out
-action.GitMachete.CheckoutSelectedAction.description.precise=Checkout branch ''{0}''
-action.GitMachete.CheckoutSelectedAction.task-title=Checking out
+action.GitMachete.BaseCheckoutAction.description.disabled.currently-checked-out=Branch ''{0}'' is currently checked out
+action.GitMachete.BaseCheckoutAction.description.precise=Checkout branch ''{0}''
+action.GitMachete.BaseCheckoutAction.task-title=Checking out
+action.GitMachete.BaseCheckoutAction.undefined.current-branch=There is no current branch; the repository is probably in detached HEAD state
 
 
 action.GitMachete.FastForwardMergeSelectedToParentAction.text=Git Machete: Fast-forward Merge into Parent
@@ -427,3 +427,17 @@ action.GitMachete.OpenMacheteTabAction.description=Open Git Machete tab
 
 action.GitMachete.OpenMacheteTabAction.notification.title.could-not-open-tab.HTML=<html><b>Could not open Git Machete tab</b></html>
 action.GitMachete.OpenMacheteTabAction.notification.message.no-git=Ensure that Git VCS is enabled in the project and there is at least one local branch present.
+
+# Branch Navigation
+
+action.GitMachete.CheckoutNextAction.text=Git Machete: Checkout Next Branch
+action.GitMachete.CheckoutNextAction.description=Checkout next branch (''{0}'')
+action.GitMachete.CheckoutNextAction.undefined.branch-name=No branches after (''{0}'') in the branch layout
+
+action.GitMachete.CheckoutPreviousAction.text=Git Machete: Checkout Previous Branch
+action.GitMachete.CheckoutPreviousAction.description=Checkout previous branch (''{0}'')
+action.GitMachete.CheckoutPreviousAction.undefined.branch-name=No branches before (''{0}'') in the branch layout
+
+action.GitMachete.CheckoutParentAction.text=Git Machete: Checkout Parent Branch
+action.GitMachete.CheckoutParentAction.description=Checkout parent branch (''{0}'')
+action.GitMachete.CheckoutParentAction.undefined.branch-name=Branch (''{0}'') does not have a parent in the branch layout

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ slf4j-lambda = "kr.pe.kwonnam.slf4j-lambda:slf4j-lambda-core:0.1"
 #      (1.*.*, rather than a specific version like 1.7.36).
 slf4j-simple = "org.slf4j:slf4j-simple:1.7.36"
 vavr = "io.vavr:vavr:0.10.4"
+# Plugins
 pluginPackages-aspectj-postCompileWeaving = "io.freefair.gradle:aspectj-plugin:6.5.1"
 pluginPackages-checkerFramework = "org.checkerframework:checkerframework-gradle-plugin:0.6.16"
 pluginPackages-grgit = "org.ajoberstar.grgit:grgit-gradle:5.0.0"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -220,7 +220,6 @@
         <action id="GitMachete.CheckoutNextAction"
                 class="com.virtuslab.gitmachete.frontend.actions.navigation.CheckoutNextAction">
             <keyboard-shortcut keymap="$default" first-keystroke="alt DOWN" />
-            <keyboard-shortcut keymap="$default" first-keystroke="alt RIGHT" />
         </action>
 
         <action id="GitMachete.CheckoutPreviousAction"
@@ -228,9 +227,13 @@
             <keyboard-shortcut keymap="$default" first-keystroke="alt UP" />
         </action>
 
-        <action id="GitMachete.ParentBranchCheckoutAction"
+        <action id="GitMachete.CheckoutParentAction"
                 class="com.virtuslab.gitmachete.frontend.actions.navigation.CheckoutParentAction">
             <keyboard-shortcut keymap="$default" first-keystroke="alt LEFT" />
+        </action>
+        <action id="GitMachete.CheckoutFirstChildAction"
+                class="com.virtuslab.gitmachete.frontend.actions.navigation.CheckoutFirstChildAction">
+            <keyboard-shortcut keymap="$default" first-keystroke="alt RIGHT" />
         </action>
     </actions>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -216,6 +216,22 @@
             <!-- In $default keymap `control` key (Windows/Linux) corresponds to `cmd` key on macOS -->
             <keyboard-shortcut keymap="$default" first-keystroke="control alt shift M" />
         </action>
+
+        <action id="GitMachete.CheckoutNextAction"
+                class="com.virtuslab.gitmachete.frontend.actions.navigation.CheckoutNextAction">
+            <keyboard-shortcut keymap="$default" first-keystroke="alt DOWN" />
+            <keyboard-shortcut keymap="$default" first-keystroke="alt RIGHT" />
+        </action>
+
+        <action id="GitMachete.CheckoutPreviousAction"
+                class="com.virtuslab.gitmachete.frontend.actions.navigation.CheckoutPreviousAction">
+            <keyboard-shortcut keymap="$default" first-keystroke="alt UP" />
+        </action>
+
+        <action id="GitMachete.ParentBranchCheckoutAction"
+                class="com.virtuslab.gitmachete.frontend.actions.navigation.CheckoutParentAction">
+            <keyboard-shortcut keymap="$default" first-keystroke="alt LEFT" />
+        </action>
     </actions>
 
 </idea-plugin>

--- a/src/uiTest/resources/project.rhino.js
+++ b/src/uiTest/resources/project.rhino.js
@@ -119,6 +119,7 @@ function Project(underlyingProject) {
 
   const ACTION_PLACE_TOOLBAR = 'GitMacheteToolbar';
   const ACTION_PLACE_CONTEXT_MENU = 'GitMacheteContextMenu';
+  const ACTION_PLACE_EMPTY = '';
   const SHOW_RESET_INFO = 'git-machete.reset.info.show';
   const SHOW_MERGE_WARNING = 'git-machete.merge.warning.show';
 
@@ -400,6 +401,18 @@ function Project(underlyingProject) {
 
   this.checkoutBranch = function (branchName) {
     invokeActionAndWait('GitMachete.CheckoutSelectedAction', ACTION_PLACE_CONTEXT_MENU, { SELECTED_BRANCH_NAME: branchName });
+  };
+
+  this.checkoutNextBranch = function () {
+    invokeActionAndWait('GitMachete.CheckoutNextAction', ACTION_PLACE_EMPTY, {});
+  };
+
+  this.checkoutPreviousBranch = function () {
+    invokeActionAndWait('GitMachete.CheckoutPreviousAction', ACTION_PLACE_EMPTY, {});
+  };
+
+  this.checkoutParentBranch = function () {
+    invokeActionAndWait('GitMachete.ParentBranchCheckoutAction', ACTION_PLACE_EMPTY, {});
   };
 
   this.fastForwardMergeSelectedToParent = function (branchName) {

--- a/src/uiTest/resources/project.rhino.js
+++ b/src/uiTest/resources/project.rhino.js
@@ -403,6 +403,10 @@ function Project(underlyingProject) {
     invokeActionAndWait('GitMachete.CheckoutSelectedAction', ACTION_PLACE_CONTEXT_MENU, { SELECTED_BRANCH_NAME: branchName });
   };
 
+  this.checkoutFirstChildBranch = function () {
+    invokeActionAndWait('GitMachete.CheckoutFirstChildAction', ACTION_PLACE_EMPTY, {});
+  };
+
   this.checkoutNextBranch = function () {
     invokeActionAndWait('GitMachete.CheckoutNextAction', ACTION_PLACE_EMPTY, {});
   };

--- a/src/uiTest/resources/project.rhino.js
+++ b/src/uiTest/resources/project.rhino.js
@@ -412,7 +412,7 @@ function Project(underlyingProject) {
   };
 
   this.checkoutParentBranch = function () {
-    invokeActionAndWait('GitMachete.ParentBranchCheckoutAction', ACTION_PLACE_EMPTY, {});
+    invokeActionAndWait('GitMachete.CheckoutParentAction', ACTION_PLACE_EMPTY, {});
   };
 
   this.fastForwardMergeSelectedToParent = function (branchName) {

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/RunningIntelliJFixtureExtension.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/RunningIntelliJFixtureExtension.scala
@@ -131,6 +131,10 @@ trait RunningIntelliJFixtureExtension extends RobotPluginExtension { this: IdePr
         runJs(s"project.checkoutBranch('$branch')")
       }
 
+      def checkoutFirstChildBranch(): Unit = doAndAwait {
+        runJs("project.checkoutFirstChildBranch()")
+      }
+
       def checkoutNextBranch(): Unit = doAndAwait {
         runJs("project.checkoutNextBranch()")
       }

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/RunningIntelliJFixtureExtension.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/RunningIntelliJFixtureExtension.scala
@@ -131,6 +131,18 @@ trait RunningIntelliJFixtureExtension extends RobotPluginExtension { this: IdePr
         runJs(s"project.checkoutBranch('$branch')")
       }
 
+      def checkoutNextBranch(): Unit = doAndAwait {
+        runJs("project.checkoutNextBranch()")
+      }
+
+      def checkoutPreviousBranch(): Unit = doAndAwait {
+        runJs("project.checkoutPreviousBranch()")
+      }
+
+      def checkoutParentBranch(): Unit = doAndAwait {
+        runJs("project.checkoutParentBranch()")
+      }
+
       def configure(): Unit = {
         runJs("project.configure()")
       }

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -91,6 +91,14 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
     // 7 branch rows + 11 commit rows
     Assert.assertEquals(18, branchAndCommitRowsCount)
 
+    project.checkoutBranch("build-chain")
+    project.checkoutPreviousBranch()
+    Assert.assertEquals(project.getCurrentBranchName(), "update-icons")
+    project.checkoutNextBranch()
+    Assert.assertEquals(project.getCurrentBranchName(), "build-chain")
+    project.checkoutParentBranch()
+    Assert.assertEquals(project.getCurrentBranchName(), "allow-ownership-link")
+
     // Let's slide out a root branch now
     project.slideOutSelected("develop")
     project.acceptBranchDeletionOnSlideOut()

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -40,7 +40,7 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
     waitAndCloseProject()
   }
 
-  val _saveThreadDumpWhenTestFailed = new TestWatcher() {
+  val _saveThreadDumpWhenTestFailed: TestWatcher = new TestWatcher() {
     override protected def failed(e: Throwable, description: Description): Unit = {
       val pid = probe.pid()
       probe.screenshot("exception")

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -105,14 +105,13 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
     project.slideOutSelected("develop")
     project.acceptBranchDeletionOnSlideOut()
     branchAndCommitRowsCount = project.refreshModelAndGetRowCount()
-    // 5 branch rows (`develop` is no longer there) + 7 commit rows
+    // 6 branch rows (`develop` is no longer there) + 7 commit rows
     // (1 commit of `allow-ownership-link` and 3 commits of `call-ws` are all gone)
     Assert.assertEquals(13, branchAndCommitRowsCount)
 
     project.checkoutBranch("master")
     project.slideOutSelected("call-ws")
     project.rejectBranchDeletionOnSlideOut()
-    branchAndCommitRowsCount = project.refreshModelAndGetRowCount()
     val managedBranchesAfterSlideOut = project.refreshModelAndGetManagedBranches()
     // Non-existent branches should be skipped while causing no error (only a low-severity notification).
     Assert.assertEquals(
@@ -125,7 +124,8 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
       ),
       managedBranchesAfterSlideOut.toSeq.sorted
     )
-    // 4 branch rows (`call-ws` is also no longer there) + 8 commit rows
+    branchAndCommitRowsCount = project.refreshModelAndGetRowCount()
+    // 5 branch rows (`call-ws` is also no longer there) + 7 commit rows
     Assert.assertEquals(12, branchAndCommitRowsCount)
   }
 

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -59,7 +59,6 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
   def saveThreadDumpWhenTestFailed: TestWatcher = _saveThreadDumpWhenTestFailed
 
   @Test def skipNonExistentBranches_toggleListingCommits_slideOutRoot(): Unit = {
-    project.openGitMacheteTab()
     overwriteMacheteFile(
       """develop
         |  non-existent
@@ -72,6 +71,7 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
         |master
         |  hotfix/add-trigger""".stripMargin
     )
+    project.openGitMacheteTab()
     val managedBranches = project.refreshModelAndGetManagedBranches()
     // Non-existent branches should be skipped while causing no error (only a low-severity notification).
     Assert.assertEquals(

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -64,8 +64,8 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
       """develop
         |  non-existent
         |    allow-ownership-link
-        |      update-icons
         |      build-chain
+        |      update-icons
         |    non-existent-leaf
         |  call-ws
         |non-existent-root
@@ -91,10 +91,12 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
     // 7 branch rows + 11 commit rows
     Assert.assertEquals(18, branchAndCommitRowsCount)
 
-    project.checkoutBranch("build-chain")
-    project.checkoutPreviousBranch()
-    Assert.assertEquals(project.getCurrentBranchName(), "update-icons")
+    project.checkoutBranch("allow-ownership-link")
+    project.checkoutFirstChildBranch()
+    Assert.assertEquals(project.getCurrentBranchName(), "build-chain")
     project.checkoutNextBranch()
+    Assert.assertEquals(project.getCurrentBranchName(), "update-icons")
+    project.checkoutPreviousBranch()
     Assert.assertEquals(project.getCurrentBranchName(), "build-chain")
     project.checkoutParentBranch()
     Assert.assertEquals(project.getCurrentBranchName(), "allow-ownership-link")


### PR DESCRIPTION
Resolves #1120

This PR is a draft and for receiving feedback.

The goal is to make it possible to checkout to the up, previous, next branches from the keyboard

Currently, it only has implementation for going to the next branch.
Checking out action is refactored to implement the functionality for the desired branch.
