### PR TITLE
Fix Squash action incorrectly remaining visible (fixes #2260)

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v7.0.1
+- Added: auto-discovery of the branch layout in case of multiple repositories
+- Fixed: branch layout and actions availability in case of multiple repositories
 
 ## v7.0.0
 - Added: support for IntelliJ 2026.1.

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSquashAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSquashAction.java
@@ -85,6 +85,8 @@ public abstract class BaseSquashAction extends BaseGitMacheteRepositoryReadyActi
           }
         }
       }
+    } else {
+      presentation.setVisible(false);
     }
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SquashCurrentAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/SquashCurrentAction.java
@@ -50,6 +50,8 @@ public class SquashCurrentAction extends BaseSquashAction {
           presentation.setDescription(getNonHtmlString("action.GitMachete.SquashCurrentAction.description"));
         }
       }
+    } else {
+      presentation.setVisible(false);
     }
   }
 

--- a/frontend/base/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/base/src/main/resources/GitMacheteBundle.properties
@@ -349,7 +349,6 @@ string.GitMachete.EnhancedGraphTable.duplicated-branches-text=The following bran
 string.GitMachete.EnhancedGraphTable.empty-table-text.cannot-discover-layout=Provided machete file ({0}) is empty and branch layout can''t be automatically detected
 string.GitMachete.EnhancedGraphTable.empty-table-text.loading=Loading\u2026
 string.GitMachete.EnhancedGraphTable.empty-table-text.only-skipped-in-machete-file=None of the branches provided by machete file ({0}) exists within the local repository
-string.GitMachete.EnhancedGraphTable.empty-table-text.try-running-discover=Provided machete file ({0}) is empty, try running ''Discover Branch Layout''
 string.GitMachete.EnhancedGraphTable.skipped-branches-text=Some branches listed in machete file do not exist: {0}
 
 action.GitMachete.EnhancedGraphTable.unmanaged-branch-notification.action.slide-in=Slide in under ''{0}''

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -362,12 +362,10 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
       repositoryGraph = repositoryGraphCache.getRepositoryGraph(snapshot, isListingCommits);
       if (snapshot.getRootBranches().isEmpty()) {
         if (snapshot.getSkippedBranchNames().isEmpty()) {
-          LOG.info("Machete file (${macheteFilePath}) is empty");
+          LOG.info("Machete file (${macheteFilePath}) is empty, so auto discover is running");
           setModel(new GraphTableModel(repositoryGraph));
           selectedBranchName = null;
-          setTextForEmptyTable(
-              getString("string.GitMachete.EnhancedGraphTable.empty-table-text.try-running-discover")
-                  .fmt(macheteFilePath.toString()));
+          queueDiscover(macheteFilePath, doOnUIThreadWhenReady);
           return;
         } else {
           setTextForEmptyTable(

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -357,11 +357,14 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
     val snapshot = gitMacheteRepositorySnapshot;
     if (snapshot == null) {
       repositoryGraph = NullRepositoryGraph.getInstance();
+      selectedBranchName = null;
     } else {
       repositoryGraph = repositoryGraphCache.getRepositoryGraph(snapshot, isListingCommits);
       if (snapshot.getRootBranches().isEmpty()) {
         if (snapshot.getSkippedBranchNames().isEmpty()) {
           LOG.info("Machete file (${macheteFilePath}) is empty");
+          setModel(new GraphTableModel(repositoryGraph));
+          selectedBranchName = null;
           setTextForEmptyTable(
               getString("string.GitMachete.EnhancedGraphTable.empty-table-text.try-running-discover")
                   .fmt(macheteFilePath.toString()));
@@ -376,6 +379,8 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
 
     if (!isMacheteFilePresent) {
       LOG.info("Machete file (${macheteFilePath}) is absent, so auto discover is running");
+      setModel(new GraphTableModel(repositoryGraph));
+      selectedBranchName = null;
       // The `doOnUIThreadWhenReady` callback must be executed once the discover task is *complete*,
       // and not just when the discover task is *enqueued*.
       // Otherwise, it'll most likely happen that the callback executes before the discover task is complete,


### PR DESCRIPTION
In this PR:
1. Fix squash action visibility — previously it was not being hidden in some cases
2. Fix branch layout issues on switching git modules — previously the branch layout was persisted in UI and that led to inconsistency and wrong actions being available
3. Auto-discover branch layout in case of empty — I cannot see much point in saying to the user "the branch layout is empty, try to discover". We can do that for them. I think it is a better UX.