### PR TITLE
Get rid of `-EAP-SNAPSHOT` version suffixes completely

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v6.2.0
-- Added: support for IntelliJ 2025.3.
+- Added: support for IntelliJ 2025.3
 - Fixed: improved loading time of Git Machete status on large repos
 
 ## v6.1.3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -376,7 +376,7 @@ intellijPlatform {
       // but with this explicit approach, the IDE versions used for verification
       // are fully controlled by repository contents (intellij-versions.properties),
       // so the builds are more reproducible in this respect.
-      val maybeEap = listOfNotNull(intellijVersions.eapOfLatestSupportedMajor?.removeEapSuffix())
+      val maybeEap = listOfNotNull(intellijVersions.eapOfLatestSupportedMajor)
       val ideVersions = intellijVersions.latestMinorsOfOldSupportedMajors + intellijVersions.latestStable + maybeEap
       ides(ideVersions.map { it.withProductCode() })
     }
@@ -474,7 +474,7 @@ uiTestTargetVersions.onEach { version ->
     description = "Runs UI tests."
     group = "verification"
 
-    systemProperty("intellij.version", version.removeEapSuffix())
+    systemProperty("intellij.version", version)
     systemProperty("intellij.product", version.productCode())
 
     testClassesDirs = uiTest.output.classesDirs

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -118,4 +118,3 @@ fun String.productCode(): String {
   }
 }
 fun String.withProductCode(): String = "${this.productCode()}-$this"
-fun String.removeEapSuffix(): String = this.removeSuffix("-EAP-SNAPSHOT")

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UpdateIntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UpdateIntellijVersions.kt
@@ -97,14 +97,14 @@ open class UpdateIntellijVersions : DefaultTask() {
       }
     }
 
-    val buildNumberThreshold = updatedVersions.eapOfLatestSupportedMajor?.removeEapSuffix()
+    val buildNumberThreshold = updatedVersions.eapOfLatestSupportedMajor
       ?: "${versionToBuildNumber(updatedVersions.latestStable)}.999999.999999"
 
     val newerEapBuildNumber = findEapWithBuildNumberHigherThan(buildNumberThreshold)
 
     if (newerEapBuildNumber != null) {
       logger.lifecycle("eapOfLatestSupportedMajor has been updated to $newerEapBuildNumber")
-      updatedVersions = updatedVersions.copy(eapOfLatestSupportedMajor = "$newerEapBuildNumber-EAP-SNAPSHOT")
+      updatedVersions = updatedVersions.copy(eapOfLatestSupportedMajor = newerEapBuildNumber)
     }
 
     if (originalVersions != updatedVersions) {

--- a/intellij-versions.properties
+++ b/intellij-versions.properties
@@ -1,4 +1,4 @@
-eapOfLatestSupportedMajor=253.25908.13-EAP-SNAPSHOT
+eapOfLatestSupportedMajor=253.25908.13
 earliestSupportedMajor=2024.2
 earliestSupportedMajorKotlinVersion=1.9
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2147

## Chain of upstream PRs as of 2025-10-10

* PR #2148:
  `master` ← `develop`

  * PR #2147:
    `develop` ← `chore/checkout-blobless`

    * **PR #2149 (THIS ONE)**:
      `chore/checkout-blobless` ← `chore/eap-snapshot-remove`

<!-- end git-machete generated -->
