### PR TITLE
Derive `kotlinxSerializationJsonVersion` automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,5 +32,3 @@ updates:
         patterns:
           # To lump all updated dependencies together into a single PR (instead of PR-per-dependency)
           - "*"
-    ignore:
-      - dependency-name: "org.jetbrains.kotlinx:kotlinx-serialization-json"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,10 +39,12 @@ val properties = Properties()
 properties.load(rootDir.parentFile.resolve("intellij-versions.properties").inputStream())
 val kotlinVersion = properties.getProperty("kotlinVersion")!!
 val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+val kotlinxSerializationJsonVersion = properties.getProperty("kotlinxSerializationJsonVersion")!!
+val kotlinxSerializationJson = "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationJsonVersion"
 
 dependencies {
   implementation(kotlinGradlePlugin)
-  implementation(libs.kotlin.serialization.json)
+  implementation(kotlinxSerializationJson)
   implementation(libs.pluginPackages.checkerFramework)
   implementation(libs.pluginPackages.grgit)
   implementation(libs.pluginPackages.spotless)

--- a/buildSrc/gradle/libs.versions.toml
+++ b/buildSrc/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jun
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiter" }
 junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitJupiter" }
-kotlin-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3"
 # Plugin packages
 # This way of applying the plugins is needed for the build-related code in buildSrc/src/main/,
 # see https://docs.gradle.org/current/samples/sample_convention_plugins.html#things_to_note.

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -67,6 +67,7 @@ data class ReleaseVersion(override val value: String) : AnyVersion {
 data class IntellijVersions(
   val earliestSupportedMajor: ReleaseVersion,
   val kotlinVersion: String,
+  val kotlinxSerializationJsonVersion: String,
   val latestMinorsOfOldSupportedMajors: List<ReleaseVersion>,
   val latestStable: ReleaseVersion,
   val upcomingMajorEap: BuildNumber?,
@@ -94,6 +95,7 @@ data class IntellijVersions(
       // to the Kotlin version listed for `earliestSupportedMajor`
       // in https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
       val kotlinVersion: String = intellijVersionsProperties.getProperty("kotlinVersion")
+      val kotlinxSerializationJsonVersion: String = intellijVersionsProperties.getProperty("kotlinxSerializationJsonVersion")
 
       // Most recent minor versions of all major releases between the earliest supported (incl.)
       // and latest stable (excl.), used for binary compatibility checks and UI tests
@@ -113,6 +115,7 @@ data class IntellijVersions(
       return IntellijVersions(
         earliestSupportedMajor = earliestSupportedMajor,
         kotlinVersion = kotlinVersion,
+        kotlinxSerializationJsonVersion = kotlinxSerializationJsonVersion,
         latestMinorsOfOldSupportedMajors = latestMinorsOfOldSupportedMajors,
         latestStable = latestStable,
         upcomingMajorEap = upcomingMajorEap,
@@ -153,6 +156,7 @@ data class IntellijVersions(
     p.setProperty("upcomingMajorEap", upcomingMajorEap?.value ?: "")
     p.setProperty("earliestSupportedMajor", earliestSupportedMajor.value)
     p.setProperty("kotlinVersion", kotlinVersion)
+    p.setProperty("kotlinxSerializationJsonVersion", kotlinxSerializationJsonVersion)
     p.setProperty("latestMinorsOfOldSupportedMajors", latestMinorsOfOldSupportedMajors.joinToString(separator = ",") { it.value })
     p.setProperty("latestStable", latestStable.value)
     return p

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -8,7 +8,11 @@ import kotlin.reflect.full.memberProperties
 sealed interface AnyVersion {
   val value: String
 
-  infix fun isNewerThan(rhsVersion: AnyVersion): Boolean {
+  /**
+   * Compares this version with another version.
+   * @return negative if this < other, zero if this == other, positive if this > other
+   */
+  infix fun compareTo(rhsVersion: AnyVersion): Int {
     if (rhsVersion.javaClass != this.javaClass) {
       throw IllegalArgumentException("$this and $rhsVersion cannot be compared")
     }
@@ -19,20 +23,14 @@ sealed interface AnyVersion {
 
     // 8.0.6 is older than 8.0.6.0, but zipped they will look like this: [(8,8), (0,0), (6,6)]
     if (firstDiff == null) {
-      return lhsSplit.size > rhsSplit.size
+      return lhsSplit.size.compareTo(rhsSplit.size)
     }
 
-    return Integer.parseInt(firstDiff.first) > Integer.parseInt(firstDiff.second)
+    return Integer.parseInt(firstDiff.first).compareTo(Integer.parseInt(firstDiff.second))
   }
 
   companion object {
-    fun <T : AnyVersion> descendingComparator(): Comparator<T> = Comparator { a, b ->
-      when {
-        a isNewerThan b -> -1
-        b isNewerThan a -> 1
-        else -> 0
-      }
-    }
+    fun <T : AnyVersion> descendingComparator(): Comparator<T> = Comparator { a, b -> -(a compareTo b) }
 
     fun String.toPlainReleaseNumber(): Int {
       if ("""\d\d\d\.[.\d]+""".toRegex().matches(this)) {

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsProvider.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsProvider.kt
@@ -57,15 +57,9 @@ class RealIntelliJVersionsProvider : IntelliJVersionsProvider {
       throw IllegalStateException("No version found for $libraryName in IntelliJ version $intellijVersion")
     }
 
-    // Find the highest version using isNewerThan
+    // Find the highest version using compareTo
     return versions.map { ReleaseVersion(it) }
-      .maxWithOrNull { a, b ->
-        when {
-          a isNewerThan b -> 1
-          b isNewerThan a -> -1
-          else -> 0
-        }
-      }?.value ?: versions.first()
+      .maxWithOrNull { a, b -> a compareTo b }?.value ?: versions.first()
   }
 
   override fun getKotlinLibraryVersionsForIntelliJ(intellijVersion: String): KotlinLibraryVersions {

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsProvider.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsProvider.kt
@@ -7,9 +7,14 @@ import kotlinx.serialization.json.jsonPrimitive
 import java.net.HttpURLConnection
 import java.net.URI
 
+data class KotlinLibraryVersions(
+  val kotlinVersion: String,
+  val kotlinxSerializationJsonVersion: String,
+)
+
 interface IntelliJVersionsProvider {
   fun listIntelliJVersionsForType(code: String, type: String, attribute: String): List<String>
-  fun getKotlinVersionForIntelliJ(intellijVersion: String): String
+  fun getKotlinLibraryVersionsForIntelliJ(intellijVersion: String): KotlinLibraryVersions
 }
 
 class RealIntelliJVersionsProvider : IntelliJVersionsProvider {
@@ -35,7 +40,35 @@ class RealIntelliJVersionsProvider : IntelliJVersionsProvider {
     return result
   }
 
-  override fun getKotlinVersionForIntelliJ(intellijVersion: String): String {
+  private fun extractLibraryVersionByUrl(jsonElement: kotlinx.serialization.json.JsonElement, url: String, libraryName: String, intellijVersion: String): String {
+    val matchingLibraries = jsonElement.jsonArray.filter { library ->
+      library.jsonObject["url"]?.jsonPrimitive?.content == url
+    }
+
+    if (matchingLibraries.isEmpty()) {
+      throw IllegalStateException("$libraryName not found for IntelliJ version $intellijVersion")
+    }
+
+    val versions = matchingLibraries.mapNotNull { library ->
+      library.jsonObject["version"]?.jsonPrimitive?.content
+    }
+
+    if (versions.isEmpty()) {
+      throw IllegalStateException("No version found for $libraryName in IntelliJ version $intellijVersion")
+    }
+
+    // Find the highest version using isNewerThan
+    return versions.map { ReleaseVersion(it) }
+      .maxWithOrNull { a, b ->
+        when {
+          a isNewerThan b -> 1
+          b isNewerThan a -> -1
+          else -> 0
+        }
+      }?.value ?: versions.first()
+  }
+
+  override fun getKotlinLibraryVersionsForIntelliJ(intellijVersion: String): KotlinLibraryVersions {
     // See https://www.jetbrains.com/legal/third-party-software/?product=IIC&version=2024.2 for web version
     val url = "https://resources.jetbrains.com/storage/third-party-libraries/idea/ideaIC-$intellijVersion-third-party-libraries.json"
     val jsonString = fetchJson(url)
@@ -43,14 +76,21 @@ class RealIntelliJVersionsProvider : IntelliJVersionsProvider {
     val json = Json { ignoreUnknownKeys = true }
     val jsonElement = json.parseToJsonElement(jsonString)
 
-    val kotlinLibrary = jsonElement.jsonArray.firstOrNull { library ->
-      library.jsonObject["name"]?.jsonPrimitive?.content == "Kotlin Standard Library"
-    }
+    val kotlinVersion = extractLibraryVersionByUrl(
+      jsonElement,
+      "https://github.com/JetBrains/kotlin",
+      "Kotlin library",
+      intellijVersion,
+    )
 
-    val version = kotlinLibrary?.jsonObject?.get("version")?.jsonPrimitive?.content
-      ?: throw IllegalStateException("Kotlin Standard Library not found for IntelliJ version $intellijVersion")
+    val kotlinxSerializationJsonVersion = extractLibraryVersionByUrl(
+      jsonElement,
+      "https://github.com/Kotlin/kotlinx.serialization",
+      "kotlinx.serialization library",
+      intellijVersion,
+    )
 
-    println("getKotlinVersionForIntelliJ($intellijVersion) = $version\n")
-    return version
+    println("getKotlinLibraryVersionsForIntelliJ($intellijVersion) = KotlinLibraryVersions(kotlinVersion=$kotlinVersion, kotlinxSerializationJsonVersion=$kotlinxSerializationJsonVersion)\n")
+    return KotlinLibraryVersions(kotlinVersion, kotlinxSerializationJsonVersion)
   }
 }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsProvider.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsProvider.kt
@@ -40,13 +40,13 @@ class RealIntelliJVersionsProvider : IntelliJVersionsProvider {
     return result
   }
 
-  private fun extractLibraryVersionByUrl(jsonElement: kotlinx.serialization.json.JsonElement, url: String, libraryName: String, intellijVersion: String): String {
+  private fun extractLibraryVersionByUrl(jsonElement: kotlinx.serialization.json.JsonElement, url: String, intellijVersion: String): String {
     val matchingLibraries = jsonElement.jsonArray.filter { library ->
       library.jsonObject["url"]?.jsonPrimitive?.content == url
     }
 
     if (matchingLibraries.isEmpty()) {
-      throw IllegalStateException("$libraryName not found for IntelliJ version $intellijVersion")
+      throw IllegalStateException("Library with URL $url not found for IntelliJ version $intellijVersion")
     }
 
     val versions = matchingLibraries.mapNotNull { library ->
@@ -54,7 +54,7 @@ class RealIntelliJVersionsProvider : IntelliJVersionsProvider {
     }
 
     if (versions.isEmpty()) {
-      throw IllegalStateException("No version found for $libraryName in IntelliJ version $intellijVersion")
+      throw IllegalStateException("No version found for library with URL $url in IntelliJ version $intellijVersion")
     }
 
     // Find the highest version using compareTo
@@ -73,14 +73,12 @@ class RealIntelliJVersionsProvider : IntelliJVersionsProvider {
     val kotlinVersion = extractLibraryVersionByUrl(
       jsonElement,
       "https://github.com/JetBrains/kotlin",
-      "Kotlin library",
       intellijVersion,
     )
 
     val kotlinxSerializationJsonVersion = extractLibraryVersionByUrl(
       jsonElement,
       "https://github.com/Kotlin/kotlinx.serialization",
-      "kotlinx.serialization library",
       intellijVersion,
     )
 

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdater.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdater.kt
@@ -19,7 +19,7 @@ class IntellijVersionsUpdater(private val versionsProvider: IntelliJVersionsProv
   fun update(earliestSupportedMajor: ReleaseVersion): IntellijVersions {
     // As per https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library:
     // "If a plugin supports multiple platform versions, it must (...) target the lowest bundled stdlib version".
-    val kotlinVersion = versionsProvider.getKotlinVersionForIntelliJ(earliestSupportedMajor.value)
+    val kotlinLibraryVersions = versionsProvider.getKotlinLibraryVersionsForIntelliJ(earliestSupportedMajor.value)
 
     // Find the latest stable release
     val latestStable = intellijReleases.first()
@@ -40,7 +40,8 @@ class IntellijVersionsUpdater(private val versionsProvider: IntelliJVersionsProv
 
     return IntellijVersions(
       earliestSupportedMajor = earliestSupportedMajor,
-      kotlinVersion = kotlinVersion,
+      kotlinVersion = kotlinLibraryVersions.kotlinVersion,
+      kotlinxSerializationJsonVersion = kotlinLibraryVersions.kotlinxSerializationJsonVersion,
       latestMinorsOfOldSupportedMajors = latestMinorsOfOldSupportedMajors,
       latestStable = latestStable,
       upcomingMajorEap = upcomingMajorEap,

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsTest.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsTest.kt
@@ -13,6 +13,7 @@ class IntellijVersionsTest {
     val iv = IntellijVersions(
       earliestSupportedMajor = ReleaseVersion("2020.3"),
       kotlinVersion = "1.9",
+      kotlinxSerializationJsonVersion = "1.6.3",
       latestMinorsOfOldSupportedMajors = listOf("2020.3.4", "2021.1.3", "2021.2.4", "2021.3.3", "2022.1.4").map { ReleaseVersion(it) },
       latestStable = ReleaseVersion("2022.2.2"),
       upcomingMajorEap = null,
@@ -32,6 +33,7 @@ class IntellijVersionsTest {
     val iv = IntellijVersions(
       earliestSupportedMajor = ReleaseVersion("2020.3"),
       kotlinVersion = "1.9",
+      kotlinxSerializationJsonVersion = "1.6.3",
       latestMinorsOfOldSupportedMajors = listOf("2020.3.4", "2021.1.3", "2021.2.4", "2021.3.3", "2022.1.4").map { ReleaseVersion(it) },
       latestStable = ReleaseVersion("2022.2.2"),
       upcomingMajorEap = BuildNumber("223.7571.182"),

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsTest.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsTest.kt
@@ -52,10 +52,10 @@ class IntellijVersionsTest {
   fun shouldRecognizeEqualVersions() {
     val version1 = BuildNumber("123.1234.56789")
     val version2 = BuildNumber("0.0.0")
-    assertFalse(version1 isNewerThan version1)
-    assertFalse(version2 isNewerThan version2)
+    assertEquals(0, version1 compareTo version1)
+    assertEquals(0, version2 compareTo version2)
 
-    assertThrows<IllegalArgumentException> { version1 isNewerThan ReleaseVersion("2025.3") }
+    assertThrows<IllegalArgumentException> { version1 compareTo ReleaseVersion("2025.3") }
   }
 
   @Test
@@ -63,7 +63,7 @@ class IntellijVersionsTest {
     val olderVersion = BuildNumber("1111.11.111")
     val newerVersions = listOf("1112.11.111", "1111.12.111", "1111.11.112", "1111.11.111.0").map { BuildNumber(it) }
 
-    for (newerVersion in newerVersions) assertTrue(newerVersion isNewerThan olderVersion)
+    for (newerVersion in newerVersions) assertTrue((newerVersion compareTo olderVersion) > 0)
   }
 
   @Test

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdaterTest.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdaterTest.kt
@@ -56,6 +56,7 @@ class IntellijVersionsUpdaterTest {
     val propertyKeys = listOf(
       "earliestSupportedMajor",
       "kotlinVersion",
+      "kotlinxSerializationJsonVersion",
       "latestMinorsOfOldSupportedMajors",
       "latestStable",
       "upcomingMajorEap",

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/MockIntelliJVersionsProvider.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/MockIntelliJVersionsProvider.kt
@@ -10,5 +10,5 @@ class MockIntelliJVersionsProvider(
     else -> emptyList()
   }
 
-  override fun getKotlinVersionForIntelliJ(intellijVersion: String): String = "1.9.22"
+  override fun getKotlinLibraryVersionsForIntelliJ(intellijVersion: String): KotlinLibraryVersions = KotlinLibraryVersions(kotlinVersion = "1.9.22", kotlinxSerializationJsonVersion = "1.6.3")
 }

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/INPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/OUTPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/INPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/OUTPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/INPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.5
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/OUTPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/INPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.5
 latestStable=2025.2.3
 upcomingMajorEap=

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/OUTPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/INPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.20558.43

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/OUTPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/INPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/OUTPUT.intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6,2025.2.3
 latestStable=2025.3
 upcomingMajorEap=

--- a/intellij-versions.properties
+++ b/intellij-versions.properties
@@ -1,5 +1,6 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.24
+kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.27642.30


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2164

## Chain of upstream PRs as of 2025-10-21

* PR #2163:
  `master` ← `develop`

  * PR #2162:
    `develop` ← `update-intellij-versions/8f8440efb862036a1855a0395344f09c`

    * PR #2164:
      `update-intellij-versions/8f8440efb862036a1855a0395344f09c` ← `refactor/kotlin-version`

      * **PR #2165 (THIS ONE)**:
        `refactor/kotlin-version` ← `chore/kotlinx-serialization-json`

<!-- end git-machete generated -->

- Rename property: earliestSupportedMajorKotlinVersion → kotlinVersion
- Add new property: kotlinxSerializationJsonVersion
- Update IntelliJVersionsProvider to fetch both versions from same JSON
- Extract common method extractLibraryVersionByUrl() to reduce duplication
- Use highest version when multiple library versions exist (via isNewerThan)
- Remove hardcoded kotlinx-serialization-json from TOML, read from properties
- Update all test files and test resources accordingly
- Verify updateIntellijVersions works correctly without modifying properties