### PR TITLE
Adapt codebase to build under 2024.2 EAP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,12 +66,12 @@ jobs:
           keys:
             # First, try finding a cache entry with the same set of libraries
             # that also comes from the same branch (so as to make the best use of Gradle compilation cache).
-            - gradle-deps-v8-{{ checksum "gradle/libs.versions.toml" }}-{{ .Branch }}
+            - gradle-deps-v10-{{ checksum "gradle/libs.versions.toml" }}-{{ .Branch }}
             # If the above key is not found, try finding a cache entry with the same set of libraries
             # coming from another branch (Gradle compilation cache might then be less useful).
-            - gradle-deps-v8-{{ checksum "gradle/libs.versions.toml" }}-
+            - gradle-deps-v10-{{ checksum "gradle/libs.versions.toml" }}-
             # As a last resort, take any available cache entry.
-            - gradle-deps-v8-
+            - gradle-deps-v10-
       - run:
           name: Start Gradle daemon
           command: ./gradlew
@@ -199,12 +199,12 @@ jobs:
                 # language=sh
                 command: |
                   du -h -d1 ~/.gradle/caches/modules-2/files-2.1/ | sort -h
-                  rm -rf ~/.gradle/caches/modules-2/files-2.1/com.jetbrains/
-                  rm -rf ~/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/
-                  du -h -d2 ~/.gradle/ | sort -h
+                  rm -rf ~/.gradle/caches/modules-2/files-2.1/idea/
+                  rm -rf ~/.gradle/caches/*/transforms
+                  du -h -d3 ~/.gradle/ | sort -h
             - save_cache:
                 paths: [ ~/.gradle/ ]
-                key: gradle-deps-v8-{{ checksum "gradle/libs.versions.toml" }}-{{ .Branch }}
+                key: gradle-deps-v10-{{ checksum "gradle/libs.versions.toml" }}-{{ .Branch }}
 
       - when:
           condition:

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/SlideInDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/SlideInDialog.kt
@@ -203,6 +203,7 @@ class SlideInDialog(
             "action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.placeholder",
           ),
         )
+        @Suppress("DEPRECATION")
         setUI(DarculaComboBoxUI(/* arc */ 0f, Insets(1, 0, 1, 0), /* paintArrowButton */false))
         addDocumentListener(
           object : DocumentListener {

--- a/src/uiTest/resources/ideprobe-linux.conf
+++ b/src/uiTest/resources/ideprobe-linux.conf
@@ -1,2 +1,9 @@
 # FIXME (VirtusLab/ideprobe#332): revert to a single config file for macOS and Linux
 include "ideprobe-common.conf"
+
+probe.resolvers.driver.env {
+  # Workaround required since 2024.2 - otherwise UI tests fail on missing `gsettings` binary (even if present in the system)
+  # See https://github.com/JetBrains/intellij-community/blob/idea/241.17011.79/platform/platform-impl/src/com/intellij/idea/inputMethodDisabler.kt#L129
+  GDMSESSION = ""
+  XDG_CURRENT_DESKTOP = ""
+}


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1846

## Full chain of PRs as of 2024-06-10

* PR #1872:
  `fix/adapt-2024.2` ➔ `bump/gradle-intellij-plugin-2.0`
* PR #1846:
  `bump/gradle-intellij-plugin-2.0` ➔ `chore/drop-2022.2`
* PR #1848:
  `chore/drop-2022.2` ➔ `develop`

<!-- end git-machete generated -->
