### PR TITLE
Render `[<worktree>]` label next to each branch held by a worktree

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -5,7 +5,8 @@
 - Dropped: support for IntelliJ 2025.2 and 2025.3.
   Note that the versions of this plugin published so far will remain available for download in IntelliJ 2025.2 - 2025.3 indefinitely.
   The change in the range of supported IntelliJ versions will only affect the new plugin releases, starting from this one.
-- Changed: when listing commits, all commits between the parent branch and the branch tip are now listed (rather than just between the fork point and the branch tip), with the fork point commit annotated `-> fork point`; this makes it easier to spot commits that side-effecting commands (rebase, squash, etc.) will skip due to a non-trivial fork point (e.g. fork point override, or fork point landing on parent's remote counterpart)
+- Added: each branch checked out in a worktree now renders next to its name with a green `[<worktree>]` label whenever the repository has at least one linked worktree (suggested by @mikechristiansenvae)
+- Changed: when listing commits, all commits between the parent branch and the branch tip are now listed (rather than just between the fork point and the branch tip), with the fork point commit annotated `-> fork point`
 - Fixed: spurious yellow edge no longer appears in `status` when the parent branch is merely behind its remote counterpart and the child branch was forked from the remote tip
 - Fixed: "Show in Git Log" action jumping to a commit in the wrong repository in multi-root projects
 - Fixed: stale "no need to fetch" cache hits across repositories sharing the same directory name in multi-root projects

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/cell/BranchOrCommitCellRendererComponent.java
@@ -168,6 +168,17 @@ public final class BranchOrCommitCellRendererComponent extends SimpleColoredRend
         append(CELL_TEXT_FRAGMENTS_SPACING + customAnnotation, GRAY_ATTRIBUTES);
       }
 
+      // Slot the worktree label between annotation and the sync-to-remote suffix, mirroring the
+      // `git machete status` ordering. The map is empty unless at least one linked worktree exists;
+      // when it fires, every branch held by some worktree gets a label (see the API docstring).
+      String worktreeLabel = gitMacheteRepositorySnapshot != null
+          ? gitMacheteRepositorySnapshot.getWorktreeLabelByLocalBranchName().get(branch.getName()).getOrNull()
+          : null;
+      if (worktreeLabel != null) {
+        val worktreeAttributes = new SimpleTextAttributes(STYLE_PLAIN, Colors.GREEN);
+        append(" [" + worktreeLabel + "]", worktreeAttributes);
+      }
+
       String statusHookOutput = branch.getStatusHookOutput();
       if (statusHookOutput != null) {
         append(CELL_TEXT_FRAGMENTS_SPACING + statusHookOutput, GRAY_ATTRIBUTES);


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2303

## Chain of upstream PRs as of 2026-06-01

* PR #2301:
  `develop` ← `improve/infer-worktree-label`

  * PR #2297:
    `improve/infer-worktree-label` ← `improve/no-checkout-when-in-other-wt`

    * PR #2303:
      `improve/no-checkout-when-in-other-wt` ← `improve/wt-label-by-branch`

      * **PR #2299 (THIS ONE)**:
        `improve/wt-label-by-branch` ← `feature/worktree-next-to-branch`

<!-- end git-machete generated -->

Mirrors the equivalent feature in `git machete status`: whenever the
repository has at least one linked worktree, every branch checked out
in any worktree picks up a green `[<label>]` annotation slotted between
the custom annotation and the sync-to-remote suffix. Labels are
component-wise derived:

- `<this worktree>` for branches held by the worktree the snapshot was
  built against,
- `<main worktree>` for branches in the main worktree when the snapshot
  is taken from a linked one,
- otherwise the holding linked worktree's path with the longest common
  path prefix of all linked-worktree paths stripped, so typical layouts
  like `~/wts/foo` / `~/wts/bar` collapse to `foo` / `bar`. The main
  worktree is deliberately excluded from the prefix computation so that
  it can't artificially lengthen every linked label when main and the
  linked roots live in disjoint subtrees.

Labels are computed once during snapshot creation (off-EDT) from the
canonicalized worktree-root map and exposed via
`IGitMacheteRepositorySnapshot#getWorktreeLabelByLocalBranchName()`,
keeping the renderer call a plain `Map#get`. A dedicated
`setup-with-worktrees.sh` fixture adds linked worktrees post-script in
Java (so the absolute paths baked into `.git/worktrees/<wt>/gitdir`
match the per-test temp dir), with `RegenerateCliOutputs` dispatching
to the same `applyPostScriptSetup` helper so the CLI sees the same
fixture shape and the integration test's CLI-comparison covers the new
label.