### PR TITLE
Improve the checks for managed branches in `skipNonExistentBranches_toggleListingCommits_slideOutRoot`

### DIFF
--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -103,6 +103,18 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
     project.slideOutSelected("call-ws")
     project.rejectBranchDeletionOnSlideOut()
     branchAndCommitRowsCount = project.refreshModelAndGetRowCount()
+    val managedBranchesAfterSlideOut = project.refreshModelAndGetManagedBranches()
+    // Non-existent branches should be skipped while causing no error (only a low-severity notification).
+    Assert.assertEquals(
+      Seq(
+        "allow-ownership-link",
+        "build-chain",
+        "hotfix/add-trigger",
+        "master",
+        "update-icons"
+      ),
+      managedBranchesAfterSlideOut.toSeq.sorted
+    )
     // 4 branch rows (`call-ws` is also no longer there) + 8 commit rows
     Assert.assertEquals(12, branchAndCommitRowsCount)
   }


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin/6906/workflows/20237cb4-088a-4833-a760-f856f08409e3/jobs/7312 (yet un-encountered problem; not opening an issue yet as it never manifested on `develop`, only on open PRs so far)