### PR TITLE
Fix open machete file action in the case missing machete file

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -4,6 +4,7 @@
 - Dropped explicit refresh action in favor of automatic updates.
 - Changed traverse action in the toolbar, so that the traverses start from the first branch instead of the current branch.
 - Improved stability in the scope of automatic refreshes.
+- Fixed an issue with open machete file action called when the file does not exist.
 
 ## v3.4.0
 - Added Branch Rename action.

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
@@ -1,13 +1,13 @@
 package com.virtuslab.gitmachete.frontend.actions.toolbar;
 
 import static com.intellij.openapi.application.ModalityState.NON_MODAL;
+import static com.virtuslab.gitmachete.frontend.actions.toolbar.OpenMacheteFileAction.openMacheteFile;
 import static com.virtuslab.gitmachete.frontend.common.WriteActionUtils.blockingRunWriteActionOnUIThread;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
-import com.intellij.ide.actions.OpenFileAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -107,21 +107,6 @@ public class DiscoverAction extends BaseProjectDependentAction {
     return repositorySnapshot -> saveDiscoveredLayout(repositorySnapshot,
         gitRepository.getMacheteFilePath(), gitRepository.getProject(),
         branchLayoutWriter, () -> openMacheteFile(gitRepository));
-  }
-
-  @UIEffect
-  private static void openMacheteFile(GitRepository gitRepository) {
-    val project = gitRepository.getProject();
-    val file = gitRepository.getMacheteFile();
-    if (file != null) {
-      OpenFileAction.openFile(file, project);
-    } else {
-      VcsNotifier.getInstance(project).notifyError(
-          /* displayId */ null,
-          /* title */ getString("action.GitMachete.OpenMacheteFileAction.notification.title.machete-file-not-found"),
-          /* message */ getString("action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found")
-              .fmt(gitRepository.getRoot().getPath()));
-    }
   }
 
   @ContinuesInBackground

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
@@ -66,6 +66,10 @@ public class OpenMacheteFileAction extends BaseProjectDependentAction {
           /* message */ getString("action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found")
               .fmt(gitDir.getPath()),
           NotificationType.ERROR);
+      // Note there is no `.expire()` call, so the action remains available as long as the notification.
+      // It is troublesome to track the notification and cover all cases when it shall be expired.
+      // However, the discover action does not any changes directly; a dialog appears with options to accept or cancel.
+      // Hence, there is no much harm in leaving this notification without the expiration.
       errorWithDiscover.addAction(NotificationAction
           .createSimple(getString("action.GitMachete.DiscoverAction.GitMacheteToolbar.text"),
               () -> ActionManager.getInstance().getAction(DiscoverAction.class.getSimpleName())

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
@@ -4,11 +4,15 @@ import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle
 
 import com.intellij.dvcs.DvcsUtil;
 import com.intellij.ide.actions.OpenFileAction;
+import com.intellij.notification.NotificationAction;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.vcs.VcsNotifier;
 import git4idea.GitUtil;
 import git4idea.config.GitVcsSettings;
+import git4idea.repo.GitRepository;
 import io.vavr.control.Try;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.CustomLog;
@@ -36,9 +40,9 @@ public class OpenMacheteFileAction extends BaseProjectDependentAction {
 
     // When selected Git repository is empty (due to e.g. unopened Git Machete tab)
     // an attempt to guess current repository based on presently opened file
-    val selectedGitRepo = getSelectedGitRepository(anActionEvent);
-    val repo = selectedGitRepo != null
-        ? selectedGitRepo
+    val gitRepository = getSelectedGitRepository(anActionEvent);
+    val repo = gitRepository != null
+        ? gitRepository
         : DvcsUtil.guessCurrentRepositoryQuick(project,
             GitUtil.getRepositoryManager(project),
             GitVcsSettings.getInstance(project).getRecentRootPath());
@@ -57,10 +61,18 @@ public class OpenMacheteFileAction extends BaseProjectDependentAction {
         .getOrNull();
 
     if (macheteFile == null) {
-      VcsNotifier.getInstance(project).notifyError(/* displayId */ null,
+      val errorWithDiscover = VcsNotifier.STANDARD_NOTIFICATION.createNotification(
           /* title */ getString("action.GitMachete.OpenMacheteFileAction.notification.title.machete-file-not-found"),
           /* message */ getString("action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found")
-              .fmt(gitDir.getPath()));
+              .fmt(gitDir.getPath()),
+          NotificationType.ERROR);
+      errorWithDiscover.addAction(NotificationAction
+          .createSimple(getString("action.GitMachete.DiscoverAction.GitMacheteToolbar.text"),
+              () -> ActionManager.getInstance().getAction(DiscoverAction.class.getSimpleName())
+                  .actionPerformed(anActionEvent)));
+
+      VcsNotifier.getInstance(project).notify(errorWithDiscover);
+
     } else {
       if (macheteFile.isDirectory()) {
         VcsNotifier.getInstance(project).notifyError(/* displayId */ null,
@@ -69,6 +81,21 @@ public class OpenMacheteFileAction extends BaseProjectDependentAction {
       }
 
       OpenFileAction.openFile(macheteFile, project);
+    }
+  }
+
+  @UIEffect
+  public static void openMacheteFile(GitRepository gitRepository) {
+    val project = gitRepository.getProject();
+    val file = gitRepository.getMacheteFile();
+    if (file != null) {
+      OpenFileAction.openFile(file, project);
+    } else {
+      VcsNotifier.getInstance(project).notifyError(
+          /* displayId */ null,
+          /* title */ getString("action.GitMachete.OpenMacheteFileAction.notification.title.machete-file-not-found"),
+          /* message */ getString("action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found")
+              .fmt(gitRepository.getRoot().getPath()));
     }
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/OpenMacheteFileAction.java
@@ -56,8 +56,6 @@ public class OpenMacheteFileAction extends BaseProjectDependentAction {
             /* message */ getString("action.GitMachete.OpenMacheteFileAction.notification.title.cannot-open"))))
         .getOrNull();
 
-    getGraphTable(anActionEvent).queueRepositoryUpdateAndModelRefresh();
-
     if (macheteFile == null) {
       VcsNotifier.getInstance(project).notifyError(/* displayId */ null,
           /* title */ getString("action.GitMachete.OpenMacheteFileAction.notification.title.machete-file-not-found"),

--- a/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/resourcebundles/src/main/resources/GitMacheteBundle.properties
@@ -397,7 +397,7 @@ action.GitMachete.OpenMacheteFileAction.description=Open machete file
 action.GitMachete.OpenMacheteFileAction.notification.title.cannot-open=Failed to open machete file
 action.GitMachete.OpenMacheteFileAction.notification.title.same-name-dir-exists=Cannot create file 'machete': Directory with the same name exists
 action.GitMachete.OpenMacheteFileAction.notification.title.machete-file-not-found=Machete file has not been found
-action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found=Could not find machete file under the specified root ({0})
+action.GitMachete.OpenMacheteFileAction.notification.message.machete-file-not-found=Could not find machete file under the specified root ({0}).
 
 
 action.GitMachete.OverrideForkPointOfCurrentAction.text=Git Machete: Override Fork Point of Current Branch\u2026


### PR DESCRIPTION
Steps to reproduce:

1. have git machete tab closed 
2. remove machete file
3. call `open machete file` from the find action dialog

result:
error - machete file not found
notification - branch layout discovered

expected: 
tbd 