### PR TITLE
Specify the location of `intellij-versions.properties` relative to `rootDir` in Gradle configs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ val jetbrainsMarketplaceToken: String? by extra(System.getenv("JETBRAINS_MARKETP
 
 val intellijVersions by extra(
   IntellijVersions.from(
-    intellijVersionsProperties = PropertiesHelper.getProperties(File("intellij-versions.properties")),
+    intellijVersionsProperties = PropertiesHelper.getProperties(rootDir.resolve("intellij-versions.properties")),
     overrideBuildTarget = project.properties["overrideBuildTarget"] as String?
   )
 )

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UpdateIntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UpdateIntellijVersions.kt
@@ -8,7 +8,6 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.provideDelegate
 import org.jsoup.Jsoup
-import java.io.File
 
 open class UpdateIntellijVersions : DefaultTask() {
 
@@ -105,7 +104,7 @@ open class UpdateIntellijVersions : DefaultTask() {
     }
 
     if (originalVersions != updatedVersions) {
-      PropertiesHelper.storeProperties(updatedVersions.toProperties(), File("intellij-versions.properties"))
+      PropertiesHelper.storeProperties(updatedVersions.toProperties(), project.rootDir.resolve("intellij-versions.properties"))
     }
   }
 }


### PR DESCRIPTION
To prevent a spurious error in IntelliJ where Gradle can't locate `intellij-versions.properties` ☹️ 