### PR TITLE
Move Discover action to the end of the toolbar

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## v3.3.0
-- Improved performance of the plugin on large repos with 100,000s of commits in history.
 - Added the interactive traverse feature.
+- Improved performance of the plugin on large repos with 100,000s of commits in history.
+- Moved Discover action to near the end of the toolbar.
 
 ## v3.2.2
 - Improve CI build stability.

--- a/scripts/prohibit-trailing-whitespace
+++ b/scripts/prohibit-trailing-whitespace
@@ -5,6 +5,6 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/utils.sh
 
-if git grep -EIn '\s+$' -- ':!gradlew'; then
+if git grep -EIn ' +$' -- ':!gradlew'; then
   die 'The above lines contain trailing whitespace, please tidy up'
 fi

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -141,12 +141,6 @@
                 <override-text place="GitMacheteToolbar"/>
             </action>
 
-            <action id="GitMachete.DiscoverAction"
-                    class="com.virtuslab.gitmachete.frontend.actions.toolbar.DiscoverAction"
-                    icon="com.virtuslab.gitmachete.frontend.icons.MacheteIcons.DISCOVER">
-                <override-text place="GitMacheteToolbar"/>
-            </action>
-
             <separator/>
 
             <action id="GitMachete.FetchAllRemotesAction"
@@ -212,6 +206,12 @@
             </action>
 
             <separator/>
+
+            <action id="GitMachete.DiscoverAction"
+                    class="com.virtuslab.gitmachete.frontend.actions.toolbar.DiscoverAction"
+                    icon="com.virtuslab.gitmachete.frontend.icons.MacheteIcons.DISCOVER">
+                <override-text place="GitMacheteToolbar"/>
+            </action>
 
             <action id="GitMachete.HelpAction"
                     class="com.virtuslab.gitmachete.frontend.actions.toolbar.HelpAction"


### PR DESCRIPTION
_Thots?..._ I'd really rather have more day-to-day actions visible, at the expense of Discover... and also I'd argue that if someone might have a worse UX due to weaker accessibility of Discover, then they'll have an even worse UX due to even weaker accessibility of Help (❓)

<img width="361" alt="image" src="https://user-images.githubusercontent.com/3383210/209442605-277bddf3-e890-49e7-bb2d-317754298086.png">
