### PR TITLE
Move kotlinxSerializationJson to libs.versions.toml and remove from IntelliJ version checking

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,12 +34,10 @@ val properties = Properties()
 properties.load(rootDir.parentFile.resolve("intellij-versions.properties").inputStream())
 val kotlinVersion = properties.getProperty("kotlinVersion")!!
 val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-val kotlinxSerializationJsonVersion = properties.getProperty("kotlinxSerializationJsonVersion")!!
-val kotlinxSerializationJson = "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationJsonVersion"
 
 dependencies {
   implementation(kotlinGradlePlugin)
-  implementation(kotlinxSerializationJson)
+  implementation(libs.kotlinxSerializationJson)
   implementation(libs.pluginPackages.checkerFramework)
   implementation(libs.pluginPackages.grgit)
   implementation(libs.pluginPackages.spotless)

--- a/buildSrc/gradle/libs.versions.toml
+++ b/buildSrc/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jun
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
 junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
+kotlinxSerializationJson = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
 # Plugin packages
 # This way of applying the plugins is needed for the build-related code in buildSrc/src/main/,
 # see https://docs.gradle.org/current/samples/sample_convention_plugins.html#things_to_note.

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersions.kt
@@ -60,7 +60,6 @@ data class ReleaseVersion(override val value: String) : AnyVersion<ReleaseVersio
 data class IntellijVersions(
   val earliestSupportedMajor: ReleaseVersion,
   val kotlinVersion: String,
-  val kotlinxSerializationJsonVersion: String,
   val latestMinorsOfOldSupportedMajors: List<ReleaseVersion>,
   val latestStable: ReleaseVersion,
   val upcomingMajorEap: BuildNumber?,
@@ -89,7 +88,6 @@ data class IntellijVersions(
       // to the Kotlin version listed for `earliestSupportedMajor`
       // in https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#kotlin-standard-library
       val kotlinVersion: String = intellijVersionsProperties.getProperty("kotlinVersion")
-      val kotlinxSerializationJsonVersion: String = intellijVersionsProperties.getProperty("kotlinxSerializationJsonVersion")
 
       // Most recent minor versions of all major releases between the earliest supported (incl.)
       // and latest stable (excl.), used for binary compatibility checks and UI tests
@@ -109,7 +107,6 @@ data class IntellijVersions(
       return IntellijVersions(
         earliestSupportedMajor = earliestSupportedMajor,
         kotlinVersion = kotlinVersion,
-        kotlinxSerializationJsonVersion = kotlinxSerializationJsonVersion,
         latestMinorsOfOldSupportedMajors = latestMinorsOfOldSupportedMajors,
         latestStable = latestStable,
         upcomingMajorEap = upcomingMajorEap,
@@ -146,7 +143,6 @@ data class IntellijVersions(
     setProperty("upcomingMajorEap", upcomingMajorEap?.value ?: "")
     setProperty("earliestSupportedMajor", earliestSupportedMajor.value)
     setProperty("kotlinVersion", kotlinVersion)
-    setProperty("kotlinxSerializationJsonVersion", kotlinxSerializationJsonVersion)
     setProperty("latestMinorsOfOldSupportedMajors", latestMinorsOfOldSupportedMajors.joinToString(separator = ",") { it.value })
     setProperty("latestStable", latestStable.value)
   }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsProvider.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsProvider.kt
@@ -9,7 +9,6 @@ import java.net.URI
 
 data class KotlinLibraryVersions(
   val kotlinVersion: String,
-  val kotlinxSerializationJsonVersion: String,
 )
 
 interface IntelliJVersionsProvider {
@@ -76,13 +75,7 @@ class RealIntelliJVersionsProvider : IntelliJVersionsProvider {
       intellijVersion,
     )
 
-    val kotlinxSerializationJsonVersion = extractLibraryVersionByUrl(
-      jsonElement,
-      "https://github.com/Kotlin/kotlinx.serialization",
-      intellijVersion,
-    )
-
-    println("getKotlinLibraryVersionsForIntelliJ($intellijVersion) = KotlinLibraryVersions(kotlinVersion=$kotlinVersion, kotlinxSerializationJsonVersion=$kotlinxSerializationJsonVersion)\n")
-    return KotlinLibraryVersions(kotlinVersion, kotlinxSerializationJsonVersion)
+    println("getKotlinLibraryVersionsForIntelliJ($intellijVersion) = KotlinLibraryVersions(kotlinVersion=$kotlinVersion)\n")
+    return KotlinLibraryVersions(kotlinVersion)
   }
 }

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdater.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdater.kt
@@ -41,7 +41,6 @@ class IntellijVersionsUpdater(private val versionsProvider: IntelliJVersionsProv
     return IntellijVersions(
       earliestSupportedMajor = earliestSupportedMajor,
       kotlinVersion = kotlinLibraryVersions.kotlinVersion,
-      kotlinxSerializationJsonVersion = kotlinLibraryVersions.kotlinxSerializationJsonVersion,
       latestMinorsOfOldSupportedMajors = latestMinorsOfOldSupportedMajors,
       latestStable = latestStable,
       upcomingMajorEap = upcomingMajorEap,

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsTest.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsTest.kt
@@ -13,7 +13,6 @@ class IntellijVersionsTest {
     val iv = IntellijVersions(
       earliestSupportedMajor = ReleaseVersion("2020.3"),
       kotlinVersion = "1.9",
-      kotlinxSerializationJsonVersion = "1.6.3",
       latestMinorsOfOldSupportedMajors = listOf("2020.3.4", "2021.1.3", "2021.2.4", "2021.3.3", "2022.1.4").map { ReleaseVersion(it) },
       latestStable = ReleaseVersion("2022.2.2"),
       upcomingMajorEap = null,
@@ -33,7 +32,6 @@ class IntellijVersionsTest {
     val iv = IntellijVersions(
       earliestSupportedMajor = ReleaseVersion("2020.3"),
       kotlinVersion = "1.9",
-      kotlinxSerializationJsonVersion = "1.6.3",
       latestMinorsOfOldSupportedMajors = listOf("2020.3.4", "2021.1.3", "2021.2.4", "2021.3.3", "2022.1.4").map { ReleaseVersion(it) },
       latestStable = ReleaseVersion("2022.2.2"),
       upcomingMajorEap = BuildNumber("223.7571.182"),

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdaterTest.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/IntellijVersionsUpdaterTest.kt
@@ -56,7 +56,6 @@ class IntellijVersionsUpdaterTest {
     val propertyKeys = listOf(
       "earliestSupportedMajor",
       "kotlinVersion",
-      "kotlinxSerializationJsonVersion",
       "latestMinorsOfOldSupportedMajors",
       "latestStable",
       "upcomingMajorEap",

--- a/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/MockIntelliJVersionsProvider.kt
+++ b/buildSrc/src/test/kotlin/com/virtuslab/gitmachete/buildsrc/MockIntelliJVersionsProvider.kt
@@ -10,5 +10,5 @@ class MockIntelliJVersionsProvider(
     else -> emptyList()
   }
 
-  override fun getKotlinLibraryVersionsForIntelliJ(intellijVersion: String): KotlinLibraryVersions = KotlinLibraryVersions(kotlinVersion = "1.9.22", kotlinxSerializationJsonVersion = "1.6.3")
+  override fun getKotlinLibraryVersionsForIntelliJ(intellijVersion: String): KotlinLibraryVersions = KotlinLibraryVersions(kotlinVersion = "1.9.22")
 }

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/INPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/0-no-updates-available/OUTPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/INPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/1-first-eap-of-upcoming-major/OUTPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/INPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.5
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/2-new-minor-with-eap/OUTPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/INPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.5
 latestStable=2025.2.3
 upcomingMajorEap=

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/3-new-minor-no-eap/OUTPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/INPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.20558.43

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/4-newer-eap-for-same-major/OUTPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/INPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/INPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6
 latestStable=2025.2.3
 upcomingMajorEap=253.25908.13

--- a/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/OUTPUT.intellij-versions.properties
+++ b/buildSrc/src/test/resources/intellij-versions-test-cases/5-eap-major-becomes-stable/OUTPUT.intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.2
 kotlinVersion=1.9.22
-kotlinxSerializationJsonVersion=1.6.3
 latestMinorsOfOldSupportedMajors=2024.2.6,2024.3.7,2025.1.6,2025.2.3
 latestStable=2025.3
 upcomingMajorEap=

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref 
 junit-platformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 kodein = "org.kodein.di:kodein-di-jvm:7.30.0"
 kotlin-coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2"
+kotlinxSerializationJson = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
 lombok = "org.projectlombok:lombok:1.18.42"
 mockito = "org.mockito:mockito-junit-jupiter:5.20.0"
 okhttp = "com.squareup.okhttp3:okhttp:5.3.2"

--- a/intellij-versions.properties
+++ b/intellij-versions.properties
@@ -1,6 +1,5 @@
 earliestSupportedMajor=2024.3
 kotlinVersion=2.0.21-RC
-kotlinxSerializationJsonVersion=1.9.0
 latestMinorsOfOldSupportedMajors=2024.3.7,2025.1.7
 latestStable=2025.2.5
 upcomingMajorEap=253.28294.169


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2195

## Chain of upstream PRs as of 2025-12-01

* PR #2195:
  `develop` ← `dependabot/gradle/develop/deps-45fa176dff`

  * **PR #2196 (THIS ONE)**:
    `dependabot/gradle/develop/deps-45fa176dff` ← `chore/remove-kotlinx`

<!-- end git-machete generated -->

- Moved kotlinxSerializationJson dependency from intellij-versions.properties to both libs.versions.toml files
- Removed automatic version checking logic from IntellijVersions, IntellijVersionsProvider, and IntellijVersionsUpdater
- Updated buildSrc/build.gradle.kts to use version catalog
- Updated all test files and test resources to reflect the changes
- kotlinxSerializationJson is now managed as a regular dependency like any other