### PR TITLE
Rename `earliestSupportedMajorKotlinVersion` to `kotlinVersion`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,7 +161,7 @@ allprojects {
   configurations.runtimeClasspath { exclude(group = "org.slf4j", module = "slf4j-api") }
 
   tasks.withType<KotlinCompile>().configureEach {
-    val kotlinLanguageVersion = intellijVersions.earliestSupportedMajorKotlinVersion.replace("""\.\d+$""".toRegex(), "")
+    val kotlinLanguageVersion = intellijVersions.kotlinVersion.replace("""\.\d+$""".toRegex(), "")
     kotlinOptions {
       apiVersion = kotlinLanguageVersion
       languageVersion = kotlinLanguageVersion

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,7 +37,7 @@ repositories {
 
 val properties = Properties()
 properties.load(rootDir.parentFile.resolve("intellij-versions.properties").inputStream())
-val kotlinVersion = properties.getProperty("earliestSupportedMajorKotlinVersion")!!
+val kotlinVersion = properties.getProperty("kotlinVersion")!!
 val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
 dependencies {

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -66,7 +66,7 @@ data class ReleaseVersion(override val value: String) : AnyVersion {
 // See https://www.jetbrains.com/intellij-repository/releases/ -> Ctrl+F .idea
 data class IntellijVersions(
   val earliestSupportedMajor: ReleaseVersion,
-  val earliestSupportedMajorKotlinVersion: String,
+  val kotlinVersion: String,
   val latestMinorsOfOldSupportedMajors: List<ReleaseVersion>,
   val latestStable: ReleaseVersion,
   val upcomingMajorEap: BuildNumber?,
@@ -82,7 +82,7 @@ data class IntellijVersions(
     fun from(intellijVersionsProperties: Properties, overrideBuildTarget: String?): IntellijVersions {
       // When this value is updated, remember to update:
       // 1. the minimum required IDEA version in README.md
-      // 2. version of Kotlin - automatically via `./gradlew updateIntellijVersions`
+      // 2. version of Kotlin and kotlinx-serialization-json - automatically via `./gradlew updateIntellijVersions`
       // Note that after bumping `earliestSupportedMajor` from AAAA.B to CCCC.D (CCCC.D is later)
       // the released plugin versions supporting AAAA.B remain available in JetBrains Marketplace.
       // Dropping a support for an IntelliJ version is less painful then,
@@ -90,9 +90,10 @@ data class IntellijVersions(
       // Marking a release version as hidden is a way to forbid its download
       // (see https://plugins.jetbrains.com/plugin/14221-git-machete/versions).
       val earliestSupportedMajor = ReleaseVersion(intellijVersionsProperties.getProperty("earliestSupportedMajor"))
-      // Every time `earliestSupportedMajor` is bumped, this should be bumped to the Kotlin version
-      // listed for `earliestSupportedMajor` in https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
-      val earliestSupportedMajorKotlinVersion: String = intellijVersionsProperties.getProperty("earliestSupportedMajorKotlinVersion")
+      // Every time `earliestSupportedMajor` is bumped, this should be bumped (using ./gradle updateIntellijVersions)
+      // to the Kotlin version listed for `earliestSupportedMajor`
+      // in https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
+      val kotlinVersion: String = intellijVersionsProperties.getProperty("kotlinVersion")
 
       // Most recent minor versions of all major releases between the earliest supported (incl.)
       // and latest stable (excl.), used for binary compatibility checks and UI tests
@@ -111,7 +112,7 @@ data class IntellijVersions(
 
       return IntellijVersions(
         earliestSupportedMajor = earliestSupportedMajor,
-        earliestSupportedMajorKotlinVersion = earliestSupportedMajorKotlinVersion,
+        kotlinVersion = kotlinVersion,
         latestMinorsOfOldSupportedMajors = latestMinorsOfOldSupportedMajors,
         latestStable = latestStable,
         upcomingMajorEap = upcomingMajorEap,
@@ -151,7 +152,7 @@ data class IntellijVersions(
     val p = Properties()
     p.setProperty("upcomingMajorEap", upcomingMajorEap?.value ?: "")
     p.setProperty("earliestSupportedMajor", earliestSupportedMajor.value)
-    p.setProperty("earliestSupportedMajorKotlinVersion", earliestSupportedMajorKotlinVersion)
+    p.setProperty("kotlinVersion", kotlinVersion)
     p.setProperty("latestMinorsOfOldSupportedMajors", latestMinorsOfOldSupportedMajors.joinToString(separator = ",") { it.value })
     p.setProperty("latestStable", latestStable.value)
     return p

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdater.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdater.kt
@@ -19,7 +19,7 @@ class IntellijVersionsUpdater(private val versionsProvider: IntelliJVersionsProv
   fun update(earliestSupportedMajor: ReleaseVersion): IntellijVersions {
     // As per https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library:
     // "If a plugin supports multiple platform versions, it must (...) target the lowest bundled stdlib version".
-    val earliestSupportedMajorKotlinVersion = versionsProvider.getKotlinVersionForIntelliJ(earliestSupportedMajor.value)
+    val kotlinVersion = versionsProvider.getKotlinVersionForIntelliJ(earliestSupportedMajor.value)
 
     // Find the latest stable release
     val latestStable = intellijReleases.first()
@@ -40,7 +40,7 @@ class IntellijVersionsUpdater(private val versionsProvider: IntelliJVersionsProv
 
     return IntellijVersions(
       earliestSupportedMajor = earliestSupportedMajor,
-      earliestSupportedMajorKotlinVersion = earliestSupportedMajorKotlinVersion,
+      kotlinVersion = kotlinVersion,
       latestMinorsOfOldSupportedMajors = latestMinorsOfOldSupportedMajors,
       latestStable = latestStable,
       upcomingMajorEap = upcomingMajorEap,

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsTest.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsTest.kt
@@ -12,7 +12,7 @@ class IntellijVersionsTest {
   fun shouldResolveIntelliJVersions() {
     val iv = IntellijVersions(
       earliestSupportedMajor = ReleaseVersion("2020.3"),
-      earliestSupportedMajorKotlinVersion = "1.9",
+      kotlinVersion = "1.9",
       latestMinorsOfOldSupportedMajors = listOf("2020.3.4", "2021.1.3", "2021.2.4", "2021.3.3", "2022.1.4").map { ReleaseVersion(it) },
       latestStable = ReleaseVersion("2022.2.2"),
       upcomingMajorEap = null,
@@ -31,7 +31,7 @@ class IntellijVersionsTest {
   fun shouldResolveIntelliJVersionsWithOverrideBuildTarget() {
     val iv = IntellijVersions(
       earliestSupportedMajor = ReleaseVersion("2020.3"),
-      earliestSupportedMajorKotlinVersion = "1.9",
+      kotlinVersion = "1.9",
       latestMinorsOfOldSupportedMajors = listOf("2020.3.4", "2021.1.3", "2021.2.4", "2021.3.3", "2022.1.4").map { ReleaseVersion(it) },
       latestStable = ReleaseVersion("2022.2.2"),
       upcomingMajorEap = BuildNumber("223.7571.182"),

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdaterTest.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdaterTest.kt
@@ -55,7 +55,7 @@ class IntellijVersionsUpdaterTest {
 
     val propertyKeys = listOf(
       "earliestSupportedMajor",
-      "earliestSupportedMajorKotlinVersion",
+      "kotlinVersion",
       "latestMinorsOfOldSupportedMajors",
       "latestStable",
       "upcomingMajorEap",

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/INPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9
+kotlinVersion=1.9
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/OUTPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9.22
+kotlinVersion=1.9.22
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/INPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9
+kotlinVersion=1.9
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/OUTPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9.22
+kotlinVersion=1.9.22
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/INPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9
+kotlinVersion=1.9
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.5
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/OUTPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9.22
+kotlinVersion=1.9.22
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/INPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9
+kotlinVersion=1.9
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.5
 latestStable=2025.2.3
 upcomingMajorEap=

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/OUTPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9.22
+kotlinVersion=1.9.22
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/INPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9
+kotlinVersion=1.9
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.20558.43

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/OUTPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9.22
+kotlinVersion=1.9.22
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/INPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9
+kotlinVersion=1.9
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/OUTPUT.intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9.22
+kotlinVersion=1.9.22
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6,2025.2.3
 latestStable=2025.3
 upcomingMajorEap=

--- a/intellij-versions.properties
+++ b/intellij-versions.properties
@@ -1,5 +1,5 @@
 earliestSupportedMajor=2024.2
-earliestSupportedMajorKotlinVersion=1.9.24
+kotlinVersion=1.9.24
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.27642.30


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2162

## Chain of upstream PRs as of 2025-10-21

* PR #2163:
  `master` ← `develop`

  * PR #2162:
    `develop` ← `update-intellij-versions/8f8440efb862036a1855a0395344f09c`

    * **PR #2164 (THIS ONE)**:
      `update-intellij-versions/8f8440efb862036a1855a0395344f09c` ← `refactor/kotlin-version`

<!-- end git-machete generated -->
