### PR TITLE
Skip `canBeCancelled` param of `Task.Backgroundable` c'tor as it's `true` by default anyway

### DIFF
--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/FetchBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/FetchBackgroundable.java
@@ -34,7 +34,7 @@ public class FetchBackgroundable extends Task.Backgroundable {
       String taskTitle,
       @Untainted String failureNotificationText,
       String successNotificationText) {
-    super(gitRepository.getProject(), taskTitle, /* canBeCancelled */ true);
+    super(gitRepository.getProject(), taskTitle);
     this.gitRepository = gitRepository;
     this.remoteName = remoteName;
     this.refspec = refspec;

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
@@ -59,7 +59,7 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Task
   public GitCommandUpdatingCurrentBranchBackgroundable(
       GitRepository gitRepository,
       String taskTitle) {
-    super(gitRepository.getProject(), taskTitle, /* canBeCancelled */ true);
+    super(gitRepository.getProject(), taskTitle);
     this.project = gitRepository.getProject();
     this.gitRepository = gitRepository;
   }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/ResetCurrentToRemoteBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/ResetCurrentToRemoteBackgroundable.java
@@ -36,9 +36,8 @@ public class ResetCurrentToRemoteBackgroundable extends Task.Backgroundable {
   private final GitRepository gitRepository;
 
   public ResetCurrentToRemoteBackgroundable(String title,
-      boolean canBeCancelled,
       String localBranchName, String remoteTrackingBranchName, GitRepository gitRepository) {
-    super(gitRepository.getProject(), title, canBeCancelled);
+    super(gitRepository.getProject(), title);
     this.localBranchName = localBranchName;
     this.remoteTrackingBranchName = remoteTrackingBranchName;
     this.gitRepository = gitRepository;

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetToRemoteAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetToRemoteAction.java
@@ -191,6 +191,6 @@ public abstract class BaseResetToRemoteAction extends BaseGitMacheteRepositoryRe
 
     new ResetCurrentToRemoteBackgroundable(
         getString("action.GitMachete.BaseResetToRemoteAction.task-title"),
-        /* canBeCancelled */ true, localBranchName, remoteTrackingBranchName, gitRepository).queue();
+        localBranchName, remoteTrackingBranchName, gitRepository).queue();
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/dialogs/GitPushDialog.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/dialogs/GitPushDialog.java
@@ -95,7 +95,7 @@ public final class GitPushDialog extends VcsPushDialog {
   public void push(boolean forcePush) {
 
     String title = getString("string.GitMachete.GitPushDialog.task-title");
-    executeAfterRunningPrePushHandlers(new Task.Backgroundable(myProject, title, /* canBeCancelled */ true) {
+    executeAfterRunningPrePushHandlers(new Task.Backgroundable(myProject, title) {
       @Override
       @UIThreadUnsafe
       public void run(ProgressIndicator indicator) {

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
@@ -65,7 +65,7 @@ public class FetchAllRemotesAction extends BaseProjectDependentAction {
     val project = getProject(anActionEvent);
     val gitRepository = getSelectedGitRepository(anActionEvent);
     val title = getString("action.GitMachete.FetchAllRemotesAction.task-title");
-    new Task.Backgroundable(project, title, /* canBeCancelled */ true) {
+    new Task.Backgroundable(project, title) {
       private @MonotonicNonNull GitFetchResult result = null;
 
       @Override

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/TraverseSyncToRemote.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/traverse/TraverseSyncToRemote.java
@@ -211,8 +211,7 @@ public class TraverseSyncToRemote {
       case YES :
         new ResetCurrentToRemoteBackgroundable(
             getString("action.GitMachete.BaseResetToRemoteAction.task-title"),
-            /* canBeCancelled */ true, gitMacheteBranch.getName(), remoteTrackingBranch.getName(),
-            gitRepository) {
+            gitMacheteBranch.getName(), remoteTrackingBranch.getName(), gitRepository) {
           @Override
           public void onSuccess() {
             graphTable.queueRepositoryUpdateAndModelRefresh(traverseNextEntry);


### PR DESCRIPTION
```java
  public abstract static class Backgroundable extends Task implements PerformInBackgroundOption {
    private final @NotNull PerformInBackgroundOption myBackgroundOption;

    public Backgroundable(@Nullable Project project, @ProgressTitle @NotNull String title) {
      this(project, title, true);
    }

    public Backgroundable(@Nullable Project project, @ProgressTitle @NotNull String title, boolean canBeCancelled) {
      this(project, title, canBeCancelled, ALWAYS_BACKGROUND);
    }
   .....
```