### PR TITLE
Collapse GitCoreRepository ctor down to a single rootDirectoryPath argument

### DIFF
--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositoryCache.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositoryCache.java
@@ -12,7 +12,5 @@ public interface IGitMacheteRepositoryCache {
   }
 
   @UIThreadUnsafe
-  IGitMacheteRepository getInstance(Path rootDirectoryPath, Path mainGitDirectoryPath, Path worktreeGitDirectoryPath,
-      Injector injector)
-      throws GitMacheteException;
+  IGitMacheteRepository getInstance(Path rootDirectoryPath, Injector injector) throws GitMacheteException;
 }

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositoryCache.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositoryCache.java
@@ -3,8 +3,6 @@ package com.virtuslab.gitmachete.backend.impl;
 import java.lang.ref.SoftReference;
 import java.nio.file.Path;
 
-import io.vavr.Tuple;
-import io.vavr.Tuple2;
 import io.vavr.collection.HashMap;
 import io.vavr.collection.Map;
 import lombok.val;
@@ -19,15 +17,15 @@ import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 public class GitMacheteRepositoryCache implements IGitMacheteRepositoryCache {
 
-  private static Map<Tuple2<Path, Path>, SoftReference<GitMacheteRepository>> gitMacheteRepositoryCache = HashMap.empty();
+  // Keyed on the project root path; for linked worktrees this is the per-worktree checkout dir,
+  // which is unique across (repo, worktree) pairs (git itself disallows the same directory being
+  // registered as more than one worktree).
+  private static Map<Path, SoftReference<GitMacheteRepository>> gitMacheteRepositoryCache = HashMap.empty();
 
   @Override
   @UIThreadUnsafe
-  public IGitMacheteRepository getInstance(Path rootDirectoryPath, Path mainGitDirectoryPath,
-      Path worktreeGitDirectoryPath, Injector injector)
-      throws GitMacheteException {
-    val key = Tuple.of(rootDirectoryPath, worktreeGitDirectoryPath);
-    val valueReference = gitMacheteRepositoryCache.get(key).getOrNull();
+  public IGitMacheteRepository getInstance(Path rootDirectoryPath, Injector injector) throws GitMacheteException {
+    val valueReference = gitMacheteRepositoryCache.get(rootDirectoryPath).getOrNull();
 
     if (valueReference != null) {
       val value = valueReference.get();
@@ -36,24 +34,22 @@ public class GitMacheteRepositoryCache implements IGitMacheteRepositoryCache {
       }
     }
 
-    val gitCoreRepository = createGitCoreRepository(rootDirectoryPath, mainGitDirectoryPath, worktreeGitDirectoryPath,
-        injector);
+    val gitCoreRepository = createGitCoreRepository(rootDirectoryPath, injector);
     val newValue = new GitMacheteRepository(gitCoreRepository);
-    gitMacheteRepositoryCache = gitMacheteRepositoryCache.put(key, new SoftReference<>(newValue));
+    gitMacheteRepositoryCache = gitMacheteRepositoryCache.put(rootDirectoryPath, new SoftReference<>(newValue));
 
     return newValue;
   }
 
   @UIThreadUnsafe
-  private IGitCoreRepository createGitCoreRepository(Path rootDirectoryPath, Path mainGitDirectoryPath,
-      Path worktreeGitDirectoryPath, Injector injector) throws GitMacheteException {
+  private IGitCoreRepository createGitCoreRepository(Path rootDirectoryPath, Injector injector)
+      throws GitMacheteException {
     try {
       val gitCoreRepositoryFactory = injector.inject(IGitCoreRepositoryFactory.class);
-      return gitCoreRepositoryFactory.create(rootDirectoryPath, mainGitDirectoryPath, worktreeGitDirectoryPath);
+      return gitCoreRepositoryFactory.create(rootDirectoryPath);
     } catch (GitCoreException e) {
       throw new GitMacheteException("Can't create an ${IGitCoreRepository.class.getSimpleName()} instance " +
-          "under ${rootDirectoryPath} (with main git directory under ${mainGitDirectoryPath} " +
-          "and worktree git directory under ${worktreeGitDirectoryPath})", e);
+          "under ${rootDirectoryPath}", e);
     }
   }
 }

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/BaseIntegrationTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/BaseIntegrationTestSuite.java
@@ -34,8 +34,7 @@ class BaseIntegrationTestSuite {
         return (T) gitCoreRepositoryFactory;
       }
     };
-    gitMacheteRepository = gitMacheteRepositoryCache.getInstance(repo.rootDirectoryPath, repo.mainGitDirectoryPath,
-        repo.worktreeGitDirectoryPath, injector);
+    gitMacheteRepository = gitMacheteRepositoryCache.getInstance(repo.rootDirectoryPath, injector);
     branchLayout = branchLayoutReader.read(new FileInputStream(repo.mainGitDirectoryPath.resolve("machete").toFile()));
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/toolbar/DiscoverAction.java
@@ -71,8 +71,6 @@ public class DiscoverAction extends BaseProjectDependentAction {
     }
 
     val rootDirPath = gitRepository.getRootDirectoryPath().toAbsolutePath();
-    val mainGitDirPath = gitRepository.getMainGitDirectoryPath().toAbsolutePath();
-    val worktreeGitDirPath = gitRepository.getWorktreeGitDirectoryPath().toAbsolutePath();
     val branchLayoutWriter = ApplicationManager.getApplication().getService(IBranchLayoutWriter.class);
 
     new SideEffectingBackgroundable(project, getNonHtmlString("action.GitMachete.DiscoverAction.task.title"), "discovery") {
@@ -81,7 +79,7 @@ public class DiscoverAction extends BaseProjectDependentAction {
       @UIThreadUnsafe
       protected void doRun(ProgressIndicator indicator) {
         val repoSnapshot = ApplicationManager.getApplication().getService(IGitMacheteRepositoryCache.class)
-            .getInstance(rootDirPath, mainGitDirPath, worktreeGitDirPath, ApplicationManager.getApplication()::getService)
+            .getInstance(rootDirPath, ApplicationManager.getApplication()::getService)
             .discoverLayoutAndCreateSnapshot();
 
         ModalityUiUtil.invokeLaterIfNeeded(NON_MODAL, () -> GraphTableDialog.Companion.of(

--- a/frontend/base/src/main/java/com/virtuslab/gitmachete/frontend/vfsutils/GitVfsUtils.java
+++ b/frontend/base/src/main/java/com/virtuslab/gitmachete/frontend/vfsutils/GitVfsUtils.java
@@ -48,11 +48,6 @@ public final class GitVfsUtils {
     return Paths.get(vfGitDir.getPath());
   }
 
-  public static Path getWorktreeGitDirectoryPath(GitRepository gitRepository) {
-    VirtualFile vfGitDir = getWorktreeGitDirectory(gitRepository);
-    return Paths.get(vfGitDir.getPath());
-  }
-
   public static Path getRootDirectoryPath(GitRepository gitRepository) {
     return Paths.get(gitRepository.getRoot().getPath());
   }

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/RediscoverSuggester.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/RediscoverSuggester.java
@@ -132,12 +132,10 @@ public class RediscoverSuggester {
   @UIThreadUnsafe
   private boolean isDiscoveredBranchLayoutEquivalentToCurrent(Path macheteFilePath) {
     Path rootDirPath = gitRepository.getRootDirectoryPath().toAbsolutePath();
-    Path mainGitDirPath = gitRepository.getMainGitDirectoryPath().toAbsolutePath();
-    Path worktreeGitDirPath = gitRepository.getWorktreeGitDirectoryPath().toAbsolutePath();
 
     try {
       val discoverRunResult = ApplicationManager.getApplication().getService(IGitMacheteRepositoryCache.class)
-          .getInstance(rootDirPath, mainGitDirPath, worktreeGitDirPath, ApplicationManager.getApplication()::getService)
+          .getInstance(rootDirPath, ApplicationManager.getApplication()::getService)
           .discoverLayoutAndCreateSnapshot();
 
       val currentBranchLayout = ReadAction

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/backgroundables/AutodiscoverBackgroundable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/backgroundables/AutodiscoverBackgroundable.java
@@ -55,14 +55,12 @@ public abstract class AutodiscoverBackgroundable extends Task.Backgroundable {
       return;
     }
     Path rootDirPath = gitRepository.getRootDirectoryPath().toAbsolutePath();
-    Path mainGitDirPath = gitRepository.getMainGitDirectoryPath().toAbsolutePath();
-    Path worktreeGitDirPath = gitRepository.getWorktreeGitDirectoryPath().toAbsolutePath();
 
     IGitMacheteRepository repository;
 
     try {
       repository = ApplicationManager.getApplication().getService(IGitMacheteRepositoryCache.class)
-          .getInstance(rootDirPath, mainGitDirPath, worktreeGitDirPath, ApplicationManager.getApplication()::getService);
+          .getInstance(rootDirPath, ApplicationManager.getApplication()::getService);
     } catch (GitMacheteException e) {
       VcsNotifier.getInstance(project)
           .notifyError(

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/backgroundables/GitMacheteRepositoryUpdateBackgroundable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/backgroundables/GitMacheteRepositoryUpdateBackgroundable.java
@@ -95,14 +95,12 @@ public final class GitMacheteRepositoryUpdateBackgroundable extends Task.Backgro
   @UIThreadUnsafe
   private @Nullable IGitMacheteRepositorySnapshot updateRepositorySnapshot() {
     Path rootDirectoryPath = gitRepository.getRootDirectoryPath();
-    Path mainGitDirectoryPath = gitRepository.getMainGitDirectoryPath();
-    Path worktreeGitDirectoryPath = gitRepository.getWorktreeGitDirectoryPath();
     Path macheteFilePath = gitRepository.getMacheteFilePath();
 
     val macheteVFile = VirtualFileManager.getInstance().findFileByNioPath(macheteFilePath);
     boolean isMacheteFilePresent = macheteVFile != null && !macheteVFile.isDirectory();
 
-    LOG.debug(() -> "Entering: rootDirectoryPath = ${rootDirectoryPath}, mainGitDirectoryPath = ${mainGitDirectoryPath}, " +
+    LOG.debug(() -> "Entering: rootDirectoryPath = ${rootDirectoryPath}, " +
         "macheteFilePath = ${macheteFilePath}, isMacheteFilePresent = ${isMacheteFilePresent}");
 
     if (isMacheteFilePresent) {
@@ -111,7 +109,7 @@ public final class GitMacheteRepositoryUpdateBackgroundable extends Task.Backgro
       try {
         BranchLayout branchLayout = readBranchLayout(macheteFilePath);
         IGitMacheteRepository gitMacheteRepository = gitMacheteRepositoryCache.getInstance(rootDirectoryPath,
-            mainGitDirectoryPath, worktreeGitDirectoryPath, ApplicationManager.getApplication()::getService);
+            ApplicationManager.getApplication()::getService);
         gitMacheteRepositoryHolder.set(gitMacheteRepository);
         return gitMacheteRepository.createSnapshotForLayout(branchLayout);
       } catch (MacheteFileReaderException e) {

--- a/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreRepositoryFactory.java
+++ b/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreRepositoryFactory.java
@@ -6,6 +6,5 @@ import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 public interface IGitCoreRepositoryFactory {
   @UIThreadUnsafe
-  IGitCoreRepository create(Path rootDirectoryPath, Path mainGitDirectoryPath, Path worktreeGitDirectoryPath)
-      throws GitCoreException;
+  IGitCoreRepository create(Path rootDirectoryPath) throws GitCoreException;
 }

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
@@ -53,6 +53,23 @@ import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 @CustomLog
 @ToString(onlyExplicitlyIncluded = true)
 public final class GitCoreRepository implements IGitCoreRepository {
+  // A single JGit Repository inferred from `rootDirectoryPath` via FileRepositoryBuilder#findGitDir,
+  // which follows the `.git` gitlink file inside a linked worktree (yielding `.git/worktrees/<wt>`)
+  // or returns `.git` directly for a plain single-worktree repo.
+  //
+  // Since JGit 7.0 (Sep 2024), BaseRepositoryBuilder honors the `commondir` pointer file that
+  // `git worktree add` drops next to the per-worktree HEAD, so this single Repository handle
+  // correctly routes:
+  //   - HEAD, reflog of HEAD, in-progress operation files (MERGE_HEAD, CHERRY_PICK_HEAD,
+  //     rebase-merge/, rebase-apply/, BISECT_START, repository state) -> per-worktree git dir,
+  //   - refs, config, object database, per-ref reflogs -> common (main) git dir.
+  //
+  // The three Path getters on `IGitCoreRepository` (root / main git dir / worktree git dir) are
+  // backed by `jgitRepo.getWorkTree()` / `getCommonDirectory()` / `getDirectory()` respectively.
+  private final Repository jgitRepo;
+  // Memoized for cheap getter access (the JGit getters return File and we'd be allocating a
+  // fresh Path on every call otherwise; some callers like CreateGitMacheteRepositoryHelper hit
+  // these getters repeatedly during snapshot construction).
   @Getter
   @ToString.Include
   private final Path rootDirectoryPath;
@@ -63,17 +80,6 @@ public final class GitCoreRepository implements IGitCoreRepository {
   @ToString.Include
   private final Path worktreeGitDirectoryPath;
 
-  // A single JGit Repository pointed at the per-worktree git dir (`.git/worktrees/<wt>` when the
-  // user is operating in a linked worktree, plain `.git` otherwise). Since JGit 7.0 (Sep 2024),
-  // BaseRepositoryBuilder honors the `commondir` pointer file that `git worktree add` drops next
-  // to the per-worktree HEAD, so a single Repository handle correctly routes:
-  //   - HEAD, reflog of HEAD, in-progress operation files (MERGE_HEAD, CHERRY_PICK_HEAD,
-  //     rebase-merge/, rebase-apply/, BISECT_START, repository state) -> per-worktree git dir,
-  //   - refs, config, object database, per-ref reflogs -> common (main) git dir.
-  // We still keep `mainGitDirectoryPath` as a Path field (and getter) because callers outside
-  // JGit need it to locate the machete file and the merge-base cache.
-  private final Repository jgitRepo;
-
   private static final String ORIGIN = "origin";
 
   // Note that these caches can be static since merge-base and commit range for the given two commits
@@ -82,22 +88,21 @@ public final class GitCoreRepository implements IGitCoreRepository {
   private static final java.util.Map<Tuple2<IGitCoreCommit, IGitCoreCommit>, List<IGitCoreCommit>> commitRangeCache = new java.util.HashMap<>();
 
   @UIThreadUnsafe
-  public GitCoreRepository(Path rootDirectoryPath, Path mainGitDirectoryPath, Path worktreeGitDirectoryPath)
-      throws GitCoreException {
-    this.rootDirectoryPath = rootDirectoryPath;
-    this.mainGitDirectoryPath = mainGitDirectoryPath;
-    this.worktreeGitDirectoryPath = worktreeGitDirectoryPath;
-
-    val builder = new FileRepositoryBuilder();
-    builder.setWorkTree(rootDirectoryPath.toFile());
-    builder.setGitDir(worktreeGitDirectoryPath.toFile());
+  public GitCoreRepository(Path rootDirectoryPath) throws GitCoreException {
+    val builder = new FileRepositoryBuilder()
+        .findGitDir(rootDirectoryPath.toFile())
+        .setMustExist(true);
 
     try {
       this.jgitRepo = builder.build();
     } catch (IOException e) {
       throw new GitCoreCannotAccessGitDirectoryException("Cannot create a repository object for " +
-          "rootDirectoryPath=${rootDirectoryPath}, worktreeGitDirectoryPath=${worktreeGitDirectoryPath}", e);
+          "rootDirectoryPath=${rootDirectoryPath}", e);
     }
+
+    this.rootDirectoryPath = jgitRepo.getWorkTree().toPath();
+    this.mainGitDirectoryPath = jgitRepo.getCommonDirectory().toPath();
+    this.worktreeGitDirectoryPath = jgitRepo.getDirectory().toPath();
 
     LOG.debug(() -> "Created ${this})");
   }
@@ -279,7 +284,7 @@ public final class GitCoreRepository implements IGitCoreRepository {
   @UIThreadUnsafe
   private List<IGitCoreReflogEntry> deriveReflogByRefFullName(String refFullName) throws GitCoreException {
     try {
-      ReflogReader reflogReader = jgitRepo.getReflogReader(refFullName);
+      ReflogReader reflogReader = jgitRepo.getRefDatabase().getReflogReader(refFullName);
       if (reflogReader == null) {
         throw new GitCoreNoSuchRevisionException("Ref '${refFullName}' does not exist in this repository");
       }

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryFactory.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryFactory.java
@@ -9,8 +9,7 @@ import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 public class GitCoreRepositoryFactory implements IGitCoreRepositoryFactory {
   @UIThreadUnsafe
-  public IGitCoreRepository create(Path rootDirectoryPath, Path mainGitDirectoryPath, Path worktreeGitDirectoryPath)
-      throws GitCoreException {
-    return new GitCoreRepository(rootDirectoryPath, mainGitDirectoryPath, worktreeGitDirectoryPath);
+  public IGitCoreRepository create(Path rootDirectoryPath) throws GitCoreException {
+    return new GitCoreRepository(rootDirectoryPath);
   }
 }

--- a/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryIntegrationTest.java
+++ b/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryIntegrationTest.java
@@ -35,7 +35,7 @@ public class GitCoreRepositoryIntegrationTest {
   public void setUp() {
     repo = new TestGitRepository(SETUP_WITH_SINGLE_REMOTE);
 
-    gitCoreRepository = new GitCoreRepository(repo.rootDirectoryPath, repo.mainGitDirectoryPath, repo.worktreeGitDirectoryPath);
+    gitCoreRepository = new GitCoreRepository(repo.rootDirectoryPath);
   }
 
   // See https://github.com/VirtusLab/git-machete-intellij-plugin/issues/1029 for the origin of this test

--- a/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryWorktreeIntegrationTest.java
+++ b/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryWorktreeIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.virtuslab.gitcore.impl.jgit;
 
+import static com.virtuslab.gitmachete.testcommon.SetupScripts.SETUP_FOR_NO_REMOTES;
 import static com.virtuslab.gitmachete.testcommon.SetupScripts.SETUP_WITH_SINGLE_REMOTE;
 import static com.virtuslab.gitmachete.testcommon.TestFileUtils.cleanUpDir;
 import static com.virtuslab.gitmachete.testcommon.TestProcessUtils.runProcessAndReturnStdout;
@@ -10,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 import lombok.SneakyThrows;
 import lombok.val;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,23 +37,22 @@ public class GitCoreRepositoryWorktreeIntegrationTest {
   }
 
   /**
-   * GitCoreRepository scoped at the linked worktree's git dir
-   * ({@code <repo>/.git/worktrees/<wt>}); the typical layout when the IDE is opened on
-   * a linked worktree.
+   * GitCoreRepository scoped at the linked worktree's root; JGit resolves the per-worktree git dir
+   * ({@code <main-repo>/.git/worktrees/<wt>}) by following the gitlink at {@code <wt-root>/.git}.
+   * This is the typical layout when the IDE is opened on a linked worktree.
    */
   @SneakyThrows
   private GitCoreRepository worktreeScoped() {
-    return new GitCoreRepository(repo.rootDirectoryPath, repo.mainGitDirectoryPath, repo.worktreeGitDirectoryPath);
+    return new GitCoreRepository(repo.rootDirectoryPath);
   }
 
   /**
-   * GitCoreRepository scoped at the main git dir
-   * (worktree git dir == main git dir; same shape as a non-worktree project).
+   * GitCoreRepository scoped at the main repo's root (worktree git dir == main git dir;
+   * same shape as a non-worktree project).
    */
   @SneakyThrows
   private GitCoreRepository mainScoped() {
-    Path mainRootPath = repo.mainGitDirectoryPath.getParent();
-    return new GitCoreRepository(mainRootPath, repo.mainGitDirectoryPath, repo.mainGitDirectoryPath);
+    return new GitCoreRepository(repo.mainGitDirectoryPath.getParent());
   }
 
   @Test
@@ -146,6 +146,64 @@ public class GitCoreRepositoryWorktreeIntegrationTest {
 
     assertEquals("develop", worktreeScoped().deriveBisectedBranch());
     assertNull(mainScoped().deriveBisectedBranch(), "Main-scoped repo must not see worktree's bisect state");
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  // Pins down the per-path-getter contract that downstream callers (machete-file location,
+  // merge-base cache, snapshot equality checks in EnhancedGraphTable) rely on.
+
+  @Test
+  @SneakyThrows
+  public void getters_onLinkedWorktree_resolveToDistinctPaths() {
+    val gitCoreRepository = worktreeScoped();
+
+    // Root is the linked worktree's checked-out directory, not the main repo's root.
+    assertEquals(repo.rootDirectoryPath.toRealPath(), gitCoreRepository.getRootDirectoryPath().toRealPath());
+
+    // The per-worktree git dir is `<main>/.git/worktrees/<wt>`, distinct from the common dir.
+    assertEquals(repo.worktreeGitDirectoryPath.toRealPath(), gitCoreRepository.getWorktreeGitDirectoryPath().toRealPath());
+
+    // The common (main) git dir is reachable via JGit's `commondir` pointer support.
+    assertEquals(repo.mainGitDirectoryPath.toRealPath(), gitCoreRepository.getMainGitDirectoryPath().toRealPath());
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  @Test
+  @SneakyThrows
+  public void getters_onPlainSingleRepo_haveMainEqualToWorktreeGitDir() {
+    // Tear down the SETUP_WITH_SINGLE_REMOTE fixture and set up a non-worktree one for this case.
+    cleanUpDir(repo.parentDirectoryPath);
+    repo = new TestGitRepository(SETUP_FOR_NO_REMOTES);
+
+    val gitCoreRepository = new GitCoreRepository(repo.rootDirectoryPath);
+
+    // For a plain single-worktree repo there's no `commondir` pointer file, so the per-worktree
+    // git dir IS the common git dir. Both getters must agree, and both must equal `<root>/.git`.
+    val rootDotGit = repo.rootDirectoryPath.resolve(".git").toRealPath();
+    assertEquals(rootDotGit, gitCoreRepository.getMainGitDirectoryPath().toRealPath());
+    assertEquals(rootDotGit, gitCoreRepository.getWorktreeGitDirectoryPath().toRealPath());
+    assertEquals(repo.rootDirectoryPath.toRealPath(), gitCoreRepository.getRootDirectoryPath().toRealPath());
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  @Test
+  @SneakyThrows
+  public void jgitFindGitDirFromLinkedWorktreeRoot_followsTheGitlinkFile() {
+    // Pointing JGit's FileRepositoryBuilder at the linked worktree's root must yield the
+    // per-worktree git dir (`<main>/.git/worktrees/<wt>`), not the main `.git` dir, by
+    // following the gitlink file at `<wt-root>/.git`.
+    val builder = new FileRepositoryBuilder()
+        .findGitDir(repo.rootDirectoryPath.toFile())
+        .setMustExist(true);
+    try (val resolved = builder.build()) {
+      assertEquals(repo.worktreeGitDirectoryPath.toRealPath(), resolved.getDirectory().toPath().toRealPath());
+      // Common-dir support landed in JGit 7.0; without it the refactor doesn't fly.
+      assertEquals(repo.mainGitDirectoryPath.toRealPath(), resolved.getCommonDirectory().toPath().toRealPath());
+      assertEquals(repo.rootDirectoryPath.toRealPath(), resolved.getWorkTree().toPath().toRealPath());
+    }
 
     cleanUpDir(repo.parentDirectoryPath);
   }


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2294

## Chain of upstream PRs as of 2026-05-26

* PR #2294:
  `develop` ← `refactor/single-jgit-repo`

  * **PR #2295 (THIS ONE)**:
    `refactor/single-jgit-repo` ← `refactor/gitcorerepo-ctor-unary`

<!-- end git-machete generated -->

`GitCoreRepository`'s ctor previously took root, main-git-dir and worktree-git-dir
paths even though all three are fully derivable from the root via JGit:
`FileRepositoryBuilder.findGitDir(root)` follows the `.git` gitlink inside a linked
worktree and `Repository#getWorkTree`/`getCommonDirectory`/`getDirectory` then
expose the three paths the rest of the codebase still needs. Drop the redundant
ctor params and cascade the same reduction through `IGitCoreRepositoryFactory`
and `IGitMacheteRepositoryCache#getInstance` (4 call sites). The cache key
shrinks from `(rootDir, worktreeGitDir)` to just `rootDir` (git itself disallows
the same dir being registered as more than one worktree).

`GitVfsUtils#getWorktreeGitDirectoryPath` loses its last consumer and is dropped.

Extend `GitCoreRepositoryWorktreeIntegrationTest` with three new tests covering
the corners the refactor depends on: (a) JGit's `findGitDir` actually follows
the gitlink file inside a linked worktree, (b) all three getters resolve to the
correct distinct paths for a linked worktree, and (c) for a plain single-worktree
repo the main and worktree git dirs coincide at `<root>/.git`.