### PR TITLE
fix: stale "no need to fetch" cache hits across repositories sharing the same directory name in multi-root projects

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -2,6 +2,7 @@
 
 ## v7.0.2
 - Fixed: "Show in Git Log" action jumping to a commit in the wrong repository in multi-root projects
+- Fixed: stale "no need to fetch" cache hits across repositories sharing the same directory name in multi-root projects
 
 ## v7.0.1
 - Added: auto-discovery of the branch layout in case of multiple repositories (contributed by @mkondratek)

--- a/frontend/actions/build.gradle.kts
+++ b/frontend/actions/build.gradle.kts
@@ -10,7 +10,9 @@ dependencies {
 
 apacheCommonsText()
 applyKotlinConfig()
+junit()
 lombok()
+mockito()
 slf4jLambdaApi()
 vavr()
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/FetchUpToDateTimeoutStatus.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/FetchUpToDateTimeoutStatus.java
@@ -9,15 +9,27 @@ public final class FetchUpToDateTimeoutStatus {
   public static final String FETCH_ALL_UP_TO_DATE_TIMEOUT_AS_STRING = "a minute";
 
   @SuppressWarnings("ConstantName")
-  private static final java.util.concurrent.ConcurrentMap<String, Long> lastFetchTimeMillisByRepositoryName = new java.util.concurrent.ConcurrentHashMap<>();
+  private static final java.util.concurrent.ConcurrentMap<String, Long> lastFetchTimeMillisByRepoKey = new java.util.concurrent.ConcurrentHashMap<>();
 
   public static boolean isUpToDate(GitRepository gitRepository) {
-    String repoName = gitRepository.getRoot().getName();
-    long lftm = lastFetchTimeMillisByRepositoryName.getOrDefault(repoName, 0L);
+    long lftm = lastFetchTimeMillisByRepoKey.getOrDefault(getRepoKey(gitRepository), 0L);
     return System.currentTimeMillis() < lftm + FETCH_ALL_UP_TO_DATE_TIMEOUT_MILLIS;
   }
 
-  public static void update(String repoName) {
-    lastFetchTimeMillisByRepositoryName.put(repoName, System.currentTimeMillis());
+  public static void update(GitRepository gitRepository) {
+    lastFetchTimeMillisByRepoKey.put(getRepoKey(gitRepository), System.currentTimeMillis());
+  }
+
+  // We key by the absolute repo root path so that two repos with the same final
+  // directory name (e.g. `~/work/projA/api/.git` and `~/work/projB/api/.git`),
+  // including across multi-root projects and across separately-opened projects
+  // sharing this app-level cache, don't end up sharing state.
+  private static String getRepoKey(GitRepository gitRepository) {
+    return gitRepository.getRoot().getPath();
+  }
+
+  // Visible for tests.
+  static void clear() {
+    lastFetchTimeMillisByRepoKey.clear();
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/Pull.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/common/Pull.java
@@ -69,8 +69,7 @@ public final class Pull {
       @Override
       @UIEffect
       public void onSuccess() {
-        String repoName = gitRepository.getRoot().getName();
-        FetchUpToDateTimeoutStatus.update(repoName);
+        FetchUpToDateTimeoutStatus.update(gitRepository);
 
         if (gitRepository.getBranches().findBranchByName(remoteBranchName) == null) {
           val errorMessage = fmt(getString("action.GitMachete.Pull.notification.remote-branch-missing.text"), remoteBranchName);

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/FetchAllRemotesAction.java
@@ -77,8 +77,7 @@ public class FetchAllRemotesAction extends BaseProjectDependentAction {
       public void doRun(ProgressIndicator indicator) {
         result = GitFetchSupport.fetchSupport(project).fetchAllRemotes(Option.of(gitRepository).toJavaList());
         if (gitRepository != null) {
-          val repoName = gitRepository.getRoot().getName();
-          FetchUpToDateTimeoutStatus.update(repoName);
+          FetchUpToDateTimeoutStatus.update(gitRepository);
         }
       }
 

--- a/frontend/actions/src/test/java/com/virtuslab/gitmachete/frontend/actions/common/FetchUpToDateTimeoutStatusTest.java
+++ b/frontend/actions/src/test/java/com/virtuslab/gitmachete/frontend/actions/common/FetchUpToDateTimeoutStatusTest.java
@@ -1,0 +1,54 @@
+package com.virtuslab.gitmachete.frontend.actions.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import git4idea.repo.GitRepository;
+import lombok.val;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FetchUpToDateTimeoutStatusTest {
+
+  @BeforeEach
+  public void setUp() {
+    FetchUpToDateTimeoutStatus.clear();
+  }
+
+  private static GitRepository mockRepo(String rootPath) {
+    val name = rootPath.substring(rootPath.lastIndexOf('/') + 1);
+    val virtualFile = mock(VirtualFile.class);
+    when(virtualFile.getPath()).thenReturn(rootPath);
+    when(virtualFile.getName()).thenReturn(name);
+    val gitRepository = mock(GitRepository.class);
+    when(gitRepository.getRoot()).thenReturn(virtualFile);
+    return gitRepository;
+  }
+
+  @Test
+  public void shouldNotConsiderFreshRepoUpToDate() {
+    val repo = mockRepo("/home/user/work/projA/api");
+    assertFalse(FetchUpToDateTimeoutStatus.isUpToDate(repo));
+  }
+
+  @Test
+  public void shouldConsiderJustUpdatedRepoUpToDate() {
+    val repo = mockRepo("/home/user/work/projA/api");
+    FetchUpToDateTimeoutStatus.update(repo);
+    assertTrue(FetchUpToDateTimeoutStatus.isUpToDate(repo));
+  }
+
+  @Test
+  public void shouldNotShareStateBetweenReposSharingDirectoryName() {
+    val repoA = mockRepo("/home/user/work/projA/api");
+    val repoB = mockRepo("/home/user/work/projB/api");
+    assertEquals(repoA.getRoot().getName(), repoB.getRoot().getName());
+
+    FetchUpToDateTimeoutStatus.update(repoA);
+
+    assertTrue(FetchUpToDateTimeoutStatus.isUpToDate(repoA));
+    assertFalse(FetchUpToDateTimeoutStatus.isUpToDate(repoB));
+  }
+}


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2278

## Chain of upstream PRs as of 2026-05-08

* PR #2278:
  `develop` ← `mk/fix/show-in-git-log-for-multiroot`

  * **PR #2280 (THIS ONE)**:
    `mk/fix/show-in-git-log-for-multiroot` ← `mk/fix/stale-fetch-cache`

<!-- end git-machete generated -->
