### PR TITLE
Bump JDK for compilation to 21

### DIFF
--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IBranchReference.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IBranchReference.java
@@ -38,10 +38,10 @@ public interface IBranchReference {
   static boolean defaultEquals(@FindDistinct IBranchReference self, @Nullable Object other) {
     if (self == other) {
       return true;
-    } else if (!(other instanceof IBranchReference)) {
+    } else if (!(other instanceof IBranchReference otherBranch)) {
       return false;
     } else {
-      return self.getFullName().equals(((IBranchReference) other).getFullName());
+      return self.getFullName().equals(otherBranch.getFullName());
     }
   }
 

--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/ICommitOfManagedBranch.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/ICommitOfManagedBranch.java
@@ -27,10 +27,10 @@ public interface ICommitOfManagedBranch {
   static boolean defaultEquals(@FindDistinct ICommitOfManagedBranch self, @Nullable Object other) {
     if (self == other) {
       return true;
-    } else if (!(other instanceof ICommitOfManagedBranch)) {
+    } else if (!(other instanceof ICommitOfManagedBranch otherCommit)) {
       return false;
     } else {
-      return self.getHash().equals(((ICommitOfManagedBranch) other).getHash());
+      return self.getHash().equals(otherCommit.getHash());
     }
   }
 

--- a/branchLayout/api/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
+++ b/branchLayout/api/src/main/java/com/virtuslab/branchlayout/api/BranchLayout.java
@@ -160,10 +160,9 @@ public class BranchLayout {
   public final boolean equals(@Nullable Object other) {
     if (this == other) {
       return true;
-    } else if (!(other instanceof BranchLayout)) {
+    } else if (!(other instanceof BranchLayout otherLayout)) {
       return false;
     } else {
-      val otherLayout = (BranchLayout) other;
       if (this.rootEntries.size() == otherLayout.rootEntries.size()) {
         val entryNameComparator = Comparator.comparing(BranchLayoutEntry::getName);
 

--- a/branchLayout/api/src/main/java/com/virtuslab/branchlayout/api/BranchLayoutEntry.java
+++ b/branchLayout/api/src/main/java/com/virtuslab/branchlayout/api/BranchLayoutEntry.java
@@ -65,10 +65,9 @@ public final class BranchLayoutEntry {
   public boolean equals(@Nullable Object other) {
     if (this == other) {
       return true;
-    } else if (!(other instanceof BranchLayoutEntry)) {
+    } else if (!(other instanceof BranchLayoutEntry otherEntry)) {
       return false;
     } else {
-      val otherEntry = (BranchLayoutEntry) other;
       val areNamesSame = this.name.equals(otherEntry.name);
       val areCustomAnnotationsSame = Objects.equals(this.customAnnotation, otherEntry.customAnnotation);
 

--- a/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreBranchSnapshot.java
+++ b/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreBranchSnapshot.java
@@ -1,7 +1,6 @@
 package com.virtuslab.gitcore.api;
 
 import io.vavr.collection.List;
-import lombok.val;
 import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -34,12 +33,11 @@ public interface IGitCoreBranchSnapshot {
   static boolean defaultEquals(@FindDistinct IGitCoreBranchSnapshot self, @Nullable Object other) {
     if (self == other) {
       return true;
-    } else if (!(other instanceof IGitCoreBranchSnapshot)) {
+    } else if (!(other instanceof IGitCoreBranchSnapshot otherBranch)) {
       return false;
     } else {
-      val o = (IGitCoreBranchSnapshot) other;
-      return self.getFullName().equals(o.getFullName())
-          && self.getPointedCommit().equals(o.getPointedCommit());
+      return self.getFullName().equals(otherBranch.getFullName())
+          && self.getPointedCommit().equals(otherBranch.getPointedCommit());
     }
   }
 

--- a/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreCommit.java
+++ b/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreCommit.java
@@ -24,10 +24,10 @@ public interface IGitCoreCommit {
   static boolean defaultEquals(@FindDistinct IGitCoreCommit self, @Nullable Object other) {
     if (self == other) {
       return true;
-    } else if (!(other instanceof IGitCoreCommit)) {
+    } else if (!(other instanceof IGitCoreCommit otherCommit)) {
       return false;
     } else {
-      return self.getHash().equals(((IGitCoreCommit) other).getHash());
+      return self.getHash().equals(otherCommit.getHash());
     }
   }
 

--- a/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreObjectHash.java
+++ b/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreObjectHash.java
@@ -27,10 +27,10 @@ public interface IGitCoreObjectHash {
   static boolean defaultEquals(@FindDistinct IGitCoreObjectHash self, @Nullable Object other) {
     if (self == other) {
       return true;
-    } else if (!(other instanceof IGitCoreObjectHash)) {
+    } else if (!(other instanceof IGitCoreObjectHash otherHash)) {
       return false;
     } else {
-      return self.getHashString().equals(((IGitCoreObjectHash) other).getHashString());
+      return self.getHashString().equals(otherHash.getHashString());
     }
   }
 

--- a/java-version.properties
+++ b/java-version.properties
@@ -1,2 +1,2 @@
 jdkVersionForRunningGradle=21
-jdkVersionForGeneratedClassfiles=17
+jdkVersionForGeneratedClassfiles=21


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2232

## Chain of upstream PRs as of 2026-02-09

* PR #2232:
  `develop` ← `fix/global-core-hooks-path`

  * **PR #2231 (THIS ONE)**:
    `fix/global-core-hooks-path` ← `fix/bump-jdk-21-ui-test`

<!-- end git-machete generated -->
