### PR TITLE
Let ide-probe sift out more types of unnamed background tasks

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # see https://docs.gradle.org/current/samples/sample_convention_plugins.html#things_to_note
 [versions]
 checker = "3.28.0"
-ideProbe = "0.50.0"
+ideProbe = "0.51.0"
 powerMock = "2.0.9"
 
 [libraries]

--- a/scripts/prohibit-trailing-whitespace
+++ b/scripts/prohibit-trailing-whitespace
@@ -5,6 +5,7 @@ set -e -o pipefail -u
 self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/utils.sh
 
-if git grep -EIn '\s+$' -- ':!gradlew'; then
+# `git grep` since 2.39.0 apparently no longer supports `\s` for whitespace, let's just look for trailing spaces.
+if git grep -EIn ' +$' -- ':!gradlew'; then
   die 'The above lines contain trailing whitespace, please tidy up'
 fi


### PR DESCRIPTION
See https://github.com/VirtusLab/ide-probe/pull/334

Before:

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/3383210/209658463-a13c5f83-39f1-4aaa-8c70-be01faea56ea.png">

After:

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/3383210/209658378-3d6866ce-2bf8-4b7c-94c7-54d7e78d140f.png">
