### PR TITLE
Bugfix/uitest race condition fix

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Removed automatic rediscovery in case of empty machete file
 
 ## v3.1.0
 - Added support for IntelliJ 2022.3.

--- a/docs/features.md
+++ b/docs/features.md
@@ -202,7 +202,7 @@ It'll be located under `.git/machete` path in your repository.
 
 This branch layout can be automatically discovered based on the state of your git repository by the `Discover Branch Layout` action.
 It constructs a layout from around 10 most recently used branches.
-**This action is automatically invoked in case of an empty or nonexistent `machete` file,**
+**This action is automatically invoked in case of a nonexistent `machete` file,**
 but you can also run it any time from IntelliJ's `Search Everywhere` (double Shift) by typing `Discover Branch Layout`.
 
 ![](discover.gif)

--- a/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
@@ -300,10 +300,10 @@ string.GitMachete.EnhancedGraphTable.automatic-discover.notification.title.canno
 string.GitMachete.EnhancedGraphTable.automatic-discover.task-title=Automatically discovering branch layout
 action.GitMachete.EnhancedGraphTable.automatic-discover.slide-out-skipped=Slide out skipped branches
 string.GitMachete.EnhancedGraphTable.automatic-discover.success-message=Branch layout has been automatically discovered. Edit the layout manually if needed.
-string.GitMachete.EnhancedGraphTable.empty-table-text.try-running-discover=Provided machete file ({0}) is empty, try running ''Discover Branch Layout''
 string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout=Provided machete file ({0}) is empty and branch layout can''t be automatically detected
 string.GitMachete.EnhancedGraphTable.empty-table-text.loading=Loading\u2026
 string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file=None of the branches provided by machete file ({0}) exists within the local repository
+string.GitMachete.EnhancedGraphTable.empty-table-text.try-running-discover=Provided machete file ({0}) is empty, try running ''Discover Branch Layout''
 string.GitMachete.EnhancedGraphTable.duplicated-branches-text=The following branches appear more than once in machete file:
 string.GitMachete.EnhancedGraphTable.skipped-branches-text=Some branches listed in machete file do not exist: {0}
 action.GitMachete.EnhancedGraphTable.branch-layout-write-failure=Writing new branch layout failed

--- a/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
@@ -300,6 +300,7 @@ string.GitMachete.EnhancedGraphTable.automatic-discover.notification.title.canno
 string.GitMachete.EnhancedGraphTable.automatic-discover.task-title=Automatically discovering branch layout
 action.GitMachete.EnhancedGraphTable.automatic-discover.slide-out-skipped=Slide out skipped branches
 string.GitMachete.EnhancedGraphTable.automatic-discover.success-message=Branch layout has been automatically discovered. Edit the layout manually if needed.
+string.GitMachete.EnhancedGraphTable.empty-table-text.try-running-discover=Provided machete file ({0}) is empty, try running ''Discover Branch Layout''
 string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout=Provided machete file ({0}) is empty and branch layout can''t be automatically detected
 string.GitMachete.EnhancedGraphTable.empty-table-text.loading=Loading\u2026
 string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file=None of the branches provided by machete file ({0}) exists within the local repository

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -194,6 +194,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
           setTextForEmptyTable(
               getString("string.GitMachete.EnhancedGraphTable.empty-table-text.try-running-discover")
                   .format(macheteFilePath.toString()));
+          return;
         } else {
           setTextForEmptyTable(
               getString("string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file")

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -192,7 +192,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
         if (gitMacheteRepositorySnapshot.getSkippedBranchNames().isEmpty()) {
           LOG.info("Machete file (${macheteFilePath}) is empty");
           setTextForEmptyTable(
-              getString("string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout")
+              getString("string.GitMachete.EnhancedGraphTable.empty-table-text.try-running-discover")
                   .format(macheteFilePath.toString()));
         } else {
           setTextForEmptyTable(

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -190,9 +190,10 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
       repositoryGraph = repositoryGraphCache.getRepositoryGraph(gitMacheteRepositorySnapshot, isListingCommits);
       if (gitMacheteRepositorySnapshot.getRootBranches().isEmpty()) {
         if (gitMacheteRepositorySnapshot.getSkippedBranchNames().isEmpty()) {
-          LOG.info("Machete file (${macheteFilePath}) is empty, so auto discover is running");
-          queueDiscover(macheteFilePath, doOnUIThreadWhenReady);
-          return;
+          LOG.info("Machete file (${macheteFilePath}) is empty");
+          setTextForEmptyTable(
+              getString("string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout")
+                  .format(macheteFilePath.toString()));
         } else {
           setTextForEmptyTable(
               getString("string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file")


### PR DESCRIPTION
Turns out the failing tests were the result of reading the _machete_ file right when it was being overwritten by the `UiTestSuite` which made the file empty for a short period of time. Code reacts to empty machete file by doing a rediscover thus the rest of the test fails.