### PR TITLE
Merge 2 UI test methods to reduce UI tests time on develop to <1 hour

### DIFF
--- a/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
+++ b/src/uiTest/scala/com/virtuslab/gitmachete/uitest/UITestSuite.scala
@@ -203,14 +203,6 @@ class UITestSuite extends TestGitRepository(SETUP_WITH_SINGLE_REMOTE) {
     )
   }
 
-  @Test def syncToParentByMergeAction(): Unit = {
-
-    // syncSelectedToParentByMerge
-    project.openGitMacheteTab()
-    project.syncSelectedToParentByMerge("call-ws")
-    project.assertSyncToParentStatus("call-ws", "InSync")
-  }
-
   @Test def pullBranch(): Unit = {
 
     // pullCurrentBranch
@@ -227,6 +219,11 @@ class UITestSuite extends TestGitRepository(SETUP_WITH_SINGLE_REMOTE) {
     project.pullSelected("update-icons")
     project.assertLocalAndRemoteBranchesAreEqual("update-icons")
     project.assertNoUncommittedChanges()
+
+    // syncSelectedToParentByMerge
+    project.openGitMacheteTab()
+    project.syncSelectedToParentByMerge("call-ws")
+    project.assertSyncToParentStatus("call-ws", "InSync")
   }
 
   @Test def resetBranchToRemote(): Unit = {


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1927

## Chain of upstream PRs as of 2024-09-19

* PR #1927:
  `master` ← `develop`

  * **PR #1928 (THIS ONE)**:
    `develop` ← `fix/ui-tests-too-long`

<!-- end git-machete generated -->
