### PR TITLE
Revamp ResetInfoDialog into a more general InfoDialog

### DIFF
--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetToRemoteAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetToRemoteAction.java
@@ -29,7 +29,7 @@ import com.virtuslab.gitmachete.backend.api.IRemoteTrackingBranchReference;
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 import com.virtuslab.gitmachete.frontend.actions.backgroundables.FetchBackgroundable;
 import com.virtuslab.gitmachete.frontend.actions.backgroundables.ResetCurrentToRemoteBackgroundable;
-import com.virtuslab.gitmachete.frontend.actions.dialogs.ResetInfoDialog;
+import com.virtuslab.gitmachete.frontend.actions.dialogs.InfoDialog;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
@@ -146,7 +146,12 @@ public abstract class BaseResetToRemoteAction extends BaseGitMacheteRepositoryRe
           remoteTrackingBranch.getName().escapeHtml4(),
           currentCommitSha);
 
-      if (!new ResetInfoDialog(project, content).showAndGet()) {
+      val resetInfoDialog = new InfoDialog(project,
+          getString("action.GitMachete.BaseResetToRemoteAction.info-dialog.title"),
+          content,
+          SHOW_RESET_INFO);
+
+      if (!resetInfoDialog.showAndGet()) {
         return;
       }
     }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/InfoDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/InfoDialog.kt
@@ -5,19 +5,23 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.Messages
 import com.intellij.ui.dsl.builder.panel
-import com.virtuslab.gitmachete.frontend.actions.base.BaseResetToRemoteAction
 import com.virtuslab.gitmachete.frontend.actions.compat.rowCompat
-import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString
 import org.checkerframework.checker.tainting.qual.Tainted
+import org.checkerframework.checker.tainting.qual.Untainted
 import java.awt.Dimension
 
-class ResetInfoDialog(project: Project, private val content: @Tainted String) :
+class InfoDialog(
+  project: Project,
+  title: @Untainted String,
+  private val content: @Tainted String,
+  propertyKey: @Untainted String
+) :
   DialogWrapper(project, /* canBeParent */ true) {
 
   init {
-    title = getString("action.GitMachete.BaseResetToRemoteAction.info-dialog.title")
+    this.title = title
     setOKButtonMnemonic('O'.code)
-    setDoNotAskOption(createDoNotAskOptionAdapter(project))
+    setDoNotAskOption(createDoNotAskOptionAdapter(project, propertyKey))
     super.init()
   }
 
@@ -30,11 +34,11 @@ class ResetInfoDialog(project: Project, private val content: @Tainted String) :
   }
 
   companion object {
-    private fun createDoNotAskOptionAdapter(project: Project) =
+    private fun createDoNotAskOptionAdapter(project: Project, propertyKey: @Untainted String) =
       object : com.intellij.openapi.ui.DoNotAskOption.Adapter() {
         override fun rememberChoice(isSelected: Boolean, exitCode: Int) {
           if (exitCode == Messages.OK && isSelected) {
-            PropertiesComponent.getInstance(project).setValue(BaseResetToRemoteAction.SHOW_RESET_INFO, false, /* defaultValue */ true)
+            PropertiesComponent.getInstance(project).setValue(propertyKey, false, /* defaultValue */ true)
           }
         }
       }


### PR DESCRIPTION
Why? 

1. because we will need a similar dialog for the traverse feature (and probably somewhere else in the future) 
2. yesNoDialog (etc) have this problem: https://github.com/VirtusLab/git-machete-intellij-plugin/issues/1299