### PR TITLE
Cache test fixture git repos in a Gradle task instead of re-running scripts per `@BeforeEach`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md
+
+Guidelines for AI coding agents working in this repository.
+
+## Code comments
+
+- Explain why the code is the way it is, not what it used to be.
+  - Bad: `// Today this also happens accidentally, because the scripts used to live under .../resources`
+  - Bad: `// Previously we did X, but switched to Y because ...`
+  - Bad: `// This was added to fix the regression introduced by commit abc1234`
+  - Good: `// Y is required because Z`
+- Refer to the current state of the codebase, the runtime contract, or the
+  invariants being enforced. The reader has `git log` and `git blame` for the
+  history; comments should not duplicate that.
+- One exception: when the current code intentionally guards against a
+  recurrence of a specific bug, it's fine to name the bug, but phrase it
+  forward-looking ("guards against X" rather than "fixes the X regression").
+- Do not narrate the change in code comments (e.g. "Added the X parameter
+  to ..."). Write comments that would still make sense to a reader who has
+  never seen the previous revision.
+- Do not add obvious, redundant comments that just restate the next line of
+  code (e.g. `// Increment the counter` above `counter++`). Comments should
+  carry information the code itself cannot convey.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,9 +150,15 @@ allprojects {
     if (project.path != ":testCommon") {
       dependsOn(":testCommon:prepareTestRepoTemplates")
       // The path is fixed-by-convention rather than queried from testCommon's `extra`, so we don't
-      // need `evaluationDependsOn(":testCommon")` here. The matching value is registered as a
-      // task output, so build-cache hits still work.
+      // need `evaluationDependsOn(":testCommon")` here.
       val templatesDir = rootProject.layout.projectDirectory.dir("testCommon/build/test-fixture-repos")
+      // Register the prebuilt-templates dir as an explicit Test input so changes to a `setup-*.sh`
+      // script invalidate downstream Test tasks. Without this, the chain would rely on the scripts
+      // being indirectly hashed under `stableClasspath` via `testCommon-test-fixtures.jar`, which
+      // is a brittle dependency on the resources layout.
+      inputs.dir(templatesDir)
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+        .withPropertyName("prebuiltTestRepoTemplates")
       systemProperty("testFixtures.prebuiltTemplatesDir", templatesDir.asFile.absolutePath)
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,6 +141,20 @@ allprojects {
       showExceptions = true
       showStackTraces = true
     }
+
+    // Wire `:testCommon:prepareTestRepoTemplates` onto every Test task, so that `TestGitRepository`
+    // can use the cached prebuilt repos instead of re-running the setup script on every
+    // `@BeforeEach`. Tests that don't use the fixtures simply ignore the system property.
+    // `:testCommon` is itself the producer; skipping the wiring there avoids a self-cycle (and the
+    // module has no production tests anyway).
+    if (project.path != ":testCommon") {
+      dependsOn(":testCommon:prepareTestRepoTemplates")
+      // The path is fixed-by-convention rather than queried from testCommon's `extra`, so we don't
+      // need `evaluationDependsOn(":testCommon")` here. The matching value is registered as a
+      // task output, so build-cache hits still work.
+      val templatesDir = rootProject.layout.projectDirectory.dir("testCommon/build/test-fixture-repos")
+      systemProperty("testFixtures.prebuiltTemplatesDir", templatesDir.asFile.absolutePath)
+    }
   }
 
   configureCheckerFramework()

--- a/testCommon/build.gradle.kts
+++ b/testCommon/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.virtuslab.gitmachete.buildsrc.*
+import org.gradle.kotlin.dsl.support.serviceOf
 
 plugins {
   `java-library`
@@ -10,4 +11,73 @@ dependencies {
   commonsIO("testFixtures")
   junitApi("testFixtures")
   lombok("testFixtures")
+}
+
+// Pre-runs every test-fixture setup script once into `build/test-fixture-repos/<scriptName>.tar`,
+// so that downstream tests can `tar -xf` it into the per-test temp dir instead of paying the ~3s
+// cost of re-running the script for every `@BeforeEach`. The output is wired onto consumer Test
+// tasks via the `testFixtures.prebuiltTemplatesDir` system property (see root build.gradle.kts).
+//
+// Why tar instead of plain directories? Gradle's output snapshotting inherits Ant's default
+// excludes (notably `**/.git/**`), which silently strip the per-fixture `.git` dir when the
+// output is restored from the build cache - breaking every test that reads the prebuilt repo.
+// A single tarball per script is opaque to the snapshotter and round-trips through the cache
+// without losing any files.
+//
+// Inputs are limited to `*.sh` under the test-fixtures resources; the task is up-to-date and
+// build-cacheable as long as none of those scripts changes.
+val fixtureResourcesDir = file("src/testFixtures/resources")
+val testRepoTemplatesDir = layout.buildDirectory.dir("test-fixture-repos")
+
+tasks.register("prepareTestRepoTemplates") {
+  description = "Pre-builds git sandbox repos for tests by running each *.sh fixture once."
+  group = "build"
+
+  inputs.files(fileTree(fixtureResourcesDir) { include("*.sh") }).withPathSensitivity(PathSensitivity.RELATIVE)
+  outputs.dir(testRepoTemplatesDir)
+  outputs.cacheIf { true }
+
+  val execOps = serviceOf<org.gradle.process.ExecOperations>()
+  val fsOps = serviceOf<org.gradle.api.file.FileSystemOperations>()
+
+  doLast {
+    val outDir = testRepoTemplatesDir.get().asFile
+    fsOps.delete { delete(outDir) }
+    outDir.mkdirs()
+
+    val commonSh = fixtureResourcesDir.resolve("common.sh")
+    val scripts = fixtureResourcesDir.listFiles { f -> f.isFile && f.name.endsWith(".sh") && f.name != "common.sh" }
+      ?: emptyArray()
+
+    for (script in scripts) {
+      val workDir = outDir.resolve(script.name + ".work")
+      workDir.mkdirs()
+
+      // common.sh and the script itself need to live next to where the fixture data is written,
+      // so that `source "$self_dir"/common.sh` resolves and the script can `cd $sandboxDir` inside
+      // the workdir.
+      commonSh.copyTo(workDir.resolve("common.sh"), overwrite = true)
+      script.copyTo(workDir.resolve(script.name), overwrite = true)
+
+      execOps.exec {
+        workingDir(workDir)
+        commandLine("bash", script.name)
+      }
+
+      // Strip the bootstrap scripts before archiving - tests don't need them, and keeping them
+      // out makes the per-test extraction step a no-op for tooling that filters them.
+      workDir.resolve("common.sh").delete()
+      workDir.resolve(script.name).delete()
+
+      // BSD/GNU `tar` is available everywhere we run (macOS + Linux CI + Windows 10+). The `-C`
+      // flag keeps paths relative to the workdir so the archive untars cleanly into any target.
+      val tarball = outDir.resolve(script.name + ".tar")
+      execOps.exec {
+        workingDir(outDir)
+        commandLine("tar", "-cf", tarball.absolutePath, "-C", workDir.absolutePath, ".")
+      }
+
+      fsOps.delete { delete(workDir) }
+    }
+  }
 }

--- a/testCommon/build.gradle.kts
+++ b/testCommon/build.gradle.kts
@@ -24,6 +24,18 @@ dependencies {
 // A single tarball per script is opaque to the snapshotter and round-trips through the cache
 // without losing any files.
 //
+// Why not Gradle's standard `Zip` (or `Tar`) task instead of shelling out to `tar`? The idiomatic
+// shape would be one task that runs the script into a staging dir and a second task (the `Zip`)
+// that depends on it and archives the dir. That works, but it sacrifices the cache-hit speedup
+// we're after: the stage task can't be cacheable (its output is a directory holding `.git`, which
+// would be stripped on cache restore - see paragraph above), and the `Zip` task's inputs include
+// the staged dir, so a "cache hit" on the zip still requires the stage task to run first - i.e. we'd
+// re-execute the setup script every time. Collapsing everything into one task whose sole output is
+// the archive avoids that, but then we have to write the archive from inside the task action, where
+// `tar` is the simplest portable mechanism available in our CI (macOS + Linux). `java.util.zip` /
+// `ant.zip` would work too; we picked plain `tar` for its 1:1 parity with the matching `tar -xf`
+// on the test side.
+//
 // Inputs are limited to `*.sh` under the test-fixtures resources; the task is up-to-date and
 // build-cacheable as long as none of those scripts changes.
 val fixtureResourcesDir = file("src/testFixtures/resources")

--- a/testCommon/src/testFixtures/java/com/virtuslab/gitmachete/testcommon/TestGitRepository.java
+++ b/testCommon/src/testFixtures/java/com/virtuslab/gitmachete/testcommon/TestGitRepository.java
@@ -2,6 +2,7 @@ package com.virtuslab.gitmachete.testcommon;
 
 import static com.virtuslab.gitmachete.testcommon.TestFileUtils.copyScriptFromResources;
 import static com.virtuslab.gitmachete.testcommon.TestFileUtils.prepareRepoFromScript;
+import static com.virtuslab.gitmachete.testcommon.TestProcessUtils.runProcessAndReturnStdout;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -9,6 +10,15 @@ import java.nio.file.Path;
 import lombok.SneakyThrows;
 
 public class TestGitRepository {
+
+  // When set, TestGitRepository copies `<prebuiltTemplatesDir>/<scriptName>/` into the per-test
+  // temp dir instead of re-running the setup script. The :testCommon:prepareTestRepoTemplates
+  // Gradle task populates this directory once per build and wires the property onto every
+  // dependent Test task; running tests from inside the IDE without that task still works -
+  // we fall back to executing the script in-process.
+  private static final String PREBUILT_TEMPLATES_DIR_PROPERTY = "testFixtures.prebuiltTemplatesDir";
+
+  private static final String SETUP_WITH_SINGLE_REMOTE = "setup-with-single-remote.sh";
 
   public final Path parentDirectoryPath;
   public final Path rootDirectoryPath;
@@ -18,7 +28,7 @@ public class TestGitRepository {
   @SneakyThrows
   public TestGitRepository(String scriptName) {
     parentDirectoryPath = Files.createTempDirectory("machete-tests-");
-    if (scriptName.equals("setup-with-single-remote.sh")) {
+    if (scriptName.equals(SETUP_WITH_SINGLE_REMOTE)) {
       rootDirectoryPath = parentDirectoryPath.resolve("machete-sandbox-worktree");
       mainGitDirectoryPath = parentDirectoryPath.resolve("machete-sandbox").resolve(".git");
       worktreeGitDirectoryPath = mainGitDirectoryPath.resolve("worktrees").resolve("machete-sandbox-worktree");
@@ -28,10 +38,53 @@ public class TestGitRepository {
       worktreeGitDirectoryPath = rootDirectoryPath.resolve(".git");
     }
 
+    materializeBaseRepo(scriptName);
+
+    if (scriptName.equals(SETUP_WITH_SINGLE_REMOTE)) {
+      addWorktreeAndDetachMain();
+    }
+
+    System.out.println("Set up a test repo in " + rootDirectoryPath);
+  }
+
+  @SneakyThrows
+  private void materializeBaseRepo(String scriptName) {
+    Path prebuiltTarball = locatePrebuiltTarball(scriptName);
+    if (prebuiltTarball != null) {
+      // ~50 ms vs ~3 s for re-running the script.
+      runProcessAndReturnStdout(parentDirectoryPath, /* timeoutSeconds */ 30, "tar", "-xf", prebuiltTarball.toString());
+      return;
+    }
     copyScriptFromResources("common.sh", parentDirectoryPath);
     copyScriptFromResources(scriptName, parentDirectoryPath);
     prepareRepoFromScript(scriptName, parentDirectoryPath);
+  }
 
-    System.out.println("Set up a test repo in " + rootDirectoryPath);
+  private static Path locatePrebuiltTarball(String scriptName) {
+    String dir = System.getProperty(PREBUILT_TEMPLATES_DIR_PROPERTY);
+    if (dir == null || dir.isEmpty()) {
+      return null;
+    }
+    Path tarball = Path.of(dir, scriptName + ".tar");
+    return Files.isRegularFile(tarball) ? tarball : null;
+  }
+
+  // Mirrors the tail that setup-with-single-remote.sh used to do inline. Kept in Java so that the
+  // absolute paths baked into `.git/worktrees/<wt>/gitdir` are stamped against the per-test
+  // parent dir, not against the build-time prebuild dir.
+  private void addWorktreeAndDetachMain() {
+    final String git = "git";
+    Path mainRepo = parentDirectoryPath.resolve("machete-sandbox");
+    // Pin the worktree to HEAD (a commit, not a branch) so that git doesn't auto-create a
+    // `machete-sandbox-worktree` branch.
+    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 30, git, "worktree", "add", "../machete-sandbox-worktree", "HEAD");
+    // Stash the worktree's per-repo hooks override before detaching HEAD on the main repo,
+    // matching the original script's ordering.
+    runProcessAndReturnStdout(rootDirectoryPath, /* timeoutSeconds */ 10,
+        git, "config", "--local", "core.hooksPath", "../machete-sandbox/.git/hooks");
+    // git refuses to check out a branch already held by another worktree, so flip the main repo
+    // into detached HEAD to give the worktree free rein over every branch.
+    String headSha = runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 10, git, "rev-parse", "HEAD").trim();
+    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 10, git, "checkout", headSha);
   }
 }

--- a/testCommon/src/testFixtures/resources/setup-with-single-remote.sh
+++ b/testCommon/src/testFixtures/resources/setup-with-single-remote.sh
@@ -73,11 +73,9 @@ cd machete-sandbox
 
   sed 's/^  //' <<< "$machete_file" > .git/machete
 
-  # Let's specify HEAD as the revision to use; otherwise a new `machete-sandbox-worktree` branch would be created.
-  git worktree add ../machete-sandbox-worktree HEAD
-  git config --local core.hooksPath ../machete-sandbox/.git/hooks
-  # git doesn't allow for any branch to be checked out in more than one worktree at any moment.
-  # Let's force-switch to detached HEAD state in the main repository folder
-  # so that we have a freedom to check out any branch in the worktree.
-  git checkout "$(git rev-parse HEAD)"
+  # NB: this script intentionally does NOT do `git worktree add ../machete-sandbox-worktree HEAD`.
+  # The matching `TestGitRepository` runs that step in Java once the (possibly pre-built and copied)
+  # template is in its final location - otherwise the absolute paths baked into
+  # `.git/worktrees/<wt>/gitdir` and `<wt-root>/.git` would point at the pre-build directory rather
+  # than the per-test temp dir.
 cd -


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2295

## Chain of upstream PRs as of 2026-05-27

* PR #2294:
  `develop` ← `refactor/single-jgit-repo`

  * PR #2295:
    `refactor/single-jgit-repo` ← `refactor/gitcorerepo-ctor-unary`

    * **PR #2296 (THIS ONE)**:
      `refactor/gitcorerepo-ctor-unary` ← `perf/tests-sandbox`

<!-- end git-machete generated -->

Every test that uses `TestGitRepository` was spawning a shell that ran one of the
fixture setup scripts (`setup-*.sh`) end-to-end - which means a handful of `git
init`, dozens of `git checkout`, `git commit` and `git push` invocations. The
scripts ran in **1.2-5.8 s** apiece (3-run avg in an isolated tempdir on this
laptop) and were re-executed for every parameterized run / every `@BeforeEach`:

| Suite                                          | Before | After |
|------------------------------------------------|-------:|------:|
| GitCoreRepositoryIntegrationTest               | 18.6 s | 2.9 s |
| GitCoreRepositoryWorktreeIntegrationTest       | 34.4 s | 5.1 s |
| backend StatusAndDiscoverIntegrationTestSuite  | 41.8 s | 11.8 s |
| backend ParentInferenceIntegrationTestSuite    | 12.1 s | 4.4 s |
| **Sum**                                        | **106.9 s** | **24.2 s** |

End-to-end wall time for `./gradlew :gitCore:jGit:test :backend:impl:test`
(prebuild already cached): **~70 s -> ~15 s**.

`:testCommon:prepareTestRepoTemplates` runs each `*.sh` fixture once into
`testCommon/build/test-fixture-repos/<scriptName>.sh.tar`, packed as a tarball.
`TestGitRepository` then `tar -xf`s the matching archive into the per-test
tempdir (~50 ms) instead of re-running the script. Tarballs (rather than plain
directories) are needed because Gradle's output snapshotting inherits Ant's
default excludes, which silently strip `.git/` directories when the output is
restored from the build cache - making round-tripped templates useless.

Stripped the `git worktree add ../machete-sandbox-worktree HEAD` tail from
`setup-with-single-remote.sh` and moved the equivalent steps into
`TestGitRepository#addWorktreeAndDetachMain`. The pre-built template now
contains only a plain `machete-sandbox` repo + the bare remote; the worktree
is added against the per-test temp dir so that the absolute paths baked into
`.git/worktrees/<wt>/gitdir` and `<wt-root>/.git` stay correct after the copy.

`TestGitRepository` falls back to executing the script directly when the system
property `testFixtures.prebuiltTemplatesDir` is unset (e.g. running tests from
the IDE without first running the Gradle task), keeping the existing dev loop
working without extra friction.