### PR TITLE
Bump CircleCI VM version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   ubuntu_executor:
     machine:
       # https://circleci.com/developer/images?imageType=machine
-      image: ubuntu-2204:2024.01.1
+      image: ubuntu-2404:2024.05.1
     resource_class: large
     working_directory: ~/git-machete-intellij-plugin
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1968

## Chain of upstream PRs as of 2025-01-11

* PR #1968:
  `master` ← `develop`

  * **PR #1969 (THIS ONE)**:
    `develop` ← `chore/bump-ci-vm-versions`

<!-- end git-machete generated -->
