### PR TITLE
Support fork points with listed and unlisted commits

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,13 +1,12 @@
 # Changelog
 
 ## v3.2.0
+- Added new `alt + enter` intention action to create a non-existing branch if user adds it to the machete file.
+- Added option to manually pick a commit for the fork point override.
 
 ## v3.1.1
 - Removed automatic rediscovery in case of empty machete file
 - Fixed indication of a repeated entry in machete file.
-
-## v3.2.0
-- Added new `alt + enter` intention action to create a non-existing branch if user adds it to the machete file.
 
 ## v3.1.0
 - Added support for IntelliJ 2022.3.

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
@@ -112,6 +112,10 @@ fun Project.ideProbe() {
   }
 }
 
+fun Project.apacheCommonsText() {
+  dependencies { "implementation"(lib("apacheCommonsText")) }
+}
+
 fun Project.jcabiAspects() {
   apply<AspectJPlugin>()
 

--- a/config/checker/org.apache.commons.astub
+++ b/config/checker/org.apache.commons.astub
@@ -1,0 +1,9 @@
+import org.checkerframework.checker.nullness.qual.PolyNull;
+
+package org.apache.commons.text;
+
+class StringEscapeUtils {
+
+  static @PolyNull String escapeHtml4(@PolyNull String input);
+
+}

--- a/frontend/actions/build.gradle.kts
+++ b/frontend/actions/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
 addIntellijToCompileClasspath(withGit4Idea = true)
 applyKotlinConfig()
+apacheCommonsText()
 lombok()
 slf4jLambdaApi()
 vavr()

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
@@ -66,8 +66,7 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
     }
 
     val nonRootBranch = branch.asNonRoot();
-    val selectedCommit = new OverrideForkPointDialog(project, nonRootBranch.getParent(), nonRootBranch)
-        .showAndGetSelectedCommit();
+    val selectedCommit = new OverrideForkPointDialog(project, nonRootBranch).showAndGetSelectedCommit();
     if (selectedCommit == null) {
       log().debug(
           "Commit selected to be the new fork point is null: most likely the action has been canceled from override-fork-point dialog");

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseOverrideForkPointAction.java
@@ -122,7 +122,7 @@ public abstract class BaseOverrideForkPointAction extends BaseGitMacheteReposito
     }
 
     try {
-      GitConfigUtil.setValue(project, root, whileDescendantOfKey, ancestorCommit.getHash());
+      GitConfigUtil.setValue(project, root, whileDescendantOfKey, forkPoint.getHash());
     } catch (VcsException e) {
       LOG.info("Attempt to get '${whileDescendantOf}' git config value failed: " + e.getMessage());
     }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -18,126 +18,105 @@ import javax.swing.JList
 import javax.swing.UIManager
 
 enum class OverrideOption {
-  PARENT,
-  INFERRED
+    PARENT,
+    INFERRED
 }
 
 class OverrideForkPointDialog(
-  project: Project,
-  private val parentBranch: IManagedBranchSnapshot,
-  private val branch: INonRootManagedBranchSnapshot
+    project: Project,
+    private val parentBranch: IManagedBranchSnapshot,
+    private val branch: INonRootManagedBranchSnapshot
 ) : DialogWrapper(project, /* canBeParent */ true) {
 
-  private var myOverrideOption = OverrideOption.PARENT
+    private var myOverrideOption = OverrideOption.PARENT
 
-  private var customCommit = branch.forkPoint
-  init {
-    title =
-      getString("action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.title")
-    setOKButtonMnemonic('O'.code)
-    super.init()
-  }
+    private var customCommit = branch.forkPoint
 
-  fun showAndGetSelectedCommit() =
-    if (showAndGet()) {
-      when (myOverrideOption) {
-        OverrideOption.PARENT -> parentBranch.pointedCommit
-        OverrideOption.INFERRED -> branch.forkPoint
-      }
-    } else {
-      customCommit
+    init {
+        title =
+            getString("action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.title")
+        setOKButtonMnemonic('O'.code)
+        super.init()
     }
 
-  override fun createCenterPanel() = panel {
-    row {
-      label(
-        format(
-          getString(
-            "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.label.HTML"
-          ),
-          branch.name
-        )
-      )
-    }
-    buttonsGroup {
-      row {
-        radioButton(
-          format(
-            getString(
-              "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.parent"
-            ),
-            parentBranch.name
-          ),
-          OverrideOption.PARENT
-        )
-          .comment(parentBranch.pointedCommit.shortMessage)
-      }
-
-      var thisRowComment = "cannot resolve commit message"
-
-      var radioButtonComment = "cannot resolve commit hash"
-
-      if (branch.forkPoint != null) {
-        thisRowComment = branch.forkPoint!!.shortMessage
-        radioButtonComment = branch.forkPoint!!.shortHash
-      }
-
-      row {
-        radioButton(
-          format(
-            getString(
-              "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred"
-            ),
-            radioButtonComment
-          ),
-          OverrideOption.INFERRED
-        )
-          .comment(
-            thisRowComment
-          )
-      }
-    }
-      .bind(
-        MutableProperty(::myOverrideOption) { myOverrideOption = it },
-        OverrideOption::class.java
-      )
-
-    row("The fork point commit:") {
-      comboBox(
-        branch.commits.toMutableList(),
-        object : DefaultListCellRenderer() {
-          private val defaultBackground = UIManager.get("List.background") as Color
-          override fun getListCellRendererComponent(
-            list: JList<*>?,
-            value: Any,
-            index: Int,
-            isSelected: Boolean,
-            cellHasFocus: Boolean
-          ): Component {
-            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
-            val commit: ICommitOfManagedBranch = value as ICommitOfManagedBranch
-
-            var prefix = ""
-
-            if (parentBranch.pointedCommit.shortHash.equals(commit.shortHash)) {
-              prefix = "parent pointed "
-            } else if (branch.forkPoint?.shortHash.equals(commit.shortHash)) {
-              prefix = "branch fork point "
+    fun showAndGetSelectedCommit() =
+        if (showAndGet()) {
+            when (myOverrideOption) {
+                OverrideOption.PARENT -> parentBranch.pointedCommit
+                OverrideOption.INFERRED -> branch.forkPoint
             }
-            text = "$prefix[${commit.shortHash}] [${commit.shortMessage}]"
-
-            if (!isSelected) {
-              setBackground(if (index % 2 == 0) background else defaultBackground)
-            }
-            return this
-          }
+        } else {
+            customCommit
         }
 
-      ).bindItem(
-        MutableProperty(::customCommit) {
-          customCommit = it as IForkPointCommitOfManagedBranch?
+    override fun createCenterPanel() = panel {
+        row {
+            label(
+                format(
+                    getString(
+                        "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.label.HTML"
+                    ),
+                    branch.name
+                )
+            )
         }
-      )
+        row {
+            label(
+                format(
+                    getString(
+                        "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.parent"
+                    ),
+                    parentBranch.name
+                )
+            )
+        }
+
+        row {
+            label(
+                format(
+                    getString(
+                        "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred"
+                    )
+                )
+            )
+        }
+
+        row("The fork point commit:") {
+            comboBox(
+                branch.commits.toMutableList(),
+                object : DefaultListCellRenderer() {
+                    private val defaultBackground = UIManager.get("List.background") as Color
+                    override fun getListCellRendererComponent(
+                        list: JList<*>?,
+                        value: Any,
+                        index: Int,
+                        isSelected: Boolean,
+                        cellHasFocus: Boolean
+                    ): Component {
+                        super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+                        val commit: ICommitOfManagedBranch = value as ICommitOfManagedBranch
+
+                        var prefix = ""
+
+                        if (parentBranch.pointedCommit.shortHash.equals(commit.shortHash)) {
+                            prefix = "parent pointed "
+                        } else if (branch.forkPoint != null && branch.forkPoint?.shortHash.equals(commit.shortHash)) {
+                            prefix = "branch fork point "
+                        }
+                        text = "$prefix[${commit.shortHash}] [${commit.shortMessage}]"
+
+                        if (!isSelected) {
+                            setBackground(if (index % 2 == 0) background else defaultBackground)
+                        }
+                        return this
+                    }
+                }
+
+            ).bindItem(
+                MutableProperty(::customCommit) {
+                    customCommit = it as IForkPointCommitOfManagedBranch?
+                }
+            )
+        }
     }
-  }
 }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -111,9 +111,6 @@ class OverrideForkPointDialog(
           ),
           OverrideOption.CUSTOM
         )
-          .comment(
-            thisRowComment
-          )
 
         comboBox<ICommitOfManagedBranch?>(
           (listOf(branch.forkPoint, parentBranch.pointedCommit) + branch.commits.toMutableList()).filterNotNull(),
@@ -155,26 +152,7 @@ class OverrideForkPointDialog(
               isEnabled = list.isEnabled
 
               text = if (commit != null) {
-                var prefix =
-                  if (parentBranch.pointedCommit.shortHash.equals(commit.shortHash)) {
-                    format(
-                      getString(
-                        "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.parent"
-                      ),
-                      parentBranch.name
-                    )
-                  } else if (branch.forkPoint?.shortHash.equals(commit.shortHash)) {
-                    format(
-                      getString(
-                        "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred"
-                      ),
-                      branch.name
-                    )
-                  } else {
-                    ""
-                  }
-
-                "$prefix[${commit.shortHash}] [${commit.shortMessage}]"
+                "[${commit.shortHash}] ${commit.shortMessage}"
               } else {
                 ""
               }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -29,8 +29,6 @@ class OverrideForkPointDialog(
 
   private val parent = branch.parent
 
-  private lateinit var rb: Cell<JBRadioButton>
-
   init {
     title =
       getString("action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.title")
@@ -89,7 +87,7 @@ class OverrideForkPointDialog(
       }
 
       row {
-        rb = radioButton(
+        val rb: Cell<JBRadioButton> = radioButton(
           format(
             getString(
               "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.custom"
@@ -99,8 +97,8 @@ class OverrideForkPointDialog(
           OverrideOption.CUSTOM
         )
 
-        val list = branch.commitsUntilParent.reverse() + listOf(branch.forkPoint, parent.pointedCommit)
-        val items = list.filterNotNull().distinct()
+        val list = branch.commitsUntilParent + listOf(branch.forkPoint, parent.pointedCommit)
+        val items = list.filterNotNull().distinct().reversed()
 
         comboBox(
           items,

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -49,30 +49,10 @@ class OverrideForkPointDialog(
         )
       )
     }
-    row {
-      label(
-        format(
-          getString(
-            "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.parent"
-          ),
-          parentBranch.name
-        )
-      )
-    }
-
-    row {
-      label(
-        format(
-          getString(
-            "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred"
-          )
-        )
-      )
-    }
 
     row("The fork point commit:") {
       comboBox<ICommitOfManagedBranch?>(
-        (branch.commits.toMutableList() + parentBranch.pointedCommit + branch.forkPoint).filterNotNull(),
+        (listOf(parentBranch.pointedCommit, branch.forkPoint) + branch.commits.toMutableList()).filterNotNull(),
         object : DefaultListCellRenderer() {
           private val defaultBackground = UIManager.get("List.background") as Color
           override fun getListCellRendererComponent(
@@ -113,9 +93,16 @@ class OverrideForkPointDialog(
               var prefix =
 
                 if (parentBranch.pointedCommit.shortHash.equals(commit.shortHash)) {
-                  "parent pointed "
+                  format(
+                    getString(
+                      "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.parent"
+                    ),
+                    parentBranch.name
+                  )
                 } else if (branch.forkPoint?.shortHash.equals(commit.shortHash)) {
-                  "branch fork point "
+                  getString(
+                    "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred"
+                  )
                 } else {
                   ""
                 }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -3,7 +3,9 @@ package com.virtuslab.gitmachete.frontend.actions.dialogs
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.dsl.builder.MutableProperty
+import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.panel
+import com.virtuslab.gitmachete.backend.api.IForkPointCommitOfManagedBranch
 import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot
 import com.virtuslab.gitmachete.backend.api.INonRootManagedBranchSnapshot
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format
@@ -22,6 +24,7 @@ class OverrideForkPointDialog(
 
   private var myOverrideOption = OverrideOption.PARENT
 
+  private var customCommit = branch.forkPoint
   init {
     title =
       getString("action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.title")
@@ -36,7 +39,7 @@ class OverrideForkPointDialog(
         OverrideOption.INFERRED -> branch.forkPoint
       }
     } else {
-      null
+      customCommit
     }
 
   override fun createCenterPanel() = panel {
@@ -92,5 +95,13 @@ class OverrideForkPointDialog(
         MutableProperty(::myOverrideOption) { myOverrideOption = it },
         OverrideOption::class.java
       )
+
+    row("The fork point commit:") {
+      comboBox(branch.commits.toMutableList()).bindItem(
+        MutableProperty(::customCommit) {
+          customCommit = it as IForkPointCommitOfManagedBranch?
+        }
+      )
+    }
   }
 }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -6,16 +6,12 @@ import com.intellij.ui.dsl.builder.MutableProperty
 import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.panel
 import com.virtuslab.gitmachete.backend.api.ICommitOfManagedBranch
-import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot
 import com.virtuslab.gitmachete.backend.api.INonRootManagedBranchSnapshot
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString
-import java.awt.Color
 import java.awt.Component
-import java.awt.Font
 import javax.swing.DefaultListCellRenderer
 import javax.swing.JList
-import javax.swing.UIManager
 
 enum class OverrideOption {
   PARENT,
@@ -25,13 +21,14 @@ enum class OverrideOption {
 
 class OverrideForkPointDialog(
   project: Project,
-  private val parentBranch: IManagedBranchSnapshot,
   private val branch: INonRootManagedBranchSnapshot
 ) : DialogWrapper(project, /* canBeParent */ true) {
 
   private var myOverrideOption = OverrideOption.PARENT
 
   private var customCommit: ICommitOfManagedBranch? = branch.forkPoint
+
+  private val parent = branch.parent
 
   init {
     title =
@@ -43,9 +40,9 @@ class OverrideForkPointDialog(
   fun showAndGetSelectedCommit() =
     if (showAndGet()) {
       when (myOverrideOption) {
-        OverrideOption.PARENT -> parentBranch.pointedCommit
+        OverrideOption.PARENT -> parent.pointedCommit
         OverrideOption.INFERRED -> branch.forkPoint
-        OverrideOption.CUSTOM -> customCommit!!
+        OverrideOption.CUSTOM -> customCommit
       }
     } else {
       null
@@ -70,21 +67,15 @@ class OverrideForkPointDialog(
             getString(
               "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.parent"
             ),
-            parentBranch.name
+            parent.name
           ),
           OverrideOption.PARENT
         )
-          .comment(parentBranch.pointedCommit.shortMessage)
+          .comment(parent.pointedCommit.shortMessage)
       }
 
-      var thisRowComment = "cannot resolve commit message"
-
-      var radioButtonComment = "cannot resolve commit hash"
-
-      if (branch.forkPoint != null) {
-        thisRowComment = branch.forkPoint!!.shortMessage
-        radioButtonComment = branch.forkPoint!!.shortHash
-      }
+      val thisRowComment = branch.forkPoint?.shortMessage ?: "cannot resolve commit message"
+      val radioButtonComment = branch.forkPoint?.shortHash ?: "cannot resolve commit hash"
 
       row {
         radioButton(
@@ -112,10 +103,14 @@ class OverrideForkPointDialog(
           OverrideOption.CUSTOM
         )
 
-        comboBox<ICommitOfManagedBranch?>(
-          (listOf(branch.forkPoint, parentBranch.pointedCommit) + branch.commitsUntilParent.toMutableList()).filterNotNull(),
+        val mutableList = branch.commitsUntilParent.toMutableList()
+        mutableList.remove(branch.forkPoint)
+        mutableList.remove(parent.pointedCommit)
+        val items = (listOf(branch.forkPoint, parent.pointedCommit) + mutableList.reversed()).filterNotNull()
+
+        comboBox(
+          items,
           object : DefaultListCellRenderer() {
-            private val defaultBackground = UIManager.get("List.background") as Color
             override fun getListCellRendererComponent(
               list: JList<*>?,
               value: Any?,
@@ -123,52 +118,13 @@ class OverrideForkPointDialog(
               isSelected: Boolean,
               cellHasFocus: Boolean
             ): Component {
-              val commit: ICommitOfManagedBranch? = value as ICommitOfManagedBranch?
-              componentOrientation = list!!.componentOrientation
-
-              var bg: Color? = null
-              var fg: Color? = null
-
-              val dropLocation = list.dropLocation
-              var customIsSelected = isSelected
-              if (dropLocation != null && !dropLocation.isInsert && dropLocation.index == index) {
-                bg = list.selectionBackground
-                fg = list.selectionForeground
-                customIsSelected = true
-              }
-
-              if (customIsSelected) {
-                background = bg ?: list.selectionBackground
-                foreground = fg ?: list.selectionForeground
-                font = Font(list.font.name, Font.BOLD, list.font.size)
-              } else {
-                font = list.font
-                background = list.background
-                foreground = list.foreground
-              }
-
-              icon = null
-
-              isEnabled = list.isEnabled
-
-              text = if (commit != null) {
-                "[${commit.shortHash}] ${commit.shortMessage}"
-              } else {
-                ""
-              }
-
-              if (!customIsSelected) {
-                setBackground(if (index % 2 == 0) background else defaultBackground)
-              }
-
+              val commit: ICommitOfManagedBranch = value as ICommitOfManagedBranch
+              text = "<html><tt>[${commit.shortHash}]</tt> ${commit.shortMessage}</html>"
               return this
             }
           }
-
         ).bindItem(
-          MutableProperty(::customCommit) {
-            customCommit = it
-          }
+          MutableProperty(::customCommit) { customCommit = it }
         )
       }
     }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -71,8 +71,8 @@ class OverrideForkPointDialog(
     }
 
     row("The fork point commit:") {
-      comboBox(
-        branch.commits.toMutableList(),
+      comboBox<ICommitOfManagedBranch?>(
+        branch.commits.toMutableList().filterNotNull(),
         object : DefaultListCellRenderer() {
           private val defaultBackground = UIManager.get("List.background") as Color
           override fun getListCellRendererComponent(
@@ -83,22 +83,52 @@ class OverrideForkPointDialog(
             cellHasFocus: Boolean
           ): Component {
             val commit: ICommitOfManagedBranch? = value as ICommitOfManagedBranch?
-            super.getListCellRendererComponent(list, commit!!, index, isSelected, cellHasFocus)
+            componentOrientation = list!!.componentOrientation
 
-            var prefix =
-              if (parentBranch.pointedCommit.shortHash.equals(commit.shortHash)) {
-                "parent pointed "
-              } else if (branch.forkPoint?.shortHash.equals(commit.shortHash)) {
-                "branch fork point "
-              } else {
-                ""
-              }
+            var bg: Color? = null
+            var fg: Color? = null
 
-            text = "$prefix[${commit.shortHash}] [${commit.shortMessage}]"
+            val dropLocation = list.dropLocation
+            var customIsSelected = isSelected
+            if (dropLocation != null && !dropLocation.isInsert && dropLocation.index == index) {
+              bg = list.selectionBackground
+              fg = list.selectionForeground
+              customIsSelected = true
+            }
 
-            if (!isSelected) {
+            if (customIsSelected) {
+              background = bg ?: list.selectionBackground
+              foreground = fg ?: list.selectionForeground
+            } else {
+              background = list.background
+              foreground = list.foreground
+            }
+
+            icon = null
+
+            isEnabled = list.isEnabled
+            font = list.font
+
+            text = if (commit != null) {
+              var prefix =
+
+                if (parentBranch.pointedCommit.shortHash.equals(commit.shortHash)) {
+                  "parent pointed "
+                } else if (branch.forkPoint?.shortHash.equals(commit.shortHash)) {
+                  "branch fork point "
+                } else {
+                  ""
+                }
+
+              "$prefix[${commit.shortHash}] [${commit.shortMessage}]"
+            } else {
+              ""
+            }
+
+            if (!customIsSelected) {
               setBackground(if (index % 2 == 0) background else defaultBackground)
             }
+
             return this
           }
         }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -100,8 +100,11 @@ class OverrideForkPointDialog(
                     parentBranch.name
                   )
                 } else if (branch.forkPoint?.shortHash.equals(commit.shortHash)) {
-                  getString(
-                    "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred"
+                  format(
+                    getString(
+                      "action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred"
+                    ),
+                    branch.name
                   )
                 } else {
                   ""

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -53,7 +53,7 @@ class OverrideForkPointDialog(
 
     row("The fork point commit:") {
       comboBox<ICommitOfManagedBranch?>(
-        (listOf(parentBranch.pointedCommit, branch.forkPoint) + branch.commits.toMutableList()).filterNotNull(),
+        (listOf(branch.forkPoint, parentBranch.pointedCommit) + branch.commits.toMutableList()).filterNotNull(),
         object : DefaultListCellRenderer() {
           private val defaultBackground = UIManager.get("List.background") as Color
           override fun getListCellRendererComponent(

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -113,7 +113,7 @@ class OverrideForkPointDialog(
         )
 
         comboBox<ICommitOfManagedBranch?>(
-          (listOf(branch.forkPoint, parentBranch.pointedCommit) + branch.commits.toMutableList()).filterNotNull(),
+          (listOf(branch.forkPoint, parentBranch.pointedCommit) + branch.commitsUntilParent.toMutableList()).filterNotNull(),
           object : DefaultListCellRenderer() {
             private val defaultBackground = UIManager.get("List.background") as Color
             override fun getListCellRendererComponent(

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -72,7 +72,7 @@ class OverrideForkPointDialog(
 
     row("The fork point commit:") {
       comboBox<ICommitOfManagedBranch?>(
-        branch.commits.toMutableList().filterNotNull(),
+        (branch.commits.toMutableList() + parentBranch.pointedCommit + branch.forkPoint).filterNotNull(),
         object : DefaultListCellRenderer() {
           private val defaultBackground = UIManager.get("List.background") as Color
           override fun getListCellRendererComponent(

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -97,7 +97,10 @@ class OverrideForkPointDialog(
       )
 
     row("The fork point commit:") {
-      comboBox(branch.commits.toMutableList()).bindItem(
+      comboBox(branch.commits.toMutableList()
+      /* should we also add a custom renderer in here for rendering the
+      commits using their short hash and message?*/
+      ).bindItem(
         MutableProperty(::customCommit) {
           customCommit = it as IForkPointCommitOfManagedBranch?
         }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -23,7 +23,7 @@ class OverrideForkPointDialog(
   private val branch: INonRootManagedBranchSnapshot
 ) : DialogWrapper(project, /* canBeParent */ true) {
 
-  private var customCommit: ICommitOfManagedBranch? = parentBranch.pointedCommit
+  private var customCommit: ICommitOfManagedBranch? = branch.forkPoint
 
   init {
     title =

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -97,7 +97,8 @@ class OverrideForkPointDialog(
       )
 
     row("The fork point commit:") {
-      comboBox(branch.commits.toMutableList()
+      comboBox(
+        branch.commits.toMutableList()
       /* should we also add a custom renderer in here for rendering the
       commits using their short hash and message?*/
       ).bindItem(

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/OverrideForkPointDialog.kt
@@ -12,6 +12,7 @@ import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.format
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString
 import java.awt.Color
 import java.awt.Component
+import java.awt.Font
 import javax.swing.DefaultListCellRenderer
 import javax.swing.JList
 import javax.swing.UIManager
@@ -79,7 +80,9 @@ class OverrideForkPointDialog(
             if (customIsSelected) {
               background = bg ?: list.selectionBackground
               foreground = fg ?: list.selectionForeground
+              font = Font(list.font.name, Font.BOLD, list.font.size)
             } else {
+              font = list.font
               background = list.background
               foreground = list.foreground
             }
@@ -87,11 +90,9 @@ class OverrideForkPointDialog(
             icon = null
 
             isEnabled = list.isEnabled
-            font = list.font
 
             text = if (commit != null) {
               var prefix =
-
                 if (parentBranch.pointedCommit.shortHash.equals(commit.shortHash)) {
                   format(
                     getString(

--- a/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
@@ -72,7 +72,7 @@ action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.label.H
 action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.title=Override Fork Point
 action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.parent=Parent branch ({0})
 action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred=Inferred commit ({0})
-action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.custom=Manually picked commit
+action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.custom=Manually picked commit:
 
 
 action.GitMachete.BasePullAction.action-name=P_ull

--- a/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
@@ -72,6 +72,7 @@ action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.label.H
 action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.title=Override Fork Point
 action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.parent=Parent branch ({0})
 action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.inferred=Inferred commit ({0})
+action.GitMachete.BaseOverrideForkPointAction.dialog.override-fork-point.radio-button.custom=Manually picked commit
 
 
 action.GitMachete.BasePullAction.action-name=P_ull

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ powerMock = "2.0.9"
 
 [libraries]
 # Libraries
+apacheCommonsText = "org.apache.commons:commons-text:1.9"
 archunit = "com.tngtech.archunit:archunit:1.0.0"
 betterStrings = "com.antkorwin:better-strings:0.5"
 checker = { module = "org.checkerframework:checker", version.ref = "checker" }


### PR DESCRIPTION
It resolves #449 

Should we add a custom renderer to render each commit with its hash and message?



