### PR TITLE
Add regression test for #1298 (unwanted `LOG.error(..., e)` calls from JGit)

### DIFF
--- a/branchLayout/impl/build.gradle.kts
+++ b/branchLayout/impl/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
 junit()
 lombok()
 slf4jLambdaApi()
-slf4jTestImpl()
+slf4jSimpleTest()
 vavr()

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
@@ -185,7 +185,13 @@ fun Project.slf4jLambdaApi() {
   }
 }
 
-fun Project.slf4jTestImpl() {
+fun Project.slf4jMock() {
+  dependencies {
+    "testImplementation"(lib("slf4j-mock"))
+  }
+}
+
+fun Project.slf4jSimpleTest() {
   // We only need to provide an SLF4J implementation in the contexts which depend on the plugin
   // but don't depend on IntelliJ.
   // In our case, that's solely the tests of certain backend modules.

--- a/gitCore/jGit/build.gradle.kts
+++ b/gitCore/jGit/build.gradle.kts
@@ -10,7 +10,7 @@ jgit()
 junit()
 lombok()
 slf4jLambdaApi()
-slf4jTestImpl()
+slf4jMock()
 vavr()
 
 applyAliasingChecker()

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
@@ -141,7 +141,8 @@ public final class GitCoreRepository implements IGitCoreRepository {
     }
   }
 
-  private boolean isBranchPresent(String branchFullName) {
+  // Public only for the sake of tests, not a part of the interface
+  public boolean isBranchPresent(String branchFullName) {
     // If '/' characters exist in the branch name, then loop-based testing is needed in order to avoid
     // possible IDE errors, which could appear in scenarios similar to the one explained below.
     // - If a branch 'foo' exists locally (which means that .git/refs/heads/foo file exists in the repository)
@@ -179,7 +180,6 @@ public final class GitCoreRepository implements IGitCoreRepository {
     }
 
     try {
-      // test below is executed for the actual branch name
       return jgitRepoForMainGitDir.resolve(branchFullName) != null;
     } catch (IOException e) {
       return false;

--- a/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/integration/GitCoreRepositoryTest.java
+++ b/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/integration/GitCoreRepositoryTest.java
@@ -1,25 +1,56 @@
 package com.virtuslab.gitcore.impl.jgit.integration;
 
 import static com.virtuslab.gitmachete.testcommon.SetupScripts.SETUP_WITH_SINGLE_REMOTE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import lombok.SneakyThrows;
 import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.simplify4u.slf4jmock.LoggerMock;
+import org.slf4j.Logger;
 
 import com.virtuslab.gitcore.impl.jgit.GitCoreRepository;
 import com.virtuslab.gitmachete.testcommon.TestGitRepository;
 
 public class GitCoreRepositoryTest {
 
-  // See https://github.com/VirtusLab/git-machete-intellij-plugin/issues/1029 for the origin of this test
-  @Test
-  public void shouldContainExceptionsInsideOptionReturningMethods() throws Exception {
+  private GitCoreRepository gitCoreRepository;
+
+  @BeforeEach
+  @SneakyThrows
+  public void setUp() {
     val repo = new TestGitRepository(SETUP_WITH_SINGLE_REMOTE);
 
-    val gitCoreRepository = new GitCoreRepository(repo.rootDirectoryPath, repo.mainGitDirectoryPath,
-        repo.worktreeGitDirectoryPath);
+    gitCoreRepository = new GitCoreRepository(repo.rootDirectoryPath, repo.mainGitDirectoryPath, repo.worktreeGitDirectoryPath);
+  }
+
+  // See https://github.com/VirtusLab/git-machete-intellij-plugin/issues/1029 for the origin of this test
+  @Test
+  @SneakyThrows
+  public void shouldContainExceptionsInsideOptionReturningMethods() {
     // Let's check against a non-existent commit.
     // No exception should be thrown, just a null returned.
     assertNull(gitCoreRepository.parseRevision("0".repeat(40)));
+  }
+
+  // See https://github.com/VirtusLab/git-machete-intellij-plugin/issues/1298 for the origin of this test
+  @Test
+  public void shouldNeverLeadToLogErrorCalledWithThrowable() {
+    assertTrue(gitCoreRepository.isBranchPresent("refs/heads/develop"));
+
+    Logger logger = mock(Logger.class);
+    LoggerMock.setMock(org.eclipse.jgit.internal.storage.file.FileSnapshot.class, logger);
+
+    assertFalse(gitCoreRepository.isBranchPresent("refs/heads/develop/something-else"));
+
+    verify(logger, never()).error(anyString(), any(Throwable.class));
   }
 }

--- a/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/integration/GitCoreRepositoryTest.java
+++ b/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/integration/GitCoreRepositoryTest.java
@@ -51,6 +51,15 @@ public class GitCoreRepositoryTest {
 
     assertFalse(gitCoreRepository.isBranchPresent("refs/heads/develop/something-else"));
 
+    // In test setup, a call to `LOG.error(String, Throwable)` doesn't crash the test
+    // (and we aren't able to simply catch an exception to detect whether such a call took place).
+    // In fact, with slf4j-simple (rather than slf4j-mock) on classpath, we'll just see stack trace printed out
+    // (unless stderr is suppressed, which is the default when running tests under Gradle).
+    // In IntelliJ, however, the situation is different, as IntelliJ provides an SLF4J implementation
+    // which opens an error notification for each `LOG.error(String, Throwable)` (but not `LOG.error(String)`) call.
+    // In this particular case, we want to avoid an `LOG.error(String, Throwable)` call in FileSnapshot c'tor
+    // ending up in an user-visible, confusing error notification.
+    // See the issue and PR #1304 for more details.
     verify(logger, never()).error(anyString(), any(Throwable.class));
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ junit-platform-launcher = "org.junit.platform:junit-platform-launcher:1.9.2"
 lombok = "org.projectlombok:lombok:1.18.24"
 mockito = "org.mockito:mockito-junit-jupiter:5.1.1"
 slf4j-lambda = "kr.pe.kwonnam.slf4j-lambda:slf4j-lambda-core:0.1"
+slf4j-mock = "org.simplify4u:slf4j-mock:2.3.0"
 # @pin because slf4j-simple 2.0.0 isn't compatible with slf4j-api v1.x.y, which is still pulled in by our dependencies.
 #      See https://www.slf4j.org/faq.html#changesInVersion200.
 #      We could theoretically also override slf4j-api to v2.0.0 in tests that rely on slf4j-simple...


### PR DESCRIPTION
See #1298, #1304