### PR TITLE
Fix Disposer.register(project, ...) (closes #1288)

### DIFF
--- a/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileViewProviderFactory.java
+++ b/frontend/file/src/main/java/com/virtuslab/gitmachete/frontend/file/MacheteFileViewProviderFactory.java
@@ -3,6 +3,7 @@ package com.virtuslab.gitmachete.frontend.file;
 import static com.intellij.openapi.application.ModalityState.NON_MODAL;
 
 import com.intellij.lang.Language;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -27,7 +28,7 @@ public class MacheteFileViewProviderFactory implements FileViewProviderFactory {
     return new MacheteFileViewProvider(manager, file, eventSystemEnabled, language);
   }
 
-  private static class MacheteFileViewProvider extends SingleRootFileViewProvider {
+  private static class MacheteFileViewProvider extends SingleRootFileViewProvider implements Disposable {
 
     MacheteFileViewProvider(PsiManager manager,
         VirtualFile virtualFile,
@@ -53,7 +54,12 @@ public class MacheteFileViewProviderFactory implements FileViewProviderFactory {
       });
       MessageBusConnection messageBusConnection = project.getMessageBus().connect();
       messageBusConnection.subscribe(topic, listener);
-      Disposer.register(project, messageBusConnection);
+      Disposer.register(this, messageBusConnection);
+    }
+
+    @Override
+    public void dispose() {
+
     }
   }
 

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/gitrepositoryselection/GitRepositoryComboBox.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/gitrepositoryselection/GitRepositoryComboBox.java
@@ -5,6 +5,7 @@ import javax.swing.JComponent;
 
 import com.intellij.dvcs.DvcsUtil;
 import com.intellij.dvcs.repo.VcsRepositoryManager;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
@@ -25,7 +26,10 @@ import com.virtuslab.gitmachete.frontend.ui.api.gitrepositoryselection.IGitRepos
 import com.virtuslab.gitmachete.frontend.ui.api.gitrepositoryselection.IGitRepositorySelectionComponentProvider;
 
 @CustomLog
-public final class GitRepositoryComboBox extends JComboBox<GitRepository> implements IGitRepositorySelectionComponentProvider {
+public final class GitRepositoryComboBox extends JComboBox<GitRepository>
+    implements
+      Disposable,
+      IGitRepositorySelectionComponentProvider {
 
   private final java.util.List<IGitRepositorySelectionChangeObserver> observers = new SmartList<>();
 
@@ -45,7 +49,7 @@ public final class GitRepositoryComboBox extends JComboBox<GitRepository> implem
           LOG.debug("Git repository mappings changed");
           ModalityUiUtil.invokeLaterIfNeeded(ModalityState.NON_MODAL, () -> updateRepositories());
         });
-    Disposer.register(project, messageBusConnection);
+    Disposer.register(this, messageBusConnection);
   }
 
   @Override
@@ -106,5 +110,10 @@ public final class GitRepositoryComboBox extends JComboBox<GitRepository> implem
   @Override
   public JComponent getSelectionComponent() {
     return this;
+  }
+
+  @Override
+  public void dispose() {
+
   }
 }

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -18,6 +18,7 @@ import com.intellij.ide.DataManager;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationAction;
 import com.intellij.notification.NotificationType;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
@@ -84,6 +85,7 @@ import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     implements
       DataProvider,
+      Disposable,
       IGitMacheteRepositorySnapshotProvider {
 
   private final Project project;
@@ -163,7 +165,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
         }
       }
     });
-    Disposer.register(project, messageBusConnection);
+    Disposer.register(this, messageBusConnection);
   }
 
   private void subscribeToGitRepositoryFilesChanges() {
@@ -171,7 +173,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     GitRepositoryChangeListener listener = repository -> queueRepositoryUpdateAndModelRefresh();
     val messageBusConnection = project.getMessageBus().connect();
     messageBusConnection.subscribe(topic, listener);
-    Disposer.register(project, messageBusConnection);
+    Disposer.register(this, messageBusConnection);
   }
 
   private void subscribeToSelectedGitRepositoryChange() {
@@ -422,4 +424,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
         Case($(), (Object) null));
   }
 
+  @Override
+  public void dispose() {
+
+  }
 }


### PR DESCRIPTION
I have reviewed the issues related to `ProjectAlreadyDisposed` but none of them contains steps to reproduce. 

The UI tests are passing. I have run the ide locally and tested it - I did not encounter the error. 

Probably it's enough.