### PR TITLE
Use zip distribution of IntelliJ in UI tests on macOS

### DIFF
--- a/src/uiTest/resources/ideprobe-common.conf
+++ b/src/uiTest/resources/ideprobe-common.conf
@@ -1,4 +1,15 @@
 probe {
+  resolvers {
+    intellij.repositories = [
+      # Let's first try using the IntelliJs downloaded by intellij-plugin-verifier or Gradle, if present.
+      "file:///"${HOME}"/.cache/pluginVerifier/ides/IC-[revision]/",
+      "file:///"${HOME}"/.cache/pluginVerifier/ides/IC-[revision]-EAP-SNAPSHOT/",
+      "file:///"${HOME}"/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/[revision]/*/ideaIC-[revision]/",
+      "file:///"${HOME}"/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/[revision]/*/ideaIC-[revision]-EAP-SNAPSHOT/",
+      official
+    ]
+  }
+
   paths {
     base = ${?IDEPROBE_PATHS_BASE}
     screenshots = ${?IDEPROBE_PATHS_SCREENSHOTS}

--- a/src/uiTest/resources/ideprobe-linux.conf
+++ b/src/uiTest/resources/ideprobe-linux.conf
@@ -1,15 +1,2 @@
-# FIXME (#1383): revert to a single config file for macOS and Linux
+# FIXME (VirtusLab/ideprobe#332): revert to a single config file for macOS and Linux
 include "ideprobe-common.conf"
-
-probe {
-  resolvers {
-    intellij.repositories = [
-      # Let's first try using the IntelliJs downloaded by intellij-plugin-verifier or Gradle, if present.
-      "file:///"${HOME}"/.cache/pluginVerifier/ides/IC-[revision]/",
-      "file:///"${HOME}"/.cache/pluginVerifier/ides/IC-[revision]-EAP-SNAPSHOT/",
-      "file:///"${HOME}"/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/[revision]/*/ideaIC-[revision]/",
-      "file:///"${HOME}"/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/[revision]/*/ideaIC-[revision]-EAP-SNAPSHOT/",
-      official
-    ]
-  }
-}

--- a/src/uiTest/resources/ideprobe-macos.conf
+++ b/src/uiTest/resources/ideprobe-macos.conf
@@ -1,12 +1,13 @@
-# FIXME (#1383): revert to a single config file for macOS and Linux
+# FIXME (VirtusLab/ideprobe#332): revert to a single config file for macOS and Linux
 include "ideprobe-common.conf"
 
 probe {
-  intellij {
-    version {
-      # Note that DMGs are apparently published for EAPs and stable releases,
-      # but NOT for candidate EAPs (which our autoupdater in CI doesn't pick up anyway).
-      ext = ".dmg"
-    }
-  }
+  driver.vmOptions = ${probe.driver.vmOptions} [
+    # Workaround for 2023.3.4 and 2024.1 EAPs <= 5, might no longer work on higher IntelliJ versions.
+    # Flags taken from `ps -f` for the IntelliJ executed by `./gradlew runIde`, then narrowed down to what's necessary.
+    "--add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED"
+    "--add-opens=java.desktop/com.apple.eawt.event=ALL-UNNAMED"
+    "--add-opens=java.desktop/com.apple.laf=ALL-UNNAMED"
+    "-Dsun.java2d.metal=true"
+  ]
 }

--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -287,10 +287,9 @@ class UITestSuite extends TestGitRepository(SETUP_WITH_SINGLE_REMOTE) {
     // squashNonCurrentBranch
     project.squashSelected("hotfix/add-trigger")
     project.acceptSquash()
+    Thread.sleep(1000) // to prevent #1079, mostly happening locally (rather on CI)
 
     managedBranchesAndCommits = project.refreshModelAndGetManagedBranchesAndCommits()
-    // TODO (#1079): figure out why once in ~100 test runs this squash does not take effect
-    //  (i.e. hotfix/add-trigger still has two unique commits)
     assertEquals(
       Seq(
         "develop",


### PR DESCRIPTION
Likely won't work OOTB on future IntelliJ versions, alas. Proper solution involves reading `product_info.json`, as in https://github.com/VirtusLab/ide-probe/issues/332. Let's close the related issues and track the problem there from now on.