### PR TITLE
status: list inferring branches next to `-> fork point` on green edges

### DIFF
--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
@@ -500,23 +500,25 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
     return applicableCommits.exists(commit -> commit.getTreeHash().equals(equivalentTo.getTreeHash()));
   }
 
-  @UIThreadUnsafe
-  private boolean isForkPointOnParentRemoteCounterpart(
+  private boolean isForkPointInferredByParentRemoteCounterpart(
       IGitCoreLocalBranchSnapshot parentCoreLocalBranch,
-      IGitCoreCommit forkPoint) throws GitCoreException {
+      ForkPointCommitOfManagedBranch forkPoint) {
     // Suppresses the spurious yellow edge that appears when the parent branch is merely behind
-    // its remote counterpart and the child branch was forked from a commit on the remote
-    // that is ahead of parent's local HEAD. We require that the fork point lies strictly
-    // between parent's local HEAD and parent's remote counterpart, so that legitimate
-    // yellow edges (where the fork point is older than parent's local HEAD) are preserved.
-    IGitCoreRemoteBranchSnapshot parentRemoteTrackingBranch = parentCoreLocalBranch.getRemoteTrackingBranch();
-    if (parentRemoteTrackingBranch == null) {
+    // its remote counterpart and the child branch was forked from the remote tip. We only fire
+    // for parents that have a remote counterpart at all (otherwise the "behind remote" situation
+    // cannot arise), and only when the parent shows up among the inferring branches - either as
+    // the parent's remote tracking branch, or as the parent itself (which can happen when the
+    // inferred commit still survives on the parent's own filtered reflog after the push).
+    if (parentCoreLocalBranch.getRemoteTrackingBranch() == null) {
       return false;
     }
-    IGitCoreCommit parentPointedCommit = parentCoreLocalBranch.getPointedCommit();
-    IGitCoreCommit parentRemotePointedCommit = parentRemoteTrackingBranch.getPointedCommit();
-    return gitCoreRepository.isAncestor(parentPointedCommit, forkPoint)
-        && gitCoreRepository.isAncestorOrEqual(forkPoint, parentRemotePointedCommit);
+    val parentName = parentCoreLocalBranch.getName();
+    return forkPoint.getUniqueBranchesContainingInReflog().exists(b -> {
+      ILocalBranchReference correspondingLocalBranch = b.isLocal()
+          ? b.asLocal()
+          : b.asRemote().getTrackedLocalBranch();
+      return correspondingLocalBranch.getName().equals(parentName);
+    });
   }
 
   @UIThreadUnsafe
@@ -557,10 +559,10 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
                   + "and fork point is absent or overridden or equal to parent branch commit, " +
                   "so we assume that this branch is in sync");
           return SyncToParentStatus.InSync;
-        } else if (isForkPointOnParentRemoteCounterpart(parentCoreLocalBranch, forkPoint.getCoreCommit())) {
+        } else if (isForkPointInferredByParentRemoteCounterpart(parentCoreLocalBranch, forkPoint)) {
           LOG.debug(
               () -> "For this branch (${branchName}) its parent's commit is ancestor of this branch pointed commit "
-                  + "and fork point lies between parent's local HEAD and parent's remote counterpart "
+                  + "and fork point was inferred from parent's remote counterpart "
                   + "(parent is just behind its remote), so we assume that this branch is in sync");
           return SyncToParentStatus.InSync;
         } else {

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
@@ -126,12 +126,16 @@ public class StatusAndDiscoverIntegrationTestSuite extends BaseIntegrationTestSu
 
       sb.append(c.getShortMessage());
       if (c.equals(forkPoint)) {
-        if (isForkPointOff) {
-          sb.append(" -> fork point ??? commit ${forkPoint.getShortHash()} seems to be a part of the unique history of ");
-          List<IBranchReference> uniqueBranchesContainingInReflog = forkPoint.getUniqueBranchesContainingInReflog();
-          sb.append(uniqueBranchesContainingInReflog.map(IBranchReference::getName).sorted().mkString(" and "));
-        } else {
-          sb.append(" -> fork point");
+        val marker = isForkPointOff ? "fork point ???" : "fork point";
+        List<IBranchReference> inferringBranches = forkPoint.getUniqueBranchesContainingInReflog();
+        // `???` already separates the marker from the prose; a colon would be redundant.
+        val separator = !isForkPointOff && (!inferringBranches.isEmpty() || forkPoint.isOverridden()) ? ":" : "";
+        sb.append(" -> ${marker}${separator}");
+        if (!inferringBranches.isEmpty()) {
+          sb.append(" commit ${forkPoint.getShortHash()} seems to be a part of the unique history of ");
+          sb.append(inferringBranches.map(IBranchReference::getName).sorted().mkString(" and "));
+        } else if (forkPoint.isOverridden()) {
+          sb.append(" overridden");
         }
       }
       sb.append(System.lineSeparator());

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite.java
@@ -14,8 +14,10 @@ import org.junit.jupiter.api.Test;
 import com.virtuslab.gitcore.api.IGitCoreCommit;
 import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitcore.api.IGitCoreRemoteBranchSnapshot;
+import com.virtuslab.gitmachete.backend.api.IBranchReference;
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.backend.impl.ForkPointCommitOfManagedBranch;
+import com.virtuslab.gitmachete.backend.impl.RemoteTrackingBranchReference;
 
 public class GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite extends BaseGitMacheteRepositoryUnitTestSuite {
 
@@ -26,9 +28,18 @@ public class GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite extends
       IGitCoreLocalBranchSnapshot childBranch,
       IGitCoreLocalBranchSnapshot parentBranch,
       IGitCoreCommit forkPointCommit) {
+    return invokeDeriveSyncToParentStatus(childBranch, parentBranch, forkPointCommit, /* containingBranches */ List.empty());
+  }
+
+  @SneakyThrows
+  private SyncToParentStatus invokeDeriveSyncToParentStatus(
+      IGitCoreLocalBranchSnapshot childBranch,
+      IGitCoreLocalBranchSnapshot parentBranch,
+      IGitCoreCommit forkPointCommit,
+      List<IBranchReference> containingBranches) {
     return aux().deriveSyncToParentStatus(
         childBranch, parentBranch,
-        ForkPointCommitOfManagedBranch.inferred(forkPointCommit, /* containingBranches */ List.empty()));
+        ForkPointCommitOfManagedBranch.inferred(forkPointCommit, containingBranches));
   }
 
   @Test
@@ -96,26 +107,39 @@ public class GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite extends
 
   @Test
   @SneakyThrows
-  public void parentBehindRemoteAndForkPointBetweenLocalAndRemote_inSync() {
+  public void parentBehindRemoteAndForkPointInferredByParentRemoteCounterpart_inSync() {
     // given
     IGitCoreCommit parentCommit = createGitCoreCommit();
     IGitCoreCommit forkPointCommit = createGitCoreCommit();
-    IGitCoreCommit parentRemoteCommit = createGitCoreCommit();
     IGitCoreCommit childCommit = createGitCoreCommit();
     IGitCoreLocalBranchSnapshot parentBranch = createGitCoreLocalBranch(parentCommit);
+    when(parentBranch.getName()).thenReturn("master");
     IGitCoreLocalBranchSnapshot childBranch = createGitCoreLocalBranch(childCommit);
     IGitCoreRemoteBranchSnapshot parentRemoteBranch = mock(IGitCoreRemoteBranchSnapshot.class);
-    when(parentRemoteBranch.getPointedCommit()).thenReturn(parentRemoteCommit);
     when(parentBranch.getRemoteTrackingBranch()).thenReturn(parentRemoteBranch);
     when(gitCoreRepository.isAncestorOrEqual(parentCommit, childCommit)).thenReturn(true);
-    when(gitCoreRepository.isAncestor(parentCommit, forkPointCommit)).thenReturn(true);
-    when(gitCoreRepository.isAncestorOrEqual(forkPointCommit, parentRemoteCommit)).thenReturn(true);
+
+    // The fork point appears in the reflog of `origin/master` (parent's remote counterpart),
+    // so the green-edge classification kicks in.
+    IBranchReference parentRemoteBranchRef = RemoteTrackingBranchReference.of(
+        mockRemoteBranch("origin/master", "refs/remotes/origin/master", "origin"),
+        parentBranch);
 
     // when
-    SyncToParentStatus syncToParentStatus = invokeDeriveSyncToParentStatus(childBranch, parentBranch, forkPointCommit);
+    SyncToParentStatus syncToParentStatus = invokeDeriveSyncToParentStatus(
+        childBranch, parentBranch, forkPointCommit, List.of(parentRemoteBranchRef));
 
     // then
     assertEquals(SyncToParentStatus.InSync, syncToParentStatus);
+  }
+
+  @SneakyThrows
+  private static IGitCoreRemoteBranchSnapshot mockRemoteBranch(String name, String fullName, String remoteName) {
+    IGitCoreRemoteBranchSnapshot snap = mock(IGitCoreRemoteBranchSnapshot.class);
+    when(snap.getName()).thenReturn(name);
+    when(snap.getFullName()).thenReturn(fullName);
+    when(snap.getRemoteName()).thenReturn(remoteName);
+    return snap;
   }
 
   @Test

--- a/backend/impl/src/test/resources/setup-for-overridden-fork-point.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-for-overridden-fork-point.sh-status.txt
@@ -1,5 +1,5 @@
   develop  <2 files>
   |
-  | Allow ownership links -> fork point
+  | Allow ownership links -> fork point: overridden
   | Build arbitrarily long chains
   o-build-chain *  <4 files>

--- a/backend/impl/src/test/resources/setup-with-single-remote.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-with-single-remote.sh-discover.txt
@@ -9,7 +9,7 @@
   | Allow ownership links
   x-allow-ownership-link (behind origin)  <3 files>
   | |
-  | | 1st round of fixes -> fork point
+  | | 1st round of fixes -> fork point: commit 9d422de seems to be a part of the unique history of allow-ownership-link
   | | Use new icons
   | o-update-icons (behind origin)  <5 files>
   |   |

--- a/backend/impl/src/test/resources/setup-with-single-remote.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-with-single-remote.sh-status.txt
@@ -3,7 +3,7 @@
   | Allow ownership links
   x-allow-ownership-link  PR #123 (behind origin)  <3 files>
   | |
-  | | 1st round of fixes -> fork point
+  | | 1st round of fixes -> fork point: commit 9d422de seems to be a part of the unique history of allow-ownership-link
   | | Use new icons
   | o-update-icons (behind origin)  <5 files>
   | |

--- a/frontend/base/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/base/src/main/resources/GitMacheteBundle.properties
@@ -319,6 +319,7 @@ string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point=fork point
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-question=fork point ?
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.found-in-reflog=seems to be a part of the unique history of
+string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.overridden=overridden
 
 string.GitMachete.BranchOrCommitCellRendererComponent.ongoing-operation.applying=APPLYING
 string.GitMachete.BranchOrCommitCellRendererComponent.ongoing-operation.bisecting=BISECTING

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -183,24 +183,26 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
       val forkPoint = containingBranch.getForkPoint();
 
       if (commitItem.getCommit().equals(forkPoint)) {
-        if (containingBranch.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff) {
-          append(
-              " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} "
-                  + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-question")
-                  + " ",
-              new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
-          append(getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit") + " ",
+        val isForkPointOff = containingBranch.getSyncToParentStatus() == SyncToParentStatus.InSyncButForkPointOff;
+        val markerText = isForkPointOff
+            ? getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point-question")
+            : getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point");
+        val inferringBranches = forkPoint.getUniqueBranchesContainingInReflog();
+        // `?` already separates the marker from the prose; a colon would be redundant.
+        val separator = !isForkPointOff && (!inferringBranches.isEmpty() || forkPoint.isOverridden()) ? ":" : "";
+        append(
+            " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} " + markerText + separator,
+            new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
+        if (!inferringBranches.isEmpty()) {
+          append(" " + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit") + " ",
               REGULAR_ATTRIBUTES);
           append(forkPoint.getShortHash(), REGULAR_BOLD_ATTRIBUTES);
           append(" " + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.found-in-reflog")
               + " ", REGULAR_ATTRIBUTES);
-          append(forkPoint.getUniqueBranchesContainingInReflog()
-              .map(b -> b.getName()).sorted().mkString(", "), REGULAR_BOLD_ATTRIBUTES);
-        } else {
-          append(
-              " ${HEAVY_WIDE_HEADED_RIGHTWARDS_ARROW} "
-                  + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.fork-point"),
-              new SimpleTextAttributes(STYLE_PLAIN, Colors.RED));
+          append(inferringBranches.map(b -> b.getName()).sorted().mkString(", "), REGULAR_BOLD_ATTRIBUTES);
+        } else if (forkPoint.isOverridden()) {
+          append(" " + getString("string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.overridden"),
+              REGULAR_ATTRIBUTES);
         }
       }
     }

--- a/testCommon/src/testFixtures/resources/common.sh
+++ b/testCommon/src/testFixtures/resources/common.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# Prevent env-var pollution from leaking author/committer identity into commits.
+# `git config --local user.name/email` (set in `create_repo` below) is shadowed
+# by these env vars whenever they're present, which silently breaks fixture
+# determinism (commits get authored by whoever leaked the vars instead of by
+# `CircleCI <circleci@example.com>`, producing different SHAs).
+# `GIT_*_DATE` are re-exported per commit by `set_fake_git_date`, so it's safe
+# (and equally important) to clear them here too.
+unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_AUTHOR_DATE \
+      GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL GIT_COMMITTER_DATE
+
 status_branch_hook=$(cat <<'EOF'
 #!/usr/bin/env bash
 branch=$1


### PR DESCRIPTION
Mirrors the corresponding CLI change in https://github.com/VirtusLab/git-machete/pull/1690.

Previously the verbose `commit XXX seems to be a part of the unique
history of <branches>` annotation only appeared after `-> fork point ???`
on yellow edges. On green edges (e.g. parent behind its remote, child
forked from the remote tip) the same fork point was rendered as a bare
`-> fork point` marker, which hides exactly where the inferred fork
point came from.

## Output changes

Append the same prose on green edges too, separated by a colon since
there is no `???` to break the line up:

```
| | 1st round of fixes -> fork point: commit 9d422de seems to be a part of the unique history of allow-ownership-link
```

Override-driven fork points (empty inferring-branch list, e.g. after
**Override Fork Point...** action) render as `-> fork point: overridden`,
so the marker still tells the user the fork point did not come out of
the usual reflog inference.

## Classifier change

Also tighten the green-edge classification for the "parent behind its
remote" case. Instead of geometric `is_ancestor` checks between the
parent's local HEAD, its remote counterpart and the fork point, fire
only when the parent shows up among the inferring branches - either
directly as the parent's remote tracking branch, or as the parent
itself when the inferred commit survives on the parent's own filtered
reflog after the push. This matches the user-visible "the fork point
was inferred from `<parent>`" intent more directly. The check is
renamed accordingly to `isForkPointInferredByParentRemoteCounterpart`.

## Test changes

- `GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite`: the
  parent-behind-remote test is rewritten
  (`parentBehindRemoteAndForkPointInferredByParentRemoteCounterpart_inSync`)
  to drive the new classifier via the inferring-branches list rather
  than via `is_ancestor` mocks.
- `StatusAndDiscoverIntegrationTestSuite` renderer mirrors the new
  formatting (colon separator + `: overridden` suffix).
- Pre-recorded CLI fixtures regenerated.
- New bundle key
  `string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.overridden=overridden`.

## Harden setup scripts against env-var pollution

The first regeneration attempt for this PR produced different commit
hashes than what CI produces. Root cause: leftover `GIT_AUTHOR_*` /
`GIT_COMMITTER_*` env vars in my shell (leaked from a prior
`git-machete` Python test run) silently shadowed the repo-local
`user.name/email` set in `create_repo`, so commits got authored by
`t <t@t>` instead of `CircleCI <circleci@example.com>` - different
SHAs.

Harden `testCommon/.../common.sh` to `unset` the offending vars up
front so every regeneration starts from a clean identity. `GIT_*_DATE`
is unset too for symmetry; `set_fake_git_date` re-exports them per
commit, so determinism of dates is unaffected.