### PR TITLE
Block checkout-like actions when target branch is held by another worktree

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -10,6 +10,7 @@
 - Fixed: "Show in Git Log" action jumping to a commit in the wrong repository in multi-root projects
 - Fixed: stale "no need to fetch" cache hits across repositories sharing the same directory name in multi-root projects
 - Fixed: "Don't show for this branch" preference of the unmanaged-branch notification was leaking across repositories that share a branch name in multi-root projects
+- Changed: Checkout, Squash, Rebase Onto Parent and Reset to Remote actions are now disabled for branches that are already checked out in another worktree
 
 ## v7.0.1
 - Added: auto-discovery of the branch layout in case of multiple repositories (contributed by @mkondratek)

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseCheckoutAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseCheckoutAction.java
@@ -57,11 +57,23 @@ public abstract class BaseCheckoutAction extends BaseGitMacheteRepositoryReadyAc
       presentation.setDescription(
           getNonHtmlString("action.GitMachete.BaseCheckoutAction.description.disabled.currently-checked-out")
               .fmt(targetBranchName));
-
-    } else {
-      presentation.setDescription(
-          getNonHtmlString("action.GitMachete.BaseCheckoutAction.description.precise").fmt(targetBranchName));
+      return;
     }
+
+    val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, targetBranchName);
+    if (worktreeRootHoldingBranch != null) {
+      // Git refuses to check out a branch already held by another worktree, so block the action up-front
+      // and surface the holding worktree's path in the tooltip rather than letting the user discover this
+      // through a side-effecting failure.
+      presentation.setEnabled(false);
+      presentation.setDescription(
+          getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
+              .fmt(targetBranchName, worktreeRootHoldingBranch.toString()));
+      return;
+    }
+
+    presentation.setDescription(
+        getNonHtmlString("action.GitMachete.BaseCheckoutAction.description.precise").fmt(targetBranchName));
   }
 
   @Override

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetToRemoteAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetToRemoteAction.java
@@ -86,6 +86,18 @@ public abstract class BaseResetToRemoteAction extends BaseGitMacheteRepositoryRe
       if (anActionEvent.getPlace().equals(ActionPlaces.CONTEXT_MENU) && isResettingCurrent) {
         anActionEvent.getPresentation().setText(getActionName());
       }
+
+      val presentation = anActionEvent.getPresentation();
+      if (presentation.isEnabledAndVisible()) {
+        val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branch);
+        if (worktreeRootHoldingBranch != null) {
+          // Reset moves the local branch ref; git refuses to update a branch held by another worktree.
+          presentation.setEnabled(false);
+          presentation.setDescription(
+              getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
+                  .fmt(branch, worktreeRootHoldingBranch.toString()));
+        }
+      }
     }
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSquashAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSquashAction.java
@@ -70,6 +70,7 @@ public abstract class BaseSquashAction extends BaseGitMacheteRepositoryReadyActi
         val description = getNonHtmlString("action.GitMachete.BaseSquashAction.not-enough-commits")
             .fmt(branchName, numberOfCommits + "", numberOfCommits == 1 ? "" : "s");
 
+        val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
         if (numberOfCommits < 2) {
           presentation.setDescription(description);
           presentation.setEnabled(false);
@@ -77,6 +78,13 @@ public abstract class BaseSquashAction extends BaseGitMacheteRepositoryReadyActi
           presentation.setEnabled(false);
           presentation.setDescription(getNonHtmlString("action.GitMachete.BaseSquashAction.fork-point-off")
               .fmt(branchName));
+        } else if (worktreeRootHoldingBranch != null) {
+          // Squashing a non-current branch first switches HEAD to it (see doSquash); git refuses if the branch
+          // is held in another worktree.
+          presentation.setEnabled(false);
+          presentation.setDescription(
+              getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
+                  .fmt(branchName, worktreeRootHoldingBranch.toString()));
         } else {
           val currentBranchIfManaged = getCurrentBranchNameIfManaged(anActionEvent);
           val isSquashingCurrentBranch = currentBranchIfManaged != null && currentBranchIfManaged.equals(branchName);

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSyncToParentByRebaseAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSyncToParentByRebaseAction.java
@@ -94,8 +94,18 @@ public abstract class BaseSyncToParentByRebaseAction extends BaseGitMacheteRepos
       } else if (branch.isNonRoot()) {
         val nonRootBranch = branch.asNonRoot();
         val upstream = nonRootBranch.getParent();
-        presentation.setDescription(getNonHtmlString("action.GitMachete.BaseSyncToParentByRebaseAction.description")
-            .fmt(branch.getName(), upstream.getName()));
+        val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
+        if (worktreeRootHoldingBranch != null) {
+          // Rebase-onto-parent checks out the branch into the active worktree before invoking rebase; git
+          // refuses if the branch is held elsewhere.
+          presentation.setEnabled(false);
+          presentation.setDescription(
+              getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
+                  .fmt(branch.getName(), worktreeRootHoldingBranch.toString()));
+        } else {
+          presentation.setDescription(getNonHtmlString("action.GitMachete.BaseSyncToParentByRebaseAction.description")
+              .fmt(branch.getName(), upstream.getName()));
+        }
       }
 
       val currentBranchNameIfManaged = getCurrentBranchNameIfManaged(anActionEvent);

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
@@ -1,5 +1,7 @@
 package com.virtuslab.gitmachete.frontend.actions.expectedkeys;
 
+import java.nio.file.Path;
+
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import lombok.val;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -53,5 +55,27 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
       log().warn(branchName + " Git Machete branch is undefined");
     }
     return branch;
+  }
+
+  /**
+   * @return the absolute root of an <i>other</i> worktree currently holding {@code branchName} checked out, or
+   *         {@code null} if no other worktree holds it (or the branch is not managed). "Other" means a
+   *         worktree different from the one the enclosing snapshot was built against. Both paths are already
+   *         canonicalized at snapshot creation time, so a plain {@link Path#equals} comparison is sufficient.
+   *         Surfacing this from the action layer lets every checkout-like action share the same up-front
+   *         guard, since git will refuse any operation that tries to switch HEAD to a branch already held
+   *         elsewhere.
+   */
+  default @Nullable Path getWorktreeRootHoldingBranchIfHeldElsewhere(AnActionEvent anActionEvent, @Nullable String branchName) {
+    val snapshot = getGitMacheteRepositorySnapshot(anActionEvent);
+    val branch = getManagedBranchByName(anActionEvent, branchName);
+    if (snapshot == null || branch == null) {
+      return null;
+    }
+    val holder = branch.getWorktreeRootHoldingBranch();
+    if (holder == null || holder.equals(snapshot.getRootDirectoryPath())) {
+      return null;
+    }
+    return holder;
   }
 }

--- a/frontend/base/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/base/src/main/resources/GitMacheteBundle.properties
@@ -20,6 +20,7 @@
 action.GitMachete.description.disabled.undefined.machete-branch={0} disabled for {1} branch since it''s not managed by Git Machete
 action.GitMachete.description.disabled.branch-is-root={0} disabled because the given machete branch is a root
 action.GitMachete.description.disabled.another-actions-ongoing=Action disabled because of the ongoing {0}
+action.GitMachete.description.disabled.branch-held-by-other-worktree=Branch ''{0}'' is already checked out in worktree {1}
 action.GitMachete.get-git-config.task-title=Getting git config value\u2026
 action.GitMachete.set-git-config.task-title=Setting git config value\u2026
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2301

## Chain of upstream PRs & tree of downstream PRs as of 2026-06-01

* PR #2301:
  `develop` ← `improve/infer-worktree-label`

  * **PR #2297 (THIS ONE)**:
    `improve/infer-worktree-label` ← `improve/no-checkout-when-in-other-wt`

      * PR #2303:
        `improve/no-checkout-when-in-other-wt` ← `improve/wt-label-by-branch`

        * PR #2299:
          `improve/wt-label-by-branch` ← `feature/worktree-next-to-branch`

<!-- end git-machete generated -->

Git refuses any operation that moves HEAD to (or rewrites the ref of) a branch
already checked out in another worktree. Instead of letting the user discover
this through a side-effecting failure, surface a worktree map on every
branch snapshot and disable the affected actions up-front with the holding
worktree's absolute path in the tooltip:
* Checkout
* Squash (when run on a non-current branch it first switches HEAD to it)
* Rebase Onto Parent
* Reset to Remote (rewrites the local branch ref via fetch refspec)