### PR TITLE
Add extra retries for retrieving Git Machete tab in UI tests

### DIFF
--- a/src/uiTest/resources/project.rhino.js
+++ b/src/uiTest/resources/project.rhino.js
@@ -75,7 +75,7 @@ function Project(underlyingProject) {
       sleep();
     } while (toolWindow === null && ++i < 50);
     if (toolWindow === null) {
-      throw new IlegalStateException("Waiting for condition timed out");
+      throw new IlegalStateException("Waiting for " + toolWindowId + " tool window timed out");
     }
 
     // The method is NOT meant to be executed on the UI thread,
@@ -83,7 +83,15 @@ function Project(underlyingProject) {
     ApplicationManager.getApplication().invokeAndWait(() => {
       toolWindow.activate(() => {});
       const contentManager = toolWindow.getContentManager();
-      const tab = contentManager.findContent(tabName);
+      let tab, i = 0;
+      do {
+        // It can (very rarely) happen that the tab isn't instantly available.
+        tab = contentManager.findContent(tabName);
+        sleep();
+      } while (tab === null && ++i < 10);
+      if (tab === null) {
+        throw new IlegalStateException("Waiting for " + tabName + " tab timed out");
+      }
       contentManager.setSelectedContent(tab);
     });
   };


### PR DESCRIPTION
To fix [a rare error in UI tests](https://app.circleci.com/pipelines/github/VirtusLab/git-machete-intellij-plugin/10517/workflows/f9076911-9282-455a-b33f-696b26d0ada9/jobs/11030) (first time seen):

```
UITestSuite > squashBranch() FAILED
    com.intellij.remoterobot.client.IdeaSideException: Wrapped java.lang.RuntimeException: org.mozilla.javascript.WrappedException: Wrapped java.lang.IllegalArgumentException: Argument for @NotNull parameter 'content' of com/intellij/ui/content/impl/ContentManagerImpl.setSelectedContent must not be null (js#132)
        at app//com.intellij.remoterobot.client.IdeRobotClient.throwIdeaSideError(IdeRobotClient.kt:141)
        at app//com.intellij.remoterobot.client.IdeRobotClient.processExecuteResponse(IdeRobotClient.kt:108)
        at app//com.intellij.remoterobot.client.IdeRobotClient.execute(IdeRobotClient.kt:59)
        at app//com.intellij.remoterobot.JavaScriptApi$DefaultImpls.runJs(JavaScriptApi.kt:35)
        at app//com.intellij.remoterobot.RemoteRobot.runJs(RemoteRobot.kt:32)
        at app//com.virtuslab.gitmachete.uitest.RunningIntelliJFixtureExtension$RunningIntelliJFixtureOps.com$virtuslab$gitmachete$uitest$RunningIntelliJFixtureExtension$RunningIntelliJFixtureOps$$runJs(RunningIntelliJFixtureExtension.scala:35)
        at app//com.virtuslab.gitmachete.uitest.RunningIntelliJFixtureExtension$RunningIntelliJFixtureOps$project$.openGitMacheteTab(RunningIntelliJFixtureExtension.scala:273)
        at app//com.virtuslab.gitmachete.uitest.UITestSuite.squashBranch(UITestSuite.scala:250)

        Caused by:
        java.lang.Throwable: Wrapped java.lang.RuntimeException: org.mozilla.javascript.WrappedException: Wrapped java.lang.IllegalArgumentException: Argument for @NotNull parameter 'content' of com/intellij/ui/content/impl/ContentManagerImpl.setSelectedContent must not be null (js#132)
            at org.mozilla.javascript.Context.throwAsScriptRuntimeEx(Context.java:1825)
            at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:227)
            at org.mozilla.javascript.NativeJavaMethod.call(NativeJavaMethod.java:211)
            at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:35)
            at org.mozilla.javascript.gen.js_1._c_anonymous_14(js:128)
            at org.mozilla.javascript.gen.js_1.call(js)
            at org.mozilla.javascript.optimizer.OptRuntime.callName(OptRuntime.java:59)
            at org.mozilla.javascript.gen.js_1._c_anonymous_13(js:111)
            at org.mozilla.javascript.gen.js_1.call(js)
            at org.mozilla.javascript.optimizer.OptRuntime.callProp0(OptRuntime.java:73)
            at org.mozilla.javascript.gen.js_3._c_script_0(js:11)
            at org.mozilla.javascript.gen.js_3.call(js)
            at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:380)
            at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3868)
            at org.mozilla.javascript.gen.js_3.call(js)
            at org.mozilla.javascript.gen.js_3.exec(js)
            at com.intellij.remoterobot.services.js.RhinoJavaScriptExecutor.executeWithContext(RhinoJavaScriptExecutor.kt:65)
            at com.intellij.remoterobot.services.js.RhinoJavaScriptExecutor.execute(RhinoJavaScriptExecutor.kt:27)
            at com.intellij.remoterobot.services.IdeRobot$doAction$3.invoke(IdeRobot.kt:308)
            at com.intellij.remoterobot.services.IdeRobot$doAction$3.invoke(IdeRobot.kt:300)
            at com.intellij.remoterobot.services.IdeRobot.getResult(IdeRobot.kt:392)
            at com.intellij.remoterobot.services.IdeRobot.doAction(IdeRobot.kt:300)
            at com.intellij.remoterobot.RobotServerImpl$startServer$2$2$24$1.invoke(RobotServerImpl.kt:282)
            at com.intellij.remoterobot.RobotServerImpl$startServer$2$2$24$1.invoke(RobotServerImpl.kt:280)
            at com.intellij.remoterobot.RobotServerImpl$Companion.commonRequest(RobotServerImpl.kt:371)
            at com.intellij.remoterobot.RobotServerImpl$startServer$2$2$24.invokeSuspend(RobotServerImpl.kt:280)
            at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
            at kotlinx.coroutines.internal.DispatchedContinuation.resumeWith(DispatchedContinuation.kt:205)
            at io.ktor.util.pipeline.SuspendFunctionGun.resumeRootWith(SuspendFunctionGun.kt:135)
            at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:109)
            at io.ktor.util.pipeline.SuspendFunctionGun.access$loop(SuspendFunctionGun.kt:11)
            at io.ktor.util.pipeline.SuspendFunctionGun$continuation$1.resumeWith(SuspendFunctionGun.kt:59)
            at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
            at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
            at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174)
            at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167)
            at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
            at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569)
            at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
            at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
            at io.ktor.server.netty.EventLoopGroupProxy$Companion.create$lambda$1$lambda$0(NettyApplicationEngine.kt:291)
            at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
            at java.base/java.lang.Thread.run(Thread.java:840)

            Caused by:
            java.lang.Throwable: org.mozilla.javascript.WrappedException: Wrapped java.lang.IllegalArgumentException: Argument for @NotNull parameter 'content' of com/intellij/ui/content/impl/ContentManagerImpl.setSelectedContent must not be null (js#132)
                at com.intellij.openapi.application.impl.LaterInvocator.invokeAndWait(LaterInvocator.java:133)
                at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:411)
                at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:446)
                at java.base/java.lang.reflect.Method.invoke(Method.java:569)
                at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:206)
                ... 41 more

                Caused by:
                java.lang.Throwable: Wrapped java.lang.IllegalArgumentException: Argument for @NotNull parameter 'content' of com/intellij/ui/content/impl/ContentManagerImpl.setSelectedContent must not be null
                    at org.mozilla.javascript.Context.throwAsScriptRuntimeEx(Context.java:1825)
                    at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:227)
                    at org.mozilla.javascript.NativeJavaMethod.call(NativeJavaMethod.java:211)
                    at org.mozilla.javascript.optimizer.OptRuntime.call1(OptRuntime.java:35)
                    at org.mozilla.javascript.gen.js_1._c_anonymous_15(js:132)
                    at org.mozilla.javascript.gen.js_1.call(js)
                    at org.mozilla.javascript.ContextFactory.doTopCall(ContextFactory.java:380)
                    at org.mozilla.javascript.ScriptRuntime.doTopCall(ScriptRuntime.java:3868)
                    at org.mozilla.javascript.gen.js_1.call(js)
                    at org.mozilla.javascript.ArrowFunction.call(ArrowFunction.java:43)
                    at org.mozilla.javascript.InterfaceAdapter.invokeImpl(InterfaceAdapter.java:166)
                    at org.mozilla.javascript.InterfaceAdapter.lambda$invoke$0(InterfaceAdapter.java:116)
                    at org.mozilla.javascript.Context.call(Context.java:535)
                    at org.mozilla.javascript.ContextFactory.call(ContextFactory.java:472)
                    at org.mozilla.javascript.InterfaceAdapter.invoke(InterfaceAdapter.java:116)
                    at org.mozilla.javascript.jdk18.VMBridge_jdk18$1.invoke(VMBridge_jdk18.java:126)
                    at jdk.proxy1/jdk.proxy1.$Proxy81.run(Unknown Source)
                    at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:236)
                    at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:25)
                    at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:198)
                    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread$lambda$2(AnyThreadWriteThreadingSupport.kt:217)
                    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:128)
                    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runIntendedWriteActionOnCurrentThread(AnyThreadWriteThreadingSupport.kt:216)
                    at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:842)
                    at com.intellij.openapi.application.impl.ApplicationImpl$2.run(ApplicationImpl.java:421)
                    at com.intellij.openapi.application.impl.AppImplKt.rethrowExceptions$lambda$2(appImpl.kt:57)
                    at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:101)
                    at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:101)
                    at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:107)
                    at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:101)
                    at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:27)
                    at com.intellij.openapi.application.impl.AppImplKt.rethrowExceptions$lambda$3(appImpl.kt:68)
                    at com.intellij.openapi.application.impl.LaterInvocator$1.run(LaterInvocator.java:102)
                    at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:117)
                    at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:43)
                    at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
                    at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:792)
                    at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:739)
                    at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:733)
                    at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
                    at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
                    at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:761)
                    at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:675)
                    at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:573)
                    at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$18$lambda$17$lambda$16$lambda$15(IdeEventQueue.kt:355)
                    at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:857)
                    at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$18$lambda$17$lambda$16(IdeEventQueue.kt:354)
                    at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$2$lambda$1(IdeEventQueue.kt:1045)
                    at com.intellij.openapi.application.WriteIntentReadAction.lambda$run$0(WriteIntentReadAction.java:24)
                    at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runWriteIntentReadAction(AnyThreadWriteThreadingSupport.kt:128)
                    at com.intellij.openapi.application.impl.ApplicationImpl.runWriteIntentReadAction(ApplicationImpl.java:916)
                    at com.intellij.openapi.application.WriteIntentReadAction.compute(WriteIntentReadAction.java:55)
                    at com.intellij.openapi.application.WriteIntentReadAction.run(WriteIntentReadAction.java:23)
                    at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$2(IdeEventQueue.kt:1045)
                    at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$3(IdeEventQueue.kt:1054)
                    at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:109)
                    at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1054)
                    at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$18(IdeEventQueue.kt:349)
                    at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:395)
                    at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
                    at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
                    at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
                    at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
                    at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
                    at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)

                    Caused by:
                    java.lang.Throwable: Argument for @NotNull parameter 'content' of com/intellij/ui/content/impl/ContentManagerImpl.setSelectedContent must not be null
                        at com.intellij.ui.content.impl.ContentManagerImpl.$$$reportNull$$$0(ContentManagerImpl.java)
                        at com.intellij.ui.content.impl.ContentManagerImpl.setSelectedContent(ContentManagerImpl.java)
                        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
                        at org.mozilla.javascript.MemberBox.invoke(MemberBox.java:206)
                        ... 63 more
```