### PR TITLE
[BUG DEMO] JUnit5TestEnvironmentInitializer implicitly depends on JUnit 4 classes

### DIFF
--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Dependencies.kt
@@ -114,7 +114,7 @@ fun Project.junit() {
     "testRuntimeOnly"(lib("junit-platformLauncher"))
     // JUnit 4 is for some reason needed since intellij-platform-gradle-plugin v2.4.0
     // (might change with future updates of this Gradle plugin; still there in v2.10.0)
-    "testRuntimeOnly"(lib("junit4"))
+    // "testRuntimeOnly"(lib("junit4"))
   }
 }
 


### PR DESCRIPTION
See https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2045