### PR TITLE
Remove redundant calls of queueRepositoryUpdateAndModelRefresh (closes #1465)

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -3,6 +3,7 @@
 ## v3.5.0
 - Dropped explicit refresh action in favor of automatic updates.
 - Changed traverse action in the toolbar, so that the traverses start from the first branch instead of the current branch.
+- Improved stability in the scope of automatic refreshes.
 
 ## v3.4.0
 - Added Branch Rename action.

--- a/config/checker/git4idea.astub
+++ b/config/checker/git4idea.astub
@@ -17,6 +17,8 @@ class GitVcs {
 package git4idea.branch;
 
 interface GitBrancher {
+  void checkout(String reference, boolean detach, List<? extends GitRepository> repositories, @UI Runnable callInAwtLater);
+
   void deleteBranches(Map<String, List<? extends GitRepository>> branchesToContainingRepositories, @UI Runnable callInAwtAfterExecution);
 }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/OverrideForkPointBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/OverrideForkPointBackgroundable.java
@@ -55,6 +55,7 @@ public class OverrideForkPointBackgroundable extends Task.Backgroundable {
       setOverrideForkPointConfigValues(myProject, root, branch.getName(), forkPoint, branch.getPointedCommit());
     }
 
+    // required since the change of .git/config is not considered as a change to VCS (and detected by the listener)
     graphTable.queueRepositoryUpdateAndModelRefresh();
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBelowAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideInBelowAction.java
@@ -141,12 +141,7 @@ public abstract class BaseSlideInBelowAction extends BaseGitMacheteRepositoryRea
         branchLayoutWriter,
         preSlideInRunnable,
         slideInOptions,
-        parentName) {
-      @Override
-      public void onFinished() {
-        getGraphTable(anActionEvent).queueRepositoryUpdateAndModelRefresh();
-      }
-    }.queue();
+        parentName).queue();
   }
 
   @ContinuesInBackground

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSlideOutAction.java
@@ -74,8 +74,7 @@ public abstract class BaseSlideOutAction extends BaseGitMacheteRepositoryReadyAc
       log().debug("selectedGitRepository is null");
     } else {
       val currentMacheteBranchIfManaged = getCurrentMacheteBranchIfManaged(anActionEvent);
-      val graphTable = getGraphTable(anActionEvent);
-      new SlideOut(branchToSlideOut, selectedGitRepository, currentMacheteBranchIfManaged, branchLayout, graphTable).run();
+      new SlideOut(branchToSlideOut, selectedGitRepository, currentMacheteBranchIfManaged, branchLayout).run();
     }
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/SlideInUnmanagedBelowAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/SlideInUnmanagedBelowAction.java
@@ -68,12 +68,7 @@ public class SlideInUnmanagedBelowAction extends BaseGitMacheteRepositoryReadyAc
           branchLayoutWriter,
           preSlideInRunnable,
           slideInOptions,
-          parentName) {
-        @Override
-        public void onFinished() {
-          getGraphTable(anActionEvent).queueRepositoryUpdateAndModelRefresh();
-        }
-      }.queue();
+          parentName).queue();
     } else {
 
       new SlideInRootBackgroundable(
@@ -81,12 +76,7 @@ public class SlideInUnmanagedBelowAction extends BaseGitMacheteRepositoryReadyAc
           branchLayout,
           branchLayoutWriter,
           preSlideInRunnable,
-          slideInOptions) {
-        @Override
-        public void onFinished() {
-          getGraphTable(anActionEvent).queueRepositoryUpdateAndModelRefresh();
-        }
-      }.queue();
+          slideInOptions).queue();
     }
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/SlideOut.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/SlideOut.java
@@ -33,7 +33,6 @@ import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot;
 import com.virtuslab.gitmachete.frontend.actions.dialogs.DeleteBranchOnSlideOutSuggestionDialog;
 import com.virtuslab.gitmachete.frontend.file.MacheteFileWriter;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
-import com.virtuslab.gitmachete.frontend.ui.api.table.BaseEnhancedGraphTable;
 import com.virtuslab.qual.async.ContinuesInBackground;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
@@ -46,21 +45,18 @@ public class SlideOut {
   private final @Nullable String currentBranchNameIfManaged;
   private final BranchLayout branchLayout;
   private final GitRepository gitRepository;
-  private final BaseEnhancedGraphTable graphTable;
 
   public static final String DELETE_LOCAL_BRANCH_ON_SLIDE_OUT_GIT_CONFIG_KEY = "machete.slideOut.deleteLocalBranch";
 
   public SlideOut(IManagedBranchSnapshot branchToSlideOut,
       GitRepository gitRepository,
       @Nullable IManagedBranchSnapshot currentBranchNameIfManaged,
-      BranchLayout branchLayout,
-      BaseEnhancedGraphTable graphTable) {
+      BranchLayout branchLayout) {
     this.project = gitRepository.getProject();
     this.branchToSlideOutName = branchToSlideOut.getName();
     this.currentBranchNameIfManaged = currentBranchNameIfManaged != null ? currentBranchNameIfManaged.getName() : null;
     this.branchLayout = branchLayout;
     this.gitRepository = gitRepository;
-    this.graphTable = graphTable;
 
     LOG.debug(() -> "Entering: branchToSlideOut = ${branchToSlideOutName}");
     LOG.debug("Refreshing repository state");

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/SlideOut.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/SlideOut.java
@@ -120,15 +120,14 @@ public class SlideOut {
   private void handleBranchDeletionDecision(String branchName, boolean shouldDelete, @UI Runnable doInUIThreadWhenReady) {
     slideOutBranch(branchName);
     if (shouldDelete) {
-      graphTable.queueRepositoryUpdateAndModelRefresh(
-          () -> GitBrancher.getInstance(project).deleteBranches(Collections.singletonMap(branchName,
-              Collections.singletonList(gitRepository)), () -> {
-                VcsNotifier.getInstance(project).notifySuccess(/* displayId */ null,
-                    /* title */ "",
-                    getString("action.GitMachete.BaseSlideOutAction.notification.title.slide-out-success.with-delete.HTML").fmt(
-                        branchName));
-                doInUIThreadWhenReady.run();
-              }));
+      GitBrancher.getInstance(project).deleteBranches(Collections.singletonMap(branchName,
+          Collections.singletonList(gitRepository)), () -> {
+            VcsNotifier.getInstance(project).notifySuccess(/* displayId */ null,
+                /* title */ "",
+                getString("action.GitMachete.BaseSlideOutAction.notification.title.slide-out-success.with-delete.HTML").fmt(
+                    branchName));
+            doInUIThreadWhenReady.run();
+          });
     } else {
       VcsNotifier.getInstance(project).notifySuccess(/* displayId */ null,
           /* title */ "",

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
@@ -151,7 +151,6 @@ public class DiscoverAction extends BaseProjectDependentAction {
       @Override
       @UIEffect
       public void onSuccess() {
-        baseEnhancedGraphTable.queueRepositoryUpdateAndModelRefresh();
         VfsUtil.markDirtyAndRefresh(/* async */ false, /* recursive */ true, /* reloadChildren */ false,
             ProjectRootManager.getInstance(project).getContentRoots());
         postWriteRunnable.run();

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/CheckoutAndExecute.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/CheckoutAndExecute.java
@@ -10,7 +10,6 @@ import lombok.CustomLog;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UI;
 
-import com.virtuslab.gitmachete.frontend.ui.api.table.BaseEnhancedGraphTable;
 import com.virtuslab.qual.async.ContinuesInBackground;
 
 @CustomLog
@@ -18,7 +17,7 @@ final class CheckoutAndExecute {
   private CheckoutAndExecute() {}
 
   @ContinuesInBackground
-  static void checkoutAndExecuteOnUIThread(GitRepository gitRepository, BaseEnhancedGraphTable graphTable, String branchName,
+  static void checkoutAndExecuteOnUIThread(GitRepository gitRepository, String branchName,
       @UI Runnable doOnUIThreadAfterCheckout) {
     val currentBranch = gitRepository.getCurrentBranch();
     if (currentBranch != null && currentBranch.getName().equals(branchName)) {
@@ -26,11 +25,10 @@ final class CheckoutAndExecute {
     } else {
       LOG.debug(() -> "Queuing '${branchName}' branch checkout background task");
 
-      Runnable repositoryRefreshRunnable = () -> graphTable.queueRepositoryUpdateAndModelRefresh(doOnUIThreadAfterCheckout);
       val gitBrancher = GitBrancher.getInstance(gitRepository.getProject());
       val repositories = Collections.singletonList(gitRepository);
 
-      gitBrancher.checkout(/* reference */ branchName, /* detach */ false, repositories, repositoryRefreshRunnable);
+      gitBrancher.checkout(/* reference */ branchName, /* detach */ false, repositories, doOnUIThreadAfterCheckout);
     }
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/TraverseSyncToParent.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/TraverseSyncToParent.java
@@ -85,7 +85,7 @@ public class TraverseSyncToParent {
             syncToRemoteRunnable);
         // Note that checking out the branch to be slid out has the unfortunate side effect
         // that we won't suggest deleting the branch after the slide out.
-        checkoutAndExecuteOnUIThread(gitRepository, graphTable, branch.getName(), slideOut);
+        checkoutAndExecuteOnUIThread(gitRepository, branch.getName(), slideOut);
         break;
 
       case InSyncButForkPointOff :
@@ -95,7 +95,7 @@ public class TraverseSyncToParent {
         } else {
           @UI Runnable rebase = () -> handleOutOfSyncOrInSyncButForkPointOff(repositorySnapshot, gitMacheteBranch.asNonRoot(),
               syncToRemoteRunnable);
-          checkoutAndExecuteOnUIThread(gitRepository, graphTable, branch.getName(), rebase);
+          checkoutAndExecuteOnUIThread(gitRepository, branch.getName(), rebase);
         }
         break;
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/TraverseSyncToParent.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/TraverseSyncToParent.java
@@ -125,7 +125,7 @@ public class TraverseSyncToParent {
         // For a branch merged to its parent, we're not syncing to remote.
         // Let's just go straight to the next branch.
         Runnable doInUIThreadWhenReady = () -> graphTable.queueRepositoryUpdateAndModelRefresh(traverseNextEntry);
-        new SlideOut(managedBranch, gitRepository, currentBranchIfManaged, branchLayout, graphTable).run(doInUIThreadWhenReady);
+        new SlideOut(managedBranch, gitRepository, currentBranchIfManaged, branchLayout).run(doInUIThreadWhenReady);
         break;
 
       case NO :

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/TraverseSyncToRemote.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/TraverseSyncToRemote.java
@@ -98,27 +98,27 @@ public class TraverseSyncToRemote {
 
       case Untracked :
         @UI Runnable pushUntracked = () -> handleUntracked(gitMacheteBranch, localBranch);
-        checkoutAndExecuteOnUIThread(gitRepository, graphTable, gitMacheteBranch.getName(), pushUntracked);
+        checkoutAndExecuteOnUIThread(gitRepository, gitMacheteBranch.getName(), pushUntracked);
         break;
 
       case AheadOfRemote :
         @UI Runnable pushAheadOfRemote = () -> handleAheadOfRemote(gitMacheteBranch, localBranch);
-        checkoutAndExecuteOnUIThread(gitRepository, graphTable, gitMacheteBranch.getName(), pushAheadOfRemote);
+        checkoutAndExecuteOnUIThread(gitRepository, gitMacheteBranch.getName(), pushAheadOfRemote);
         break;
 
       case DivergedFromAndNewerThanRemote :
         @UI Runnable pushForceDiverged = () -> handleDivergedFromAndNewerThanRemote(gitMacheteBranch, localBranch);
-        checkoutAndExecuteOnUIThread(gitRepository, graphTable, gitMacheteBranch.getName(), pushForceDiverged);
+        checkoutAndExecuteOnUIThread(gitRepository, gitMacheteBranch.getName(), pushForceDiverged);
         break;
 
       case DivergedFromAndOlderThanRemote :
         @UI Runnable resetToRemote = () -> handleDivergedFromAndOlderThanRemote(gitMacheteBranch);
-        checkoutAndExecuteOnUIThread(gitRepository, graphTable, gitMacheteBranch.getName(), resetToRemote);
+        checkoutAndExecuteOnUIThread(gitRepository, gitMacheteBranch.getName(), resetToRemote);
         break;
 
       case BehindRemote :
         @UI Runnable pullBehindRemote = () -> handleBehindRemote(gitMacheteBranch);
-        checkoutAndExecuteOnUIThread(gitRepository, graphTable, gitMacheteBranch.getName(), pullBehindRemote);
+        checkoutAndExecuteOnUIThread(gitRepository, gitMacheteBranch.getName(), pullBehindRemote);
         break;
 
       default :

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -303,6 +303,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
         mostRecentlyCheckedOutBranch = repositoryCurrentBranchName;
       }
     }
+    // required to indicate the currently checked out branch after a checkout
     queueRepositoryUpdateAndModelRefresh();
   }
 
@@ -450,7 +451,7 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
       @UI Runnable doOnUIThreadWhenReady) {
     return (IGitMacheteRepositorySnapshot repositorySnapshot) -> ModalityUiUtil.invokeLaterIfNeeded(NON_MODAL, () -> {
       gitMacheteRepositorySnapshot = repositorySnapshot;
-      queueRepositoryUpdateAndModelRefresh(doOnUIThreadWhenReady);
+      doOnUIThreadWhenReady.run();
 
       val notifier = VcsNotifier.getInstance(project);
       val notification = VcsNotifier.STANDARD_NOTIFICATION.createNotification(


### PR DESCRIPTION
Tested so far:
- [x] discover
- [x] slide in (from base slide in)
- [x] slide in (from slide in unmanaged root) 
- [x] slide in (from slide in unmanaged non-root)
- [x] slide out 
- [x] traverse - but not very meticulously 