### PR TITLE
Fix env vars needed for plugin signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,9 @@ jobs:
       - run:
           name: Build plugin artifact
           command: ./gradlew buildPlugin
+      - run:
+          name: Sign plugin artifact
+          command: ./gradlew signPlugin
       - store_artifacts:
           path: build/distributions/
           destination: .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,30 +374,32 @@ openssl req\
 ```
 
 #### Plugin signing as part of the CI publish process through the Gradle Plugin
-Please note that you would have to copy the contents of `private.pem`, `chain.crt`, and `$PASSWORD_ENVIRONMENT_VARIABLE_NAME`, in the [corresponding environment variables](https://app.circleci.com/settings/project/github/VirtusLab/git-machete-intellij-plugin); in order for the Gradle IntelliJ Plugin to pick them up and use them for the plugin signing task, before publishing to the Marketplace.
+Please note that you would have to copy the contents of `private.pem`, `chain.crt`, and `PLUGIN_SIGN_PRIVATE_KEY_PASS`,
+in the [corresponding environment variables](https://app.circleci.com/settings/project/github/VirtusLab/git-machete-intellij-plugin),
+in order for the Gradle IntelliJ Plugin to pick them up and use them for the plugin signing task, before publishing to the Marketplace.
 For doing so, on a MacOS system you can follow the below instructions (on Linux, use `xclip -selection clipboard` instead of `pbcopy`):
 
 1. Type the following command for copying the contents of the private key to the clipboard
 ```shell
-pbcopy < private.pem
+cat private.pem | base64 -w 0 | pbcopy
 ```
-2. Create an environment variable named `PLUGIN_SIGN_PRIVATE_KEY` on the CI, and paste the content from the clipboard as its value.
+2. Create an environment variable named `PLUGIN_SIGN_PRIVATE_KEY_BASE64` on the CI, and paste the content from the clipboard as its value.
 3. for copying the contents of the certificate to clipboard:
 ```shell
-pbcopy < chain.crt
+cat chain.crt | base64 -w 0 | pbcopy
 ```
-4. Create an environment variable named `PLUGIN_SIGN_CERT_CHAIN` on the CI, and paste the content from the clipboard as its value.
+4. Create an environment variable named `PLUGIN_SIGN_CERT_CHAIN_BASE64` on the CI, and paste the content from the clipboard as its value.
 5. Type the following command for copying the value of the private key password to the clipboard
 ```shell
-echo $PLUGIN_SIGN_PRIVATE_KEY_PASS | pbcopy
+echo "$PLUGIN_SIGN_PRIVATE_KEY_PASS" | pbcopy
 ```
 6. Create an environment variable named `PLUGIN_SIGN_PRIVATE_KEY_PASS` on the CI and paste the contents of the clipboard as its value.
 
 #### Local plugin signing for test, through the Gradle plugin
 
 ```shell
-export PLUGIN_SIGN_PRIVATE_KEY=$(<private.pem)
-export PLUGIN_SIGN_CERT_CHAIN=$(<chain.crt)
+export PLUGIN_SIGN_PRIVATE_KEY_BASE64=$(base64 -w 0 < private.pem)
+export PLUGIN_SIGN_CERT_CHAIN_BASE64=$(base64 -w 0 < chain.crt)
 ```
 
 Then run `./gradlew publishPlugin` to produce the unsigned and signed `.zip` files in the `build/distributions/` directory.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import nl.littlerobots.vcu.plugin.VersionCatalogUpdatePlugin
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import se.ascp.gradle.GradleVersionsFilterPlugin
+import java.util.Base64
 
 plugins {
   checkstyle
@@ -38,8 +39,12 @@ val javaMajorVersion: JavaVersion by extra(JavaVersion.VERSION_11)
 val ciBranch: String? by extra(System.getenv("CIRCLE_BRANCH"))
 val isCI: Boolean by extra(System.getenv("CI") == "true")
 val jetbrainsMarketplaceToken: String? by extra(System.getenv("JETBRAINS_MARKETPLACE_TOKEN"))
-val pluginSignPrivateKey: String? by extra(System.getenv("PLUGIN_SIGN_PRIVATE_KEY"))
-val pluginSignCertificateChain: String? by extra(System.getenv("PLUGIN_SIGN_CERT_CHAIN"))
+
+fun String.fromBase64(): String {
+  return String(Base64.getDecoder().decode(this))
+}
+val pluginSignCertificateChain: String? by extra(System.getenv("PLUGIN_SIGN_CERT_CHAIN_BASE64")?.fromBase64())
+val pluginSignPrivateKey: String? by extra(System.getenv("PLUGIN_SIGN_PRIVATE_KEY_BASE64")?.fromBase64())
 val pluginSignPrivateKeyPass: String? by extra(System.getenv("PLUGIN_SIGN_PRIVATE_KEY_PASS"))
 
 val compileJavaJvmArgs: List<String>? by extra((project.properties["compileJavaJvmArgs"] as String?)?.split(" "))


### PR DESCRIPTION
I didn't get to the bottom of the issue, probably some off-by-one error around handling newlines in env vars by CircleCI or whatnot.

Anyway, following the approach of [git-machete](https://github.com/VirtusLab/git-machete/blob/master/ci/deb-ppa-upload/export-gpg-ssh-config), let's just keep all env vars that can contain newlines as base64 in the CI.