### PR TITLE
Suppress spurious yellow edge; list all parent..branch commits, mark fork point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local Maven proxy URL (optional); see gradle-local.properties.example
+/gradle-local.properties
+
 /allure-results/
 bin/
 build/

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v7.0.2
+- Changed: when listing commits, all commits between the parent branch and the branch tip are now listed (rather than just between the fork point and the branch tip), with the fork point commit annotated `-> fork point`; this makes it easier to spot commits that side-effecting commands (rebase, squash, etc.) will skip due to a non-trivial fork point (e.g. fork point override, or fork point landing on parent's remote counterpart)
 - Fixed: spurious yellow edge no longer appears in `status` when the parent branch is merely behind its remote counterpart and the child branch was forked from the remote tip
 - Fixed: "Show in Git Log" action jumping to a commit in the wrong repository in multi-root projects
 - Fixed: stale "no need to fetch" cache hits across repositories sharing the same directory name in multi-root projects

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v7.0.2
+- Fixed: spurious yellow edge no longer appears in `status` when the parent branch is merely behind its remote counterpart and the child branch was forked from the remote tip
 - Fixed: "Show in Git Log" action jumping to a commit in the wrong repository in multi-root projects
 - Fixed: stale "no need to fetch" cache hits across repositories sharing the same directory name in multi-root projects
 - Fixed: "Don't show for this branch" preference of the unmanaged-branch notification was leaking across repositories that share a branch name in multi-root projects

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
@@ -221,19 +221,9 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
       uniqueCommits = List.empty();
     } else if (syncToParentStatus == SyncToParentStatus.MergedToParent) {
       uniqueCommits = List.empty();
-    } else if (syncToParentStatus == SyncToParentStatus.OutOfSync) {
-      // For red edges the branch is NOT a descendant of its parent. Calling `deriveCommitRange` directly with
-      // the parent's tip as `untilExclusive` would expose a quirk of `RevSort.BOUNDARY`: the merge-base would
-      // leak into the result as a phantom extra commit. Instead, we explicitly derive the merge-base and use
-      // it as the lower bound; this matches CLI's `git log parent..branch` semantics (which returns commits
-      // reachable from branch but not parent - i.e. branch's commits since the merge-base).
-      val mergeBase = gitCoreRepository.deriveAnyMergeBase(corePointedCommit, parentCoreLocalBranch.getPointedCommit());
-      uniqueCommits = mergeBase != null
-          ? gitCoreRepository.deriveCommitRange(corePointedCommit, mergeBase)
-          : gitCoreRepository.deriveCommitRange(corePointedCommit, forkPoint.getCoreCommit());
     } else {
-      // For yellow and green edges (where branch IS a descendant of parent), include the entire range from the
-      // commit pointed by the branch until its parent. This makes it possible to highlight the fork point
+      // For all of yellow, green and red edges we include the entire range from the commit pointed by the branch
+      // until its parent (rather than just until its fork point). This makes it possible to highlight the fork point
       // candidate on the commit listing - and lets the user spot commits that side-effecting commands
       // (rebase/squash/etc.) will skip due to a non-trivial fork point (e.g. fork point override or
       // fork point landing on parent's remote counterpart).

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
@@ -221,9 +221,15 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
       uniqueCommits = List.empty();
     } else if (syncToParentStatus == SyncToParentStatus.MergedToParent) {
       uniqueCommits = List.empty();
+    } else if (syncToParentStatus == SyncToParentStatus.OutOfSync) {
+      // For red edges the branch has diverged from its parent: there is no clean linear `parent..branch`
+      // path, and listing the full range would show parent's commits that aren't on the branch at all.
+      // List only the unique commits of the branch (`fork-point..branch`, exclusive); this matches what
+      // side-effecting commands (rebase/squash/...) operate on.
+      uniqueCommits = gitCoreRepository.deriveCommitRange(corePointedCommit, forkPoint.getCoreCommit());
     } else {
-      // For all of yellow, green and red edges we include the entire range from the commit pointed by the branch
-      // until its parent (rather than just until its fork point). This makes it possible to highlight the fork point
+      // For yellow and green edges (where branch IS a descendant of parent), include the entire range from the
+      // commit pointed by the branch until its parent. This makes it possible to highlight the fork point
       // candidate on the commit listing - and lets the user spot commits that side-effecting commands
       // (rebase/squash/etc.) will skip due to a non-trivial fork point (e.g. fork point override or
       // fork point landing on parent's remote counterpart).

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
@@ -495,6 +495,25 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
   }
 
   @UIThreadUnsafe
+  private boolean isForkPointOnParentRemoteCounterpart(
+      IGitCoreLocalBranchSnapshot parentCoreLocalBranch,
+      IGitCoreCommit forkPoint) throws GitCoreException {
+    // Suppresses the spurious yellow edge that appears when the parent branch is merely behind
+    // its remote counterpart and the child branch was forked from a commit on the remote
+    // that is ahead of parent's local HEAD. We require that the fork point lies strictly
+    // between parent's local HEAD and parent's remote counterpart, so that legitimate
+    // yellow edges (where the fork point is older than parent's local HEAD) are preserved.
+    IGitCoreRemoteBranchSnapshot parentRemoteTrackingBranch = parentCoreLocalBranch.getRemoteTrackingBranch();
+    if (parentRemoteTrackingBranch == null) {
+      return false;
+    }
+    IGitCoreCommit parentPointedCommit = parentCoreLocalBranch.getPointedCommit();
+    IGitCoreCommit parentRemotePointedCommit = parentRemoteTrackingBranch.getPointedCommit();
+    return gitCoreRepository.isAncestor(parentPointedCommit, forkPoint)
+        && gitCoreRepository.isAncestorOrEqual(forkPoint, parentRemotePointedCommit);
+  }
+
+  @UIThreadUnsafe
   public SyncToParentStatus deriveSyncToParentStatus(
       IGitCoreLocalBranchSnapshot coreLocalBranch,
       IGitCoreLocalBranchSnapshot parentCoreLocalBranch,
@@ -531,6 +550,12 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
               () -> "For this branch (${branchName}) its parent's commit is ancestor of this branch pointed commit "
                   + "and fork point is absent or overridden or equal to parent branch commit, " +
                   "so we assume that this branch is in sync");
+          return SyncToParentStatus.InSync;
+        } else if (isForkPointOnParentRemoteCounterpart(parentCoreLocalBranch, forkPoint.getCoreCommit())) {
+          LOG.debug(
+              () -> "For this branch (${branchName}) its parent's commit is ancestor of this branch pointed commit "
+                  + "and fork point lies between parent's local HEAD and parent's remote counterpart "
+                  + "(parent is just behind its remote), so we assume that this branch is in sync");
           return SyncToParentStatus.InSync;
         } else {
           LOG.debug(

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
@@ -221,9 +221,19 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
       uniqueCommits = List.empty();
     } else if (syncToParentStatus == SyncToParentStatus.MergedToParent) {
       uniqueCommits = List.empty();
+    } else if (syncToParentStatus == SyncToParentStatus.OutOfSync) {
+      // For red edges the branch is NOT a descendant of its parent. Calling `deriveCommitRange` directly with
+      // the parent's tip as `untilExclusive` would expose a quirk of `RevSort.BOUNDARY`: the merge-base would
+      // leak into the result as a phantom extra commit. Instead, we explicitly derive the merge-base and use
+      // it as the lower bound; this matches CLI's `git log parent..branch` semantics (which returns commits
+      // reachable from branch but not parent - i.e. branch's commits since the merge-base).
+      val mergeBase = gitCoreRepository.deriveAnyMergeBase(corePointedCommit, parentCoreLocalBranch.getPointedCommit());
+      uniqueCommits = mergeBase != null
+          ? gitCoreRepository.deriveCommitRange(corePointedCommit, mergeBase)
+          : gitCoreRepository.deriveCommitRange(corePointedCommit, forkPoint.getCoreCommit());
     } else {
-      // For all of yellow, green and red edges we include the entire range from the commit pointed by the branch
-      // until its parent (rather than just until its fork point). This makes it possible to highlight the fork point
+      // For yellow and green edges (where branch IS a descendant of parent), include the entire range from the
+      // commit pointed by the branch until its parent. This makes it possible to highlight the fork point
       // candidate on the commit listing - and lets the user spot commits that side-effecting commands
       // (rebase/squash/etc.) will skip due to a non-trivial fork point (e.g. fork point override or
       // fork point landing on parent's remote counterpart).

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
@@ -221,13 +221,13 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
       uniqueCommits = List.empty();
     } else if (syncToParentStatus == SyncToParentStatus.MergedToParent) {
       uniqueCommits = List.empty();
-    } else if (syncToParentStatus == SyncToParentStatus.InSyncButForkPointOff) {
-      // In case of yellow edge, we include the entire range from the commit pointed by the branch until its parent,
-      // and not until just its fork point. This makes it possible to highlight the fork point candidate on the commit listing.
-      uniqueCommits = gitCoreRepository.deriveCommitRange(corePointedCommit, parentCoreLocalBranch.getPointedCommit());
     } else {
-      // We're handling the cases of green and red edges here.
-      uniqueCommits = gitCoreRepository.deriveCommitRange(corePointedCommit, forkPoint.getCoreCommit());
+      // For all of yellow, green and red edges we include the entire range from the commit pointed by the branch
+      // until its parent (rather than just until its fork point). This makes it possible to highlight the fork point
+      // candidate on the commit listing - and lets the user spot commits that side-effecting commands
+      // (rebase/squash/etc.) will skip due to a non-trivial fork point (e.g. fork point override or
+      // fork point landing on parent's remote counterpart).
+      uniqueCommits = gitCoreRepository.deriveCommitRange(corePointedCommit, parentCoreLocalBranch.getPointedCommit());
     }
 
     val pointedCommit = new CommitOfManagedBranch(corePointedCommit);

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
@@ -117,6 +117,7 @@ public class StatusAndDiscoverIntegrationTestSuite extends BaseIntegrationTestSu
 
     val commits = branch.getUniqueCommits().reverse();
     val forkPoint = branch.getForkPoint();
+    val isForkPointOff = branch.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff;
 
     for (val c : commits) {
       sb.append("  ");
@@ -125,9 +126,13 @@ public class StatusAndDiscoverIntegrationTestSuite extends BaseIntegrationTestSu
 
       sb.append(c.getShortMessage());
       if (c.equals(forkPoint)) {
-        sb.append(" -> fork point ??? commit ${forkPoint.getShortHash()} seems to be a part of the unique history of ");
-        List<IBranchReference> uniqueBranchesContainingInReflog = forkPoint.getUniqueBranchesContainingInReflog();
-        sb.append(uniqueBranchesContainingInReflog.map(IBranchReference::getName).sorted().mkString(" and "));
+        if (isForkPointOff) {
+          sb.append(" -> fork point ??? commit ${forkPoint.getShortHash()} seems to be a part of the unique history of ");
+          List<IBranchReference> uniqueBranchesContainingInReflog = forkPoint.getUniqueBranchesContainingInReflog();
+          sb.append(uniqueBranchesContainingInReflog.map(IBranchReference::getName).sorted().mkString(" and "));
+        } else {
+          sb.append(" -> fork point");
+        }
       }
       sb.append(System.lineSeparator());
     }

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite.java
@@ -4,6 +4,7 @@ import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.TestGitCoreRef
 import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.createGitCoreCommit;
 import static com.virtuslab.gitmachete.backend.unit.UnitTestUtils.createGitCoreLocalBranch;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.vavr.collection.List;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import com.virtuslab.gitcore.api.IGitCoreCommit;
 import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
+import com.virtuslab.gitcore.api.IGitCoreRemoteBranchSnapshot;
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.backend.impl.ForkPointCommitOfManagedBranch;
 
@@ -90,6 +92,30 @@ public class GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite extends
 
     // then
     assertEquals(SyncToParentStatus.InSyncButForkPointOff, syncToParentStatus);
+  }
+
+  @Test
+  @SneakyThrows
+  public void parentBehindRemoteAndForkPointBetweenLocalAndRemote_inSync() {
+    // given
+    IGitCoreCommit parentCommit = createGitCoreCommit();
+    IGitCoreCommit forkPointCommit = createGitCoreCommit();
+    IGitCoreCommit parentRemoteCommit = createGitCoreCommit();
+    IGitCoreCommit childCommit = createGitCoreCommit();
+    IGitCoreLocalBranchSnapshot parentBranch = createGitCoreLocalBranch(parentCommit);
+    IGitCoreLocalBranchSnapshot childBranch = createGitCoreLocalBranch(childCommit);
+    IGitCoreRemoteBranchSnapshot parentRemoteBranch = mock(IGitCoreRemoteBranchSnapshot.class);
+    when(parentRemoteBranch.getPointedCommit()).thenReturn(parentRemoteCommit);
+    when(parentBranch.getRemoteTrackingBranch()).thenReturn(parentRemoteBranch);
+    when(gitCoreRepository.isAncestorOrEqual(parentCommit, childCommit)).thenReturn(true);
+    when(gitCoreRepository.isAncestor(parentCommit, forkPointCommit)).thenReturn(true);
+    when(gitCoreRepository.isAncestorOrEqual(forkPointCommit, parentRemoteCommit)).thenReturn(true);
+
+    // when
+    SyncToParentStatus syncToParentStatus = invokeDeriveSyncToParentStatus(childBranch, parentBranch, forkPointCommit);
+
+    // then
+    assertEquals(SyncToParentStatus.InSync, syncToParentStatus);
   }
 
   @Test

--- a/backend/impl/src/test/resources/setup-for-overridden-fork-point.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-for-overridden-fork-point.sh-status.txt
@@ -1,4 +1,5 @@
   develop  <2 files>
   |
+  | Allow ownership links -> fork point
   | Build arbitrarily long chains
   o-build-chain *  <4 files>

--- a/backend/impl/src/test/resources/setup-for-squash-merge.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-for-squash-merge.sh-status.txt
@@ -2,9 +2,5 @@
   |
   m-allow-ownership-link  PR #123 (untracked)  <3 files>
   |
-  | Allow ownership links
-  | 1st round of fixes
-  | Master commit
-  | Other master commit -> fork point
   | Build arbitrarily long chains
   x-build-chain *  <6 files>

--- a/backend/impl/src/test/resources/setup-for-squash-merge.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-for-squash-merge.sh-status.txt
@@ -2,5 +2,9 @@
   |
   m-allow-ownership-link  PR #123 (untracked)  <3 files>
   |
+  | Allow ownership links
+  | 1st round of fixes
+  | Master commit
+  | Other master commit -> fork point
   | Build arbitrarily long chains
   x-build-chain *  <6 files>

--- a/backend/impl/src/test/resources/setup-with-single-remote.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-with-single-remote.sh-discover.txt
@@ -9,9 +9,8 @@
   | Allow ownership links
   x-allow-ownership-link (behind origin)  <3 files>
   | |
-  | | 1st round of fixes -> fork point ??? commit 9d422de seems to be a part of the unique history of allow-ownership-link
   | | Use new icons
-  | ?-update-icons (behind origin)  <5 files>
+  | o-update-icons (behind origin)  <5 files>
   |   |
   |   | Build arbitrarily long chains
   |   o-build-chain (untracked)  <6 files>

--- a/backend/impl/src/test/resources/setup-with-single-remote.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-with-single-remote.sh-discover.txt
@@ -9,6 +9,7 @@
   | Allow ownership links
   x-allow-ownership-link (behind origin)  <3 files>
   | |
+  | | 1st round of fixes -> fork point
   | | Use new icons
   | o-update-icons (behind origin)  <5 files>
   |   |

--- a/backend/impl/src/test/resources/setup-with-single-remote.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-with-single-remote.sh-status.txt
@@ -3,9 +3,8 @@
   | Allow ownership links
   x-allow-ownership-link  PR #123 (behind origin)  <3 files>
   | |
-  | | 1st round of fixes -> fork point ??? commit 9d422de seems to be a part of the unique history of allow-ownership-link
   | | Use new icons
-  | ?-update-icons (behind origin)  <5 files>
+  | o-update-icons (behind origin)  <5 files>
   | |
   | | 1st round of fixes
   | | Use new icons -> fork point ??? commit 89fd9a5 seems to be a part of the unique history of update-icons

--- a/backend/impl/src/test/resources/setup-with-single-remote.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-with-single-remote.sh-status.txt
@@ -3,6 +3,7 @@
   | Allow ownership links
   x-allow-ownership-link  PR #123 (behind origin)  <3 files>
   | |
+  | | 1st round of fixes -> fork point
   | | Use new icons
   | o-update-icons (behind origin)  <5 files>
   | |

--- a/backend/impl/src/test/resources/version.txt
+++ b/backend/impl/src/test/resources/version.txt
@@ -1,1 +1,1 @@
-git-machete version 3.37.1
+git-machete version 3.41.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,12 +60,15 @@ val optionalMavenProxyFromGradleLocal: String? = run {
     ?.takeIf { it.isNotEmpty() }
 }
 
-// gradle/init.gradle (auto-applied by ./gradlew) rewrites mavenCentral() URLs when mavenProxyUrl
-// is set in gradle-local.properties. Optional proxy entry is still listed first for mirrors.
+// Either the corporate proxy or Maven Central - never both (see gradle-local.properties.example).
+// gradle/init.gradle still rewrites any stray Central URLs (e.g. from plugins) when the proxy is set.
 fun org.gradle.api.artifacts.dsl.RepositoryHandler.standardMavenRepositories() {
   mavenLocal()
-  optionalMavenProxyFromGradleLocal?.let { maven(it) }
-  mavenCentral()
+  if (optionalMavenProxyFromGradleLocal != null) {
+    maven(optionalMavenProxyFromGradleLocal)
+  } else {
+    mavenCentral()
+  }
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URI
 import java.util.Base64
+import java.util.Properties
 import java.util.zip.ZipEntry
 import java.util.zip.ZipFile
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion as GradleKotlinVersion
@@ -49,10 +50,27 @@ val shouldRunAllCheckers: Boolean by extra(isCI || project.hasProperty("runAllCh
 
 tasks.register<UpdateIntellijVersions>("updateIntellijVersions")
 
+// Optional Maven proxy URL from gitignored gradle-local.properties (see gradle-local.properties.example).
+val optionalMavenProxyFromGradleLocal: String? = run {
+  val f = rootDir.resolve("gradle-local.properties")
+  if (!f.isFile) return@run null
+  Properties().apply { f.reader().use { load(it) } }
+    .getProperty("mavenProxyUrl")
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }
+}
+
+// gradle/init.gradle (auto-applied by ./gradlew) rewrites mavenCentral() URLs when mavenProxyUrl
+// is set in gradle-local.properties. Optional proxy entry is still listed first for mirrors.
+fun org.gradle.api.artifacts.dsl.RepositoryHandler.standardMavenRepositories() {
+  mavenLocal()
+  optionalMavenProxyFromGradleLocal?.let { maven(it) }
+  mavenCentral()
+}
+
 allprojects {
   repositories {
-    mavenLocal()
-    mavenCentral()
+    standardMavenRepositories()
   }
 
   apply<JavaLibraryPlugin>()
@@ -183,7 +201,7 @@ subprojects {
     applyGuiEffectChecker()
 
     repositories {
-      mavenCentral()
+      standardMavenRepositories()
       intellijPlatform {
         defaultRepositories()
         jetbrainsRuntime()
@@ -220,7 +238,7 @@ group = "com.virtuslab"
 configureVersionFromGit()
 
 repositories {
-  mavenCentral()
+  standardMavenRepositories()
   intellijPlatform {
     defaultRepositories()
     jetbrainsRuntime()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,8 +24,19 @@ plugins {
   alias(libs.plugins.taskTree)
 }
 
+// Same optional proxy as root: gradle-local.properties at repo root (see gradle-local.properties.example).
+val optionalMavenProxyFromGradleLocal: String? = run {
+  val f = rootDir.parentFile.resolve("gradle-local.properties")
+  if (!f.isFile) return@run null
+  Properties().apply { f.reader().use { load(it) } }
+    .getProperty("mavenProxyUrl")
+    ?.trim()
+    ?.takeIf { it.isNotEmpty() }
+}
+
 repositories {
   mavenLocal()
+  optionalMavenProxyFromGradleLocal?.let { maven(it) }
   mavenCentral()
   gradlePluginPortal()
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -36,8 +36,11 @@ val optionalMavenProxyFromGradleLocal: String? = run {
 
 repositories {
   mavenLocal()
-  optionalMavenProxyFromGradleLocal?.let { maven(it) }
-  mavenCentral()
+  if (optionalMavenProxyFromGradleLocal != null) {
+    maven(optionalMavenProxyFromGradleLocal)
+  } else {
+    mavenCentral()
+  }
   gradlePluginPortal()
 }
 

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -7,19 +7,24 @@ rootProject.name = "buildSrc"
 pluginManagement {
   repositories {
     mavenLocal()
-    val f = File(settingsDir.parentFile, "gradle-local.properties")
-    if (f.isFile) {
-      val url = java.util.Properties().apply { f.reader().use { load(it) } }
+    val mavenProxyUrl = run {
+      val f = File(settingsDir.parentFile, "gradle-local.properties")
+      if (!f.isFile) {
+        return@run null
+      }
+      java.util.Properties().apply { f.reader().use { load(it) } }
         .getProperty("mavenProxyUrl")
         ?.trim()
         ?.takeIf { it.isNotEmpty() }
-      if (url != null) {
-        maven(url = uri(url))
-      }
+    }
+    if (mavenProxyUrl != null) {
+      maven(url = uri(mavenProxyUrl))
     }
     if (providers.gradleProperty("includePublicMavenReposForPlugins").orNull != "false") {
       gradlePluginPortal()
-      mavenCentral()
+      if (mavenProxyUrl == null) {
+        mavenCentral()
+      }
     }
   }
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,25 @@
+import java.io.File
+
+// buildSrc is a separate settings build: root pluginManagement does not apply here (gradle#29610).
+
+rootProject.name = "buildSrc"
+
+pluginManagement {
+  repositories {
+    mavenLocal()
+    val f = File(settingsDir.parentFile, "gradle-local.properties")
+    if (f.isFile) {
+      val url = java.util.Properties().apply { f.reader().use { load(it) } }
+        .getProperty("mavenProxyUrl")
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+      if (url != null) {
+        maven(url = uri(url))
+      }
+    }
+    if (providers.gradleProperty("includePublicMavenReposForPlugins").orNull != "false") {
+      gradlePluginPortal()
+      mavenCentral()
+    }
+  }
+}

--- a/frontend/base/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/base/src/main/resources/GitMacheteBundle.properties
@@ -316,8 +316,8 @@ string.GitMachete.error-report-submitter.report-action-text=Open Issue On GitHub
 # Graph Table
 
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit=commit
-string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point=fork point ?
-string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-simple=fork point
+string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point=fork point
+string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-question=fork point ?
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.found-in-reflog=seems to be a part of the unique history of
 
 string.GitMachete.BranchOrCommitCellRendererComponent.ongoing-operation.applying=APPLYING

--- a/frontend/base/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/base/src/main/resources/GitMacheteBundle.properties
@@ -317,6 +317,7 @@ string.GitMachete.error-report-submitter.report-action-text=Open Issue On GitHub
 
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit=commit
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point=fork point ?
+string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-simple=fork point
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.found-in-reflog=seems to be a part of the unique history of
 
 string.GitMachete.BranchOrCommitCellRendererComponent.ongoing-operation.applying=APPLYING

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -183,21 +183,23 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
       val forkPoint = containingBranch.getForkPoint();
 
       if (commitItem.getCommit().equals(forkPoint)) {
-        val isForkPointOff = containingBranch.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff;
-        val forkPointLabelKey = isForkPointOff
-            ? "string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point"
-            : "string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-simple";
-        append(
-            " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} " + getString(forkPointLabelKey),
-            new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
-        if (isForkPointOff) {
-          append(" " + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit") + " ",
+        if (containingBranch.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff) {
+          append(
+              " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} "
+                  + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point") + " ",
+              new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
+          append(getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit") + " ",
               REGULAR_ATTRIBUTES);
           append(forkPoint.getShortHash(), REGULAR_BOLD_ATTRIBUTES);
           append(" " + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.found-in-reflog")
               + " ", REGULAR_ATTRIBUTES);
           append(forkPoint.getUniqueBranchesContainingInReflog()
               .map(b -> b.getName()).sorted().mkString(", "), REGULAR_BOLD_ATTRIBUTES);
+        } else {
+          append(
+              " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} "
+                  + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-simple"),
+              new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
         }
       }
     }

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -53,6 +53,7 @@ import com.virtuslab.gitmachete.backend.api.INonRootManagedBranchSnapshot;
 import com.virtuslab.gitmachete.backend.api.IRootManagedBranchSnapshot;
 import com.virtuslab.gitmachete.backend.api.OngoingRepositoryOperationType;
 import com.virtuslab.gitmachete.backend.api.RelationToRemote;
+import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.frontend.defs.Colors;
 import com.virtuslab.gitmachete.frontend.graph.api.items.IBranchItem;
 import com.virtuslab.gitmachete.frontend.graph.api.items.ICommitItem;
@@ -182,17 +183,22 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
       val forkPoint = containingBranch.getForkPoint();
 
       if (commitItem.getCommit().equals(forkPoint)) {
+        val isForkPointOff = containingBranch.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff;
+        val forkPointLabelKey = isForkPointOff
+            ? "string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point"
+            : "string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-simple";
         append(
-            " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} "
-                + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point") + " ",
+            " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} " + getString(forkPointLabelKey),
             new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
-        append(getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit") + " ",
-            REGULAR_ATTRIBUTES);
-        append(forkPoint.getShortHash(), REGULAR_BOLD_ATTRIBUTES);
-        append(" " + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.found-in-reflog")
-            + " ", REGULAR_ATTRIBUTES);
-        append(forkPoint.getUniqueBranchesContainingInReflog()
-            .map(b -> b.getName()).sorted().mkString(", "), REGULAR_BOLD_ATTRIBUTES);
+        if (isForkPointOff) {
+          append(" " + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit") + " ",
+              REGULAR_ATTRIBUTES);
+          append(forkPoint.getShortHash(), REGULAR_BOLD_ATTRIBUTES);
+          append(" " + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.found-in-reflog")
+              + " ", REGULAR_ATTRIBUTES);
+          append(forkPoint.getUniqueBranchesContainingInReflog()
+              .map(b -> b.getName()).sorted().mkString(", "), REGULAR_BOLD_ATTRIBUTES);
+        }
       }
     }
   }

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -186,7 +186,8 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
         if (containingBranch.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff) {
           append(
               " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} "
-                  + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point") + " ",
+                  + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-question")
+                  + " ",
               new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
           append(getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit") + " ",
               REGULAR_ATTRIBUTES);
@@ -198,7 +199,7 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
         } else {
           append(
               " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} "
-                  + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-simple"),
+                  + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point"),
               new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
         }
       }

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
@@ -594,13 +594,18 @@ public final class GitCoreRepository implements IGitCoreRepository {
       // which by default shows commits in reverse chronological order (https://git-scm.com/docs/git-log#_commit_ordering).
       // In this case (unlike with `ancestorsOf`), apparently there is no significant effect on performance.
       walk.sort(RevSort.COMMIT_TIME_DESC);
-      walk.sort(RevSort.BOUNDARY);
+      // Note: deliberately NOT using `RevSort.BOUNDARY`. With BOUNDARY enabled, JGit yields the boundary commit
+      // (an uninteresting commit with at least one interesting child) in addition to the interesting ones.
+      // When `fromInclusive` is a descendant of `untilExclusive`, the boundary equals `untilExclusive` and could
+      // be filtered out post-hoc; but when the two have diverged (e.g. red edges in `git machete status`), the
+      // boundary equals the merge-base, which is neither `untilExclusive` nor reachable from it, and would leak
+      // into the result. Without BOUNDARY the walk naturally stops before yielding uninteresting commits, which
+      // matches `git log untilExclusive..fromInclusive` semantics for both descendant and divergent histories.
 
       walk.markStart(walk.parseCommit(convertGitCoreCommitToObjectId(fromInclusive)));
       walk.markUninteresting(walk.parseCommit(convertGitCoreCommitToObjectId(untilExclusive)));
 
       return Iterator.ofAll(walk.iterator())
-          .takeWhile(revCommit -> !revCommit.getId().getName().equals(untilExclusive.getHash().getHashString()))
           .toJavaStream()
           .peek(revCommit -> LOG.debug(() -> "* " + revCommit.getId().getName()))
           .map(GitCoreCommit::new)

--- a/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryIntegrationTest.java
+++ b/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryIntegrationTest.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitcore.impl.jgit;
 
 import static com.virtuslab.gitmachete.testcommon.SetupScripts.SETUP_WITH_SINGLE_REMOTE;
 import static com.virtuslab.gitmachete.testcommon.TestFileUtils.cleanUpDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,12 +12,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.Objects;
+
+import io.vavr.collection.List;
 import lombok.SneakyThrows;
+import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.simplify4u.slf4jmock.LoggerMock;
 import org.slf4j.Logger;
 
+import com.virtuslab.gitcore.api.IGitCoreCommit;
 import com.virtuslab.gitmachete.testcommon.TestGitRepository;
 
 public class GitCoreRepositoryIntegrationTest {
@@ -78,6 +84,47 @@ public class GitCoreRepositoryIntegrationTest {
     assertNull(gitCoreRepository.parseRevision("refs/remotes/."));
 
     // Deliberately done in the test and not in an @AfterEach method, so that the directory is retained in case of test failure.
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  @Test
+  @SneakyThrows
+  public void deriveCommitRange_descendantUntil_returnsCommitsBetween() {
+    // `update-icons` was created at the tip of `allow-ownership-link` (after `1st round of fixes` was added
+    // to the upstream of `allow-ownership-link`) and added one commit (`Use new icons`) on top.
+    // After `git reset --keep HEAD~1` on `allow-ownership-link`, the local `allow-ownership-link` points back
+    // to `Allow ownership links`, so `update-icons` IS a descendant of local `allow-ownership-link`.
+    val updateIconsTip = Objects.requireNonNull(gitCoreRepository.parseRevision("refs/heads/update-icons"));
+    val allowOwnershipLinkTip = Objects.requireNonNull(gitCoreRepository.parseRevision("refs/heads/allow-ownership-link"));
+
+    val range = gitCoreRepository.deriveCommitRange(updateIconsTip, allowOwnershipLinkTip);
+    val messages = range.map(IGitCoreCommit::getShortMessage);
+
+    assertEquals(List.of("Use new icons", "1st round of fixes"), messages);
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  // Regression test: with `RevSort.BOUNDARY` enabled, JGit yielded the merge-base as a phantom extra
+  // commit when `fromInclusive` and `untilExclusive` had diverged (as for red edges in `git machete status`).
+  // See https://github.com/VirtusLab/git-machete-intellij-plugin/pull/2277 for context.
+  @Test
+  @SneakyThrows
+  public void deriveCommitRange_divergentUntil_doesNotIncludeMergeBase() {
+    // After `git reset --keep HEAD~1` rolled local `allow-ownership-link` back from "1st round of fixes" to
+    // "Allow ownership links", `allow-ownership-link` and `develop` have diverged:
+    //   develop:              Root -> Develop commit -> Other develop commit
+    //   allow-ownership-link: Root -> Develop commit -> Allow ownership links
+    // Hence merge-base(allow-ownership-link, develop) = "Develop commit", which is reachable from `develop` and so
+    // must NOT appear in `deriveCommitRange(allow-ownership-link, develop)`.
+    val allowOwnershipLinkTip = Objects.requireNonNull(gitCoreRepository.parseRevision("refs/heads/allow-ownership-link"));
+    val developTip = Objects.requireNonNull(gitCoreRepository.parseRevision("refs/heads/develop"));
+
+    val range = gitCoreRepository.deriveCommitRange(allowOwnershipLinkTip, developTip);
+    val messages = range.map(IGitCoreCommit::getShortMessage);
+
+    assertEquals(List.of("Allow ownership links"), messages);
+
     cleanUpDir(repo.parentDirectoryPath);
   }
 }

--- a/gradle-local.properties.example
+++ b/gradle-local.properties.example
@@ -1,0 +1,10 @@
+# Copy to `gradle-local.properties` (gitignored) if you need a corporate Maven proxy for this repo.
+# Omit the file on machines with direct access to Maven Central / the Gradle Plugin Portal.
+#
+# Replaces a global ~/.gradle/init.gradle that rewrote Central - this project configures the proxy
+# only here, so other Gradle projects on the same machine are unaffected.
+#
+# gradle/init.gradle (loaded automatically by ./gradlew) rewrites Maven Central repository URLs
+# to this host. You can still omit this file on machines with direct access to Central.
+#
+# mavenProxyUrl=https://maven-proxy.example.com

--- a/gradle-local.properties.example
+++ b/gradle-local.properties.example
@@ -4,7 +4,7 @@
 # Replaces a global ~/.gradle/init.gradle that rewrote Central - this project configures the proxy
 # only here, so other Gradle projects on the same machine are unaffected.
 #
-# gradle/init.gradle (loaded automatically by ./gradlew) rewrites Maven Central repository URLs
-# to this host. You can still omit this file on machines with direct access to Central.
+# With mavenProxyUrl set, the build uses this mirror only (no mavenCentral). ./gradlew loads
+# gradle/init.gradle to rewrite any stray Central URLs some plugins may still declare.
 #
 # mavenProxyUrl=https://maven-proxy.example.com

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+# Optional: mavenProxyUrl in gitignored gradle-local.properties; ./gradlew loads gradle/init.gradle
+# to rewrite Central URLs. If plugin resolution still hits blocked Central, set in ~/.gradle/gradle.properties:
+#   includePublicMavenReposForPlugins=false
+
 kotlin.stdlib.default.dependency=false
 org.gradle.caching=true
 org.gradle.configureOnDemand=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
-# Optional: mavenProxyUrl in gitignored gradle-local.properties; ./gradlew loads gradle/init.gradle
-# to rewrite Central URLs. If plugin resolution still hits blocked Central, set in ~/.gradle/gradle.properties:
+# Optional: mavenProxyUrl in gitignored gradle-local.properties (proxy OR mavenCentral, not both).
+# ./gradlew loads gradle/init.gradle to rewrite stray Central URLs from plugins. If resolution still
+# hits blocked Central, set in ~/.gradle/gradle.properties:
 #   includePublicMavenReposForPlugins=false
 
 kotlin.stdlib.default.dependency=false

--- a/gradle/init.gradle
+++ b/gradle/init.gradle
@@ -1,6 +1,6 @@
 // Repo-local Gradle init script (applied automatically by ./gradlew when this file exists).
-// Rewrites Maven Central repository base URLs to mavenProxyUrl from gradle-local.properties
-// (same idea as a corporate ~/.gradle/init.gradle, but self-contained in the repo).
+// When gradle-local.properties sets mavenProxyUrl, rewrites any repository URL still pointing at
+// Central (e.g. added by a plugin) to that mirror. Build scripts use proxy OR mavenCentral exclusively.
 //
 // If gradle-local.properties is missing or has no mavenProxyUrl, this script is a no-op.
 

--- a/gradle/init.gradle
+++ b/gradle/init.gradle
@@ -1,0 +1,59 @@
+// Repo-local Gradle init script (applied automatically by ./gradlew when this file exists).
+// Rewrites Maven Central repository base URLs to mavenProxyUrl from gradle-local.properties
+// (same idea as a corporate ~/.gradle/init.gradle, but self-contained in the repo).
+//
+// If gradle-local.properties is missing or has no mavenProxyUrl, this script is a no-op.
+
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+
+import java.util.Properties
+
+static String loadMavenProxyUrl(File repoRoot) {
+  def f = new File(repoRoot, "gradle-local.properties")
+  if (!f.isFile()) {
+    return null
+  }
+  def p = new Properties()
+  f.withReader("UTF-8") { p.load(it) }
+  def u = p.getProperty("mavenProxyUrl")?.trim()
+  return u ? u.replaceAll(/\/$/, "") : null
+}
+
+static void rewriteIfMavenCentral(MavenArtifactRepository repo, String proxyBase) {
+  def old = repo.url?.toString()
+  if (old == null) {
+    return
+  }
+  def neu = old
+    .replace("https://repo.maven.apache.org", proxyBase)
+    .replace("https://repo1.maven.org", proxyBase)
+    .replace("http://repo.maven.apache.org", proxyBase)
+    .replace("http://repo1.maven.org", proxyBase)
+  if (neu != old) {
+    repo.url = new URI(neu)
+  }
+}
+
+gradle.settingsEvaluated { settings ->
+  def proxy = loadMavenProxyUrl(settings.rootDir)
+  gradle.ext.set("mavenProxyRewriteBase", proxy)
+  if (proxy == null) {
+    return
+  }
+  settings.pluginManagement.repositories.withType(MavenArtifactRepository).configureEach { repo ->
+    rewriteIfMavenCentral(repo, proxy)
+  }
+}
+
+gradle.afterProject { project ->
+  def proxy = gradle.ext.get("mavenProxyRewriteBase")
+  if (proxy == null) {
+    return
+  }
+  project.repositories.withType(MavenArtifactRepository).configureEach { repo ->
+    rewriteIfMavenCentral(repo, proxy)
+  }
+  project.buildscript.repositories.withType(MavenArtifactRepository).configureEach { repo ->
+    rewriteIfMavenCentral(repo, proxy)
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ remoteRobot = "0.11.23"
 [libraries]
 # Libraries
 apacheCommonsText = "org.apache.commons:commons-text:1.15.0"
-archunit = "com.tngtech.archunit:archunit:1.4.2"
+archunit = "com.tngtech.archunit:archunit:1.4.1"
 betterStrings = "com.antkorwin:better-strings:0.5"
 checker = { module = "org.checkerframework:checker", version.ref = "checker" }
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker" }

--- a/gradlew
+++ b/gradlew
@@ -208,10 +208,19 @@ DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 #   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
 #     treated as '${Hostname}' itself on the command line.
 
-set -- \
-        "-Dorg.gradle.appname=$APP_BASE_NAME" \
-        -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
-        "$@"
+# Repo-local init script (optional Maven Central URL rewrite; see gradle/init.gradle).
+if [ -r "$APP_HOME/gradle/init.gradle" ]; then
+  set -- \
+          "-Dorg.gradle.appname=$APP_BASE_NAME" \
+          -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
+          -I "$APP_HOME/gradle/init.gradle" \
+          "$@"
+else
+  set -- \
+          "-Dorg.gradle.appname=$APP_BASE_NAME" \
+          -jar "$APP_HOME/gradle/wrapper/gradle-wrapper.jar" \
+          "$@"
+fi
 
 # Stop when "xargs" is not available.
 if ! command -v xargs >/dev/null 2>&1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,34 @@
+import java.io.File
+
 rootProject.name = "git-machete-intellij-plugin"
+
+// Plugin resolution for this build (including buildSrc's `plugins { }`). See buildSrc/settings.gradle.kts too.
+//
+// Optional corporate proxy: repo-root `gradle-local.properties` (gitignored), key `mavenProxyUrl`.
+// Without `~/.gradle/init.gradle` rewriting Central, you need that file on networks that require the proxy.
+//
+// If plugin resolution still hits repo.maven.apache.org directly and fails, set in ~/.gradle/gradle.properties:
+//   includePublicMavenReposForPlugins=false
+pluginManagement {
+  repositories {
+    mavenLocal()
+    val f = File(settingsDir, "gradle-local.properties")
+    if (f.isFile) {
+      val url = java.util.Properties().apply { f.reader().use { load(it) } }
+        .getProperty("mavenProxyUrl")
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+      if (url != null) {
+        maven(url = uri(url))
+      }
+    }
+    if (providers.gradleProperty("includePublicMavenReposForPlugins").orNull != "false") {
+      gradlePluginPortal()
+      mavenCentral()
+    }
+  }
+}
+
 // Note: please keep the projects in a topological order
 include(
   "qual",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,26 +5,31 @@ rootProject.name = "git-machete-intellij-plugin"
 // Plugin resolution for this build (including buildSrc's `plugins { }`). See buildSrc/settings.gradle.kts too.
 //
 // Optional corporate proxy: repo-root `gradle-local.properties` (gitignored), key `mavenProxyUrl`.
-// Without `~/.gradle/init.gradle` rewriting Central, you need that file on networks that require the proxy.
+// When set, plugin resolution uses that mirror only (no mavenCentral() here); otherwise mavenCentral().
 //
 // If plugin resolution still hits repo.maven.apache.org directly and fails, set in ~/.gradle/gradle.properties:
 //   includePublicMavenReposForPlugins=false
 pluginManagement {
   repositories {
     mavenLocal()
-    val f = File(settingsDir, "gradle-local.properties")
-    if (f.isFile) {
-      val url = java.util.Properties().apply { f.reader().use { load(it) } }
+    val mavenProxyUrl = run {
+      val f = File(settingsDir, "gradle-local.properties")
+      if (!f.isFile) {
+        return@run null
+      }
+      java.util.Properties().apply { f.reader().use { load(it) } }
         .getProperty("mavenProxyUrl")
         ?.trim()
         ?.takeIf { it.isNotEmpty() }
-      if (url != null) {
-        maven(url = uri(url))
-      }
+    }
+    if (mavenProxyUrl != null) {
+      maven(url = uri(mavenProxyUrl))
     }
     if (providers.gradleProperty("includePublicMavenReposForPlugins").orNull != "false") {
       gradlePluginPortal()
-      mavenCentral()
+      if (mavenProxyUrl == null) {
+        mavenCentral()
+      }
     }
   }
 }


### PR DESCRIPTION
Mirrors the corresponding CLI change in https://github.com/VirtusLab/git-machete/pull/1667.

## Two related changes to `git machete status`

### 1. Suppress spurious yellow edge when parent is just behind its remote

Treat a child branch as in-sync with its parent when the inferred fork
point lies strictly between parent's local HEAD and parent's remote
counterpart. This is the common case where the user just hasn't pulled
the parent yet; the legitimate yellow edge (fork point older than
parent's local HEAD) is preserved.

### 2. Commit listing now shows the full parent..branch range, with the fork point annotated

Previously, green edges (`InSync`) listed only commits between fork
point and branch tip, hiding any commits between parent's local HEAD
and the fork point. That was misleading whenever the fork point lay
above parent's local HEAD — e.g. due to a fork-point override, or due
to (1) above where the fork point lands on parent's remote.

Side-effecting commands (rebase, squash, etc.) operate on the narrower
`fork-point..branch` range, so silently dropping these commits from
the visual gave the impression they didn't exist.

Now both green and yellow edges expose the full `parent..branch` range
via `uniqueCommits`. The renderer annotates the fork point commit
(when it appears in that range, i.e. `fork_point != parent_hash`):

- yellow edges keep the existing `fork point ? commit X seems to be a
  part of the unique history of Y` annotation;
- green/red edges get a simpler `fork point` annotation (no commit
  hash, no reflog blurb), matching the CLI behavior.

## Test changes

- New unit test `parentBehindRemoteAndForkPointBetweenLocalAndRemote_inSync` in
  `GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite`.
- `StatusAndDiscoverIntegrationTestSuite` renderer differentiates yellow
  vs other sync statuses for the fork point annotation.
- Pre-recorded CLI outputs (`setup-with-single-remote.sh-status.txt`,
  `setup-with-single-remote.sh-discover.txt`) regenerated.
- `version.txt` bumped to `3.41.0`.