### PR TITLE
Use Foojay JDK toolchain resolver for Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ build/
 *.log
 /out/
 *.pem
-.sdkmanrc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,11 @@ Additional setup:
 
 ## Build
 
-Set up Java 21, preferably using [sdkman](https://sdkman.io/),
+Set up Java 21 or newer, preferably using [sdkman](https://sdkman.io/),
 with [`sdkman_auto_env=true`](https://sdkman.io/usage#config) and [`.sdkmanrc`](https://sdkman.io/usage#env).
+The exact JDK that compiles the plugin (currently Java 21, see `java-version.properties`)
+is auto-provisioned via Gradle's Java toolchain feature backed by [Foojay](https://foojay.io/),
+so any Java &ge; 21 is fine for running Gradle itself.
 
 To build the project, run `./gradlew build`. Please note that for the initial build attempt, you might need to add the `--info` option, in order to respond to the prompt of accepting Gradle Terms of Service.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,11 +106,12 @@ Additional setup:
 
 ## Build
 
-Set up Java 21 or newer, preferably using [sdkman](https://sdkman.io/),
-with [`sdkman_auto_env=true`](https://sdkman.io/usage#config) and [`.sdkmanrc`](https://sdkman.io/usage#env).
-The exact JDK that compiles the plugin (currently Java 21, see `java-version.properties`)
-is auto-provisioned via Gradle's Java toolchain feature backed by [Foojay](https://foojay.io/),
-so any Java &ge; 21 is fine for running Gradle itself.
+No JDK has to be installed system-wide before building: the plugin uses Gradle's
+[Java toolchain](https://docs.gradle.org/current/userguide/toolchains.html) feature backed by the
+[Foojay](https://foojay.io/) resolver, so the JDK that actually compiles the plugin
+(see `jdkVersionForGeneratedClassfiles` in `java-version.properties`) is auto-provisioned by Gradle
+on first build. Any JDK supported by Gradle as a runtime is therefore fine for invoking `./gradlew`
+itself - including the one bundled with IntelliJ IDEA, which the IDE uses by default to run Gradle.
 
 To build the project, run `./gradlew build`. Please note that for the initial build attempt, you might need to add the `--info` option, in order to respond to the prompt of accepting Gradle Terms of Service.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,8 +79,12 @@ allprojects {
   apply<JavaLibraryPlugin>()
 
   java {
-    sourceCompatibility = targetJavaVersion
-    targetCompatibility = targetJavaVersion // redundant, added for clarity
+    // Drives sourceCompatibility, targetCompatibility and `javac --release` in one place.
+    // Auto-provisioned via Foojay (see settings.gradle.kts) when no matching JDK is present locally,
+    // so the Gradle process JVM no longer has to match the bytecode target.
+    toolchain {
+      languageVersion.set(JavaLanguageVersion.of(targetJavaVersion.majorVersion.toInt()))
+    }
   }
 
   // String interpolation support, see https://github.com/antkorwin/better-strings.
@@ -102,14 +106,8 @@ allprojects {
 
     options.isFork = true
 
-    // `sourceCompatibility` and `targetCompatibility` say nothing about the Java APIs available to the compiled code.
-    // In fact, for X < Y it's perfectly possible to compile Java X code that uses Java Y APIs...
-    // This will work fine, until we actually try to run those compiled classes under Java X-compatible JVM,
-    // when we'll end up with NoSuchMethodError for APIs added between Java X and Java Y
-    // (i.e. for X=8 and Y=11: InputStream#readAllBytes, Stream#takeWhile and String#isBlank).
-    // `options.release = X` makes sure that regardless of Java version used to run the compiler,
-    // only Java X-compatible APIs are available to the compiled code.
-    options.release.set(Integer.parseInt(targetJavaVersion.majorVersion))
+    // No need to set `options.release` here: the Java toolchain (configured in `allprojects { java { toolchain { ... } } }`)
+    // pins the compiler JDK to the same major as the bytecode target, so the available Java APIs match by construction.
   }
 
   tasks.withType<Javadoc> {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,17 +4,15 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties
 
-// Not worth using Gradle toolchains, they don't seem to work as expected for buildSrc (or are just hard to configure properly).
-// Let the developers install sdkman to switch Java versions instead.
-val javaVersionProperties = Properties().apply {
-  load(rootDir.parentFile.resolve("java-version.properties").inputStream())
-}
-val requiredJavaVersion = javaVersionProperties.getProperty("jdkVersionForRunningGradle").toInt()
+// Gradle toolchains aren't easily applicable to buildSrc itself, so we only enforce a *minimum* JVM
+// for running Gradle here. The bytecode targeted by the plugin is decoupled and driven by the
+// `java { toolchain { ... } }` block in the root build (which is auto-provisioned via Foojay).
+val minJavaVersionForRunningGradle = 21
 val currentJavaVersion = JavaVersion.current()
-if (currentJavaVersion != JavaVersion.toVersion(requiredJavaVersion)) {
+if (currentJavaVersion < JavaVersion.toVersion(minJavaVersionForRunningGradle)) {
   throw GradleException(
-    "This build must be run under Java $requiredJavaVersion, rather than the current $currentJavaVersion. " +
-      "Consider using sdkman with .sdkmanrc file for easily switching Java versions.",
+    "This build must be run under Java $minJavaVersionForRunningGradle or newer, rather than the current $currentJavaVersion. " +
+      "Consider using sdkman for easily switching Java versions.",
   )
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,17 +4,10 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties
 
-// Gradle toolchains aren't easily applicable to buildSrc itself, so we only enforce a *minimum* JVM
-// for running Gradle here. The bytecode targeted by the plugin is decoupled and driven by the
-// `java { toolchain { ... } }` block in the root build (which is auto-provisioned via Foojay).
-val minJavaVersionForRunningGradle = 21
-val currentJavaVersion = JavaVersion.current()
-if (currentJavaVersion < JavaVersion.toVersion(minJavaVersionForRunningGradle)) {
-  throw GradleException(
-    "This build must be run under Java $minJavaVersionForRunningGradle or newer, rather than the current $currentJavaVersion. " +
-      "Consider using sdkman for easily switching Java versions.",
-  )
-}
+// No project-specific JDK check here: Gradle itself enforces its own minimum JVM (and rejects
+// anything below it with a clear error), and the JDK that actually compiles the plugin is
+// auto-provisioned via the Java toolchain set up in the root `build.gradle.kts` and the Foojay
+// resolver in `settings.gradle.kts` - so the JVM running Gradle is purely an implementation detail.
 
 plugins {
   `kotlin-dsl`

--- a/java-version.properties
+++ b/java-version.properties
@@ -1,2 +1,1 @@
-jdkVersionForRunningGradle=21
 jdkVersionForGeneratedClassfiles=21

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,6 +34,13 @@ pluginManagement {
   }
 }
 
+plugins {
+  // Auto-provisions JDK toolchains via the Foojay Disco API, so CI / fresh dev machines
+  // don't need a system JDK installed that matches every Gradle toolchain query
+  // (e.g. JDK 25 requested by the IntelliJ Platform plugin against newer EAP IDEs).
+  id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 // Note: please keep the projects in a topological order
 include(
   "qual",


### PR DESCRIPTION
This avoids the need to install a JDK matching every Gradle toolchain query
(e.g. JDK 25 requested by the IntelliJ Platform plugin against newer EAP IDEs)
on CI / fresh dev machines.