### PR TITLE
Ensure `GitMacheteRepositorySnapshot#getManagedBranches` returns branches in the order as in .git/machete

### DIFF
--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
@@ -20,6 +20,7 @@ public interface IGitMacheteRepositorySnapshot {
   @Nullable
   IManagedBranchSnapshot getCurrentBranchIfManaged();
 
+  /** Branches are ordered as they occur in the machete file */
   List<IManagedBranchSnapshot> getManagedBranches();
 
   @Nullable

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
@@ -17,9 +17,9 @@ import com.jcabi.aspects.Loggable;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.collection.HashMap;
+import io.vavr.collection.LinkedHashMap;
 import io.vavr.collection.List;
 import io.vavr.collection.Map;
-import io.vavr.collection.Queue;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Set;
 import io.vavr.collection.TreeSet;
@@ -374,15 +374,15 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       }
     }
 
-    private Map<String, IManagedBranchSnapshot> createManagedBranchByNameMap(List<RootManagedBranchSnapshot> rootBranches) {
-      Map<String, IManagedBranchSnapshot> branchByName = HashMap.empty();
-      Queue<IManagedBranchSnapshot> queue = Queue.ofAll(rootBranches);
-      // BFS over all branches
-      while (queue.nonEmpty()) {
-        val headAndTail = queue.dequeue();
-        val branch = headAndTail._1;
+    private LinkedHashMap<String, IManagedBranchSnapshot> createManagedBranchByNameMap(
+        List<RootManagedBranchSnapshot> rootBranches) {
+      LinkedHashMap<String, IManagedBranchSnapshot> branchByName = LinkedHashMap.empty();
+      List<IManagedBranchSnapshot> stack = List.ofAll(rootBranches);
+      // Non-recursive DFS over all branches
+      while (stack.nonEmpty()) {
+        val branch = stack.head();
         branchByName = branchByName.put(branch.getName(), branch);
-        queue = headAndTail._2.appendAll(branch.getChildren());
+        stack = stack.tail().prependAll(branch.getChildren());
       }
       return branchByName;
     }

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepository.java
@@ -374,11 +374,12 @@ public class GitMacheteRepository implements IGitMacheteRepository {
       }
     }
 
+    // Using LinkedHashMap to retain the original order of branches.
     private LinkedHashMap<String, IManagedBranchSnapshot> createManagedBranchByNameMap(
         List<RootManagedBranchSnapshot> rootBranches) {
       LinkedHashMap<String, IManagedBranchSnapshot> branchByName = LinkedHashMap.empty();
       List<IManagedBranchSnapshot> stack = List.ofAll(rootBranches);
-      // Non-recursive DFS over all branches
+      // A non-recursive DFS over all branches
       while (stack.nonEmpty()) {
         val branch = stack.head();
         branchByName = branchByName.put(branch.getName(), branch);

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
@@ -1,7 +1,7 @@
 package com.virtuslab.gitmachete.backend.impl;
 
+import io.vavr.collection.LinkedHashMap;
 import io.vavr.collection.List;
-import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class GitMacheteRepositorySnapshot implements IGitMacheteRepositorySnapsh
 
   private final @Nullable IManagedBranchSnapshot currentBranchIfManaged;
 
-  private final Map<String, IManagedBranchSnapshot> managedBranchByName;
+  private final LinkedHashMap<String, IManagedBranchSnapshot> managedBranchByName;
 
   @Getter
   private final Set<String> duplicatedBranchNames;

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
@@ -26,6 +26,7 @@ public class GitMacheteRepositorySnapshot implements IGitMacheteRepositorySnapsh
 
   private final @Nullable IManagedBranchSnapshot currentBranchIfManaged;
 
+  // Using LinkedHashMap to retain the original order of branches.
   private final LinkedHashMap<String, IManagedBranchSnapshot> managedBranchByName;
 
   @Getter

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -58,7 +58,6 @@
             <property name="illegalClasses" value="org.jetbrains.annotations.NotNull, org.jetbrains.annotations.Nullable"/>
         </module>
         <module name="IllegalThrows"/>
-        <module name="IllegalType"/>
         <module name="InnerAssignment"/>
         <module name="LeftCurly">
             <property name="tokens"

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -19,6 +19,7 @@ object UITestSuite extends UISuite {}
 
 @RunWith(classOf[JUnit4])
 class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH_SINGLE_REMOTE) {
+
   import UITestSuite._
 
   private val project = intelliJ.project
@@ -76,15 +77,15 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
     // Non-existent branches should be skipped while causing no error (only a low-severity notification).
     Assert.assertEquals(
       Seq(
+        "develop",
         "allow-ownership-link",
         "build-chain",
+        "update-icons",
         "call-ws",
-        "develop",
-        "hotfix/add-trigger",
         "master",
-        "update-icons"
+        "hotfix/add-trigger"
       ),
-      managedBranches.toSeq.sorted
+      managedBranches.toSeq
     )
     project.toggleListingCommits()
     var branchAndCommitRowsCount = project.refreshModelAndGetRowCount()
@@ -118,11 +119,11 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
       Seq(
         "allow-ownership-link",
         "build-chain",
-        "hotfix/add-trigger",
+        "update-icons",
         "master",
-        "update-icons"
+        "hotfix/add-trigger"
       ),
-      managedBranchesAfterSlideOut.toSeq.sorted
+      managedBranchesAfterSlideOut.toSeq
     )
     branchAndCommitRowsCount = project.refreshModelAndGetRowCount()
     // 5 branch rows (`call-ws` is also no longer there) + 7 commit rows
@@ -242,24 +243,24 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
     var managedBranches = project.refreshModelAndGetManagedBranchesAndCommits()
     Assert.assertEquals(
       Seq(
-        "1st round of fixes",
-        "1st round of fixes",
-        "Allow ownership links",
-        "Build arbitrarily long chains",
-        "Call web service",
-        "HOTFIX Add the trigger",
-        "HOTFIX Add the trigger - fixes",
-        "Use new icons",
-        "Use new icons",
-        "allow-ownership-link",
-        "build-chain",
-        "call-ws",
         "develop",
-        "hotfix/add-trigger",
+        "Allow ownership links",
+        "allow-ownership-link",
+        "Use new icons",
+        "1st round of fixes",
+        "update-icons",
+        "Build arbitrarily long chains",
+        "Use new icons",
+        "1st round of fixes",
+        "build-chain",
+        "Call web service",
+        "call-ws",
         "master",
-        "update-icons"
+        "HOTFIX Add the trigger - fixes",
+        "HOTFIX Add the trigger",
+        "hotfix/add-trigger"
       ),
-      managedBranches.toSeq.sorted
+      managedBranches.toSeq
     )
 
     Assert.assertEquals(16, managedBranches.length)
@@ -271,23 +272,23 @@ class UITestSuite extends BaseGitRepositoryBackedIntegrationTestSuite(SETUP_WITH
     managedBranches = project.refreshModelAndGetManagedBranchesAndCommits()
     Assert.assertEquals(
       Seq(
-        "1st round of fixes",
-        "1st round of fixes",
-        "Allow ownership links",
-        "Build arbitrarily long chains",
-        "Call web service",
-        "HOTFIX Add the trigger",
-        "Use new icons",
-        "Use new icons",
-        "allow-ownership-link",
-        "build-chain",
-        "call-ws",
         "develop",
-        "hotfix/add-trigger",
+        "Allow ownership links",
+        "allow-ownership-link",
+        "Use new icons",
+        "1st round of fixes",
+        "update-icons",
+        "Build arbitrarily long chains",
+        "Use new icons",
+        "1st round of fixes",
+        "build-chain",
+        "Call web service",
+        "call-ws",
         "master",
-        "update-icons"
+        "HOTFIX Add the trigger",
+        "hotfix/add-trigger"
       ),
-      managedBranches.toSeq.sorted
+      managedBranches.toSeq
     )
 
     Assert.assertEquals(15, managedBranches.length)


### PR DESCRIPTION
1️⃣ 3️⃣ 3️⃣ 7️⃣ 