### PR TITLE
Fix too long string (closes #1198)

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -2,6 +2,7 @@
 
 ## v3.2.1
 - Fixed the issue with the unmanaged branch notification showing up after adding a branch from an external (non-IntelliJ) terminal.
+- Fixed the text overflow in VCS notifications.
 
 ## v3.2.0
 - Added a new `alt + enter` intention action to create a non-existing branch if user adds it to the machete file.

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/CheckRemoteBranchBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/CheckRemoteBranchBackgroundable.java
@@ -9,25 +9,30 @@ import com.intellij.openapi.vcs.VcsNotifier;
 import git4idea.GitBranch;
 import git4idea.repo.GitRepository;
 import lombok.SneakyThrows;
+import lombok.experimental.ExtensionMethod;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.GitMacheteException;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
+@ExtensionMethod(GitMacheteBundle.class)
 public class CheckRemoteBranchBackgroundable extends Task.Backgroundable {
 
   private final Project project;
   private final GitRepository gitRepository;
   private final String remoteBranchName;
-  private final String taskFailNotification;
+  private final String taskFailNotificationTitle;
+  private final String taskFailNotificationPrefix;
 
   public CheckRemoteBranchBackgroundable(Project project, GitRepository gitRepository, String remoteBranchName,
-      String taskFailNotification) {
+      String taskFailNotificationTitle, String taskFailNotificationPrefix) {
     super(project, getString("action.GitMachete.CheckRemoteBranchBackgroundable.task-title"));
     this.project = project;
     this.gitRepository = gitRepository;
     this.remoteBranchName = remoteBranchName;
-    this.taskFailNotification = taskFailNotification;
+    this.taskFailNotificationTitle = taskFailNotificationTitle;
+    this.taskFailNotificationPrefix = taskFailNotificationPrefix;
   }
 
   @Override
@@ -36,7 +41,8 @@ public class CheckRemoteBranchBackgroundable extends Task.Backgroundable {
   public void run(ProgressIndicator indicator) {
     GitBranch targetBranch = gitRepository.getBranches().findBranchByName(remoteBranchName);
     if (targetBranch == null) {
-      throw new GitMacheteException(getString("action.GitMachete.CheckRemoteBranchBackgroundable.notification.fail.text"));
+      throw new GitMacheteException(
+          getString("action.GitMachete.CheckRemoteBranchBackgroundable.notification.fail.text").format(remoteBranchName));
     }
   }
 
@@ -46,8 +52,7 @@ public class CheckRemoteBranchBackgroundable extends Task.Backgroundable {
     String errorMessage = error.getMessage();
     if (errorMessage != null) {
       VcsNotifier.getInstance(project).notifyError(
-          /* displayId */ null,
-          taskFailNotification, errorMessage);
+          /* displayId */ null, taskFailNotificationTitle, taskFailNotificationPrefix + errorMessage);
     }
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardMergeToParentAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardMergeToParentAction.java
@@ -72,8 +72,6 @@ public abstract class BaseFastForwardMergeToParentAction extends BaseGitMacheteR
     val mergeProps = new MergeProps(
         /* movingBranchName */ nonRootStayingBranch.getParent(),
         /* stayingBranchName */ nonRootStayingBranch);
-    FastForwardMerge.perform(project, gitRepository, mergeProps,
-        /* fetchNotificationPrefix */ "", /* insertNewlineAfterPrefix */ false);
-
+    FastForwardMerge.perform(project, gitRepository, mergeProps, /* fetchNotificationTextPrefix */ "");
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullAction.java
@@ -94,11 +94,12 @@ public abstract class BasePullAction extends BaseGitMacheteRepositoryReadyAction
 
       val isUpToDate = FetchUpToDateTimeoutStatus.isUpToDate(gitRepository);
       val fetchNotificationPrefix = isUpToDate
-          ? getNonHtmlString("action.GitMachete.BasePullAction.notification.title.no-fetch-perform")
+          ? getNonHtmlString("action.GitMachete.BasePullAction.notification.prefix.no-fetch-perform")
               .format(FETCH_ALL_UP_TO_DATE_TIMEOUT_AS_STRING)
-          : getNonHtmlString("action.GitMachete.BasePullAction.notification.title.fetch-perform");
+          : getNonHtmlString("action.GitMachete.BasePullAction.notification.prefix.fetch-perform");
+      val fetchNotificationTextPrefix = fetchNotificationPrefix + (fetchNotificationPrefix.isEmpty() ? "" : " ");
       Runnable fastForwardRunnable = () -> FastForwardMerge.perform(project, gitRepository, mergeProps,
-          fetchNotificationPrefix, /* insertNewlineAfterPrefix */ true);
+          fetchNotificationTextPrefix);
 
       if (isUpToDate) {
         fastForwardRunnable.run();

--- a/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
@@ -24,7 +24,7 @@ action.GitMachete.description.disabled.branch-is-root={0} disabled because the g
 # Backgroundables
 
 action.GitMachete.CheckRemoteBranchBackgroundable.task-title=Checking remote branch
-action.GitMachete.CheckRemoteBranchBackgroundable.notification.fail.text=The remote branch does not exist, cannot pull anymore
+action.GitMachete.CheckRemoteBranchBackgroundable.notification.fail.text=The remote branch ''{0}'' does not exist, cannot pull anymore.
 
 action.GitMachete.GitCommandUpdatingCurrentBranchBackgroundable.notification.message.view-commits=View commits
 action.GitMachete.GitCommandUpdatingCurrentBranchBackgroundable.notification.title.update-fail={0} failed
@@ -49,8 +49,9 @@ action.GitMachete.MergeCurrentBranchFastForwardOnlyBackgroundable.operation-name
 
 action.GitMachete.BaseFastForwardMergeToParentAction.description-action-name=Fast-forward merge
 action.GitMachete.BaseFastForwardMergeToParentAction.description=Fast-forward merge branch ''{1}'' to ''{0}''
-action.GitMachete.BaseFastForwardMergeToParentAction.notification.title.ff-fail=Fast-forward merge branch ''{1}'' to ''{0}'' failed.
-action.GitMachete.BaseFastForwardMergeToParentAction.notification.title.ff-success.HTML=<html>Branch <b>{1}</b> has been fast-forward merged to <b>{0}</b></html>
+action.GitMachete.BaseFastForwardMergeToParentAction.notification.title.ff-fail=Fast-forward merge failed
+action.GitMachete.BaseFastForwardMergeToParentAction.notification.text.ff-fail=Fast-forward merge branch ''{1}'' to ''{0}'' failed.
+action.GitMachete.BaseFastForwardMergeToParentAction.notification.text.ff-success=Branch ''{1}'' has been fast-forward merged to ''{0}''.
 action.GitMachete.BaseFastForwardMergeToParentAction.task-title=Fast-forward merging
 action.GitMachete.BaseFastForwardMergeToParentAction.task-subtitle=Fast-forwarding\u2026
 
@@ -81,8 +82,8 @@ action.GitMachete.BasePullAction.description-action-name=Pull (fast-forward only
 action.GitMachete.BasePullAction.notification.title.pull-fail=Pull of branch ''{0}'' failed
 action.GitMachete.BasePullAction.notification.title.pull-success.HTML=<html>Branch <b>{0}</b> has been pulled</html>
 action.GitMachete.BasePullAction.task-title=Fetching
-action.GitMachete.BasePullAction.notification.title.no-fetch-perform=No new fetch has been performed since the latest fetch happened less than {0} ago.
-action.GitMachete.BasePullAction.notification.title.fetch-perform=Fetch has been performed.
+action.GitMachete.BasePullAction.notification.prefix.no-fetch-perform=No new fetch has been performed since the latest fetch happened less than {0} ago.
+action.GitMachete.BasePullAction.notification.prefix.fetch-perform=Fetch has been performed.
 
 
 action.GitMachete.BasePushAction.action-name=_Push


### PR DESCRIPTION
The lesson from this one - keep titles short. The detailed info should be kept in the notification content.

pull non-current with fetch:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/19799111/199815233-2fa3362d-a6a7-4b11-a6d4-a572ccdafa47.png">

pull non-current without fetch:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/19799111/199815387-6e176b6c-8a9e-429e-95db-6ca768d42ac3.png">

pull non-current with fetch - fail:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/19799111/199818824-7b1fdd78-603c-46ab-b12c-94bcc5daf69a.png">

pull non-current without fetch - fail:
<img width="382" alt="image" src="https://user-images.githubusercontent.com/19799111/199819007-c36822b5-215c-47b6-9089-1717523a1166.png">


