### PR TITLE
Surface per-branch worktree holder on the model

### DIFF
--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
@@ -14,7 +14,13 @@ import com.virtuslab.branchlayout.api.BranchLayout;
  * Each {@code get...} method is guaranteed to return the same value each time it's called on a given object.
  */
 public interface IGitMacheteRepositorySnapshot {
-  Path getMainGitDirectoryPath();
+  /**
+   * @return the root directory of the worktree this snapshot was built against
+   *         (the directory containing the per-worktree gitlink {@code .git}).
+   *         Canonicalized at snapshot creation time, so a plain {@link Path#equals} against another canonical path
+   *         is enough to ask "is this snapshot scoped to that worktree?".
+   */
+  Path getRootDirectoryPath();
 
   BranchLayout getBranchLayout();
 

--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IManagedBranchSnapshot.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IManagedBranchSnapshot.java
@@ -1,5 +1,7 @@
 package com.virtuslab.gitmachete.backend.api;
 
+import java.nio.file.Path;
+
 import io.vavr.collection.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.EnsuresQualifierIf;
@@ -46,4 +48,14 @@ public interface IManagedBranchSnapshot extends ILocalBranchReference {
 
   @Nullable
   String getStatusHookOutput();
+
+  /**
+   * @return the root directory of the worktree currently holding this branch checked out, or {@code null}
+   *         if no worktree holds it. This may be the worktree against which the enclosing
+   *         {@link IGitMacheteRepositorySnapshot} was built (in which case the branch is the snapshot's
+   *         current branch); use {@link IGitMacheteRepositorySnapshot#getRootDirectoryPath()} to tell
+   *         "our" worktree apart from "another" one.
+   */
+  @Nullable
+  Path getWorktreeRootHoldingBranch();
 }

--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/NullGitMacheteRepositorySnapshot.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/NullGitMacheteRepositorySnapshot.java
@@ -20,7 +20,7 @@ public final class NullGitMacheteRepositorySnapshot implements IGitMacheteReposi
   }
 
   @Override
-  public Path getMainGitDirectoryPath() {
+  public Path getRootDirectoryPath() {
     return Path.of("");
   }
 

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/BaseManagedBranchSnapshot.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/BaseManagedBranchSnapshot.java
@@ -1,5 +1,7 @@
 package com.virtuslab.gitmachete.backend.impl;
 
+import java.nio.file.Path;
+
 import io.vavr.collection.List;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,6 +29,7 @@ public abstract class BaseManagedBranchSnapshot implements IManagedBranchSnapsho
   private final RelationToRemote relationToRemote;
   private final @Nullable String customAnnotation;
   private final @Nullable String statusHookOutput;
+  private final @Nullable Path worktreeRootHoldingBranch;
 
   @ToString.Include(name = "children") // avoid recursive `toString` calls on child branches
   private List<String> getChildNames() {
@@ -43,20 +46,5 @@ public abstract class BaseManagedBranchSnapshot implements IManagedBranchSnapsho
     for (val child : children) {
       child.setParent(this);
     }
-  }
-
-  @Override
-  public @Nullable IRemoteTrackingBranchReference getRemoteTrackingBranch() {
-    return remoteTrackingBranch;
-  }
-
-  @Override
-  public @Nullable String getCustomAnnotation() {
-    return customAnnotation;
-  }
-
-  @Override
-  public @Nullable String getStatusHookOutput() {
-    return statusHookOutput;
   }
 }

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
@@ -18,7 +18,7 @@ import com.virtuslab.gitmachete.backend.api.IRootManagedBranchSnapshot;
 public class GitMacheteRepositorySnapshot implements IGitMacheteRepositorySnapshot {
 
   @Getter
-  private final Path mainGitDirectoryPath;
+  private final Path rootDirectoryPath;
 
   @Getter
   private final List<IRootManagedBranchSnapshot> rootBranches;

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/NonRootManagedBranchSnapshot.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/NonRootManagedBranchSnapshot.java
@@ -1,5 +1,7 @@
 package com.virtuslab.gitmachete.backend.impl;
 
+import java.nio.file.Path;
+
 import io.vavr.collection.List;
 import lombok.CustomLog;
 import lombok.Getter;
@@ -44,11 +46,13 @@ public final class NonRootManagedBranchSnapshot extends BaseManagedBranchSnapsho
       RelationToRemote relationToRemote,
       @Nullable String customAnnotation,
       @Nullable String statusHookOutput,
+      @Nullable Path worktreeRootHoldingBranch,
       @Nullable IForkPointCommitOfManagedBranch forkPoint,
       List<ICommitOfManagedBranch> uniqueCommits,
       List<ICommitOfManagedBranch> commitsUntilParent,
       SyncToParentStatus syncToParentStatus) {
-    super(name, fullName, children, pointedCommit, remoteTrackingBranch, relationToRemote, customAnnotation, statusHookOutput);
+    super(name, fullName, children, pointedCommit, remoteTrackingBranch, relationToRemote, customAnnotation, statusHookOutput,
+        worktreeRootHoldingBranch);
 
     this.forkPoint = forkPoint;
     this.uniqueCommits = uniqueCommits;

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/RootManagedBranchSnapshot.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/RootManagedBranchSnapshot.java
@@ -1,5 +1,7 @@
 package com.virtuslab.gitmachete.backend.impl;
 
+import java.nio.file.Path;
+
 import io.vavr.collection.List;
 import lombok.CustomLog;
 import lombok.ToString;
@@ -22,8 +24,10 @@ public final class RootManagedBranchSnapshot extends BaseManagedBranchSnapshot i
       @Nullable IRemoteTrackingBranchReference remoteTrackingBranch,
       RelationToRemote relationToRemote,
       @Nullable String customAnnotation,
-      @Nullable String statusHookOutput) {
-    super(name, fullName, children, pointedCommit, remoteTrackingBranch, relationToRemote, customAnnotation, statusHookOutput);
+      @Nullable String statusHookOutput,
+      @Nullable Path worktreeRootHoldingBranch) {
+    super(name, fullName, children, pointedCommit, remoteTrackingBranch, relationToRemote, customAnnotation, statusHookOutput,
+        worktreeRootHoldingBranch);
 
     LOG.debug("Creating ${this}");
 

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
@@ -13,6 +13,7 @@ import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.collection.LinkedHashMap;
 import io.vavr.collection.List;
+import io.vavr.collection.Map;
 import io.vavr.collection.Seq;
 import io.vavr.control.Try;
 import lombok.CustomLog;
@@ -53,7 +54,8 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
   private final StatusBranchHookExecutor statusHookExecutor;
   private final List<String> remoteNames;
   private final java.util.Set<String> createdBranches = new java.util.HashSet<>();
-  private final Path mainGitDirectoryPath;
+  private final Path rootDirectoryPath;
+  private final Map<String, Path> worktreeRootByLocalBranchName;
 
   @UIThreadUnsafe
   public CreateGitMacheteRepositoryHelper(
@@ -63,7 +65,21 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
 
     this.statusHookExecutor = statusHookExecutor;
     this.remoteNames = gitCoreRepository.deriveAllRemoteNames();
-    this.mainGitDirectoryPath = gitCoreRepository.getMainGitDirectoryPath();
+    // Canonicalize both the snapshot's own worktree root and every holder path up front (off-EDT), so
+    // downstream consumers - in particular the action layer that compares "are we held in another worktree?"
+    // on the UI thread - can rely on a plain Path#equals check without doing filesystem I/O.
+    this.rootDirectoryPath = toRealPathOrSelf(gitCoreRepository.getRootDirectoryPath());
+    this.worktreeRootByLocalBranchName = gitCoreRepository.deriveWorktreeRootByLocalBranchName()
+        .mapValues(CreateGitMacheteRepositoryHelper::toRealPathOrSelf);
+  }
+
+  @UIThreadUnsafe
+  private static Path toRealPathOrSelf(Path path) {
+    try {
+      return path.toRealPath();
+    } catch (java.io.IOException e) {
+      return path;
+    }
   }
 
   @UIThreadUnsafe
@@ -103,7 +119,7 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
 
     val operationsBaseBranchName = deriveOngoingOperationsBaseBranchName(ongoingOperationType);
 
-    return new GitMacheteRepositorySnapshot(mainGitDirectoryPath, List.narrow(rootBranches), branchLayout,
+    return new GitMacheteRepositorySnapshot(rootDirectoryPath, List.narrow(rootBranches), branchLayout,
         currentBranchIfManaged, managedBranchByName, duplicatedBranchNames, skippedBranchNames,
         new IGitMacheteRepositorySnapshot.OngoingRepositoryOperation(ongoingOperationType, operationsBaseBranchName));
   }
@@ -182,9 +198,10 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
     val remoteTrackingBranch = getRemoteTrackingBranchForCoreLocalBranch(coreLocalBranch);
     val statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit);
 
+    val worktreeRootHoldingBranch = worktreeRootByLocalBranchName.get(branchName).getOrNull();
     val createdRootBranch = new RootManagedBranchSnapshot(branchName, branchFullName,
         childBranches.getCreatedBranches(), pointedCommit, remoteTrackingBranch, relationToRemote, customAnnotation,
-        statusHookOutput);
+        statusHookOutput, worktreeRootHoldingBranch);
     return CreatedAndDuplicatedAndSkippedBranches.of(List.of(createdRootBranch),
         childBranches.getDuplicatedBranchNames(), childBranches.getSkippedBranchNames());
   }
@@ -244,10 +261,11 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
     val statusHookOutput = statusHookExecutor.deriveHookOutputFor(branchName, pointedCommit);
     val commitsUntilParent = gitCoreRepository.deriveCommitRange(corePointedCommit, parentCoreLocalBranch.getPointedCommit());
 
+    val worktreeRootHoldingBranch = worktreeRootByLocalBranchName.get(branchName).getOrNull();
     val result = new NonRootManagedBranchSnapshot(branchName, branchFullName, childBranches.getCreatedBranches(),
-        pointedCommit, remoteTrackingBranch, relationToRemote, customAnnotation, statusHookOutput, forkPoint,
-        uniqueCommits.map(CommitOfManagedBranch::new), commitsUntilParent.map(CommitOfManagedBranch::new),
-        syncToParentStatus);
+        pointedCommit, remoteTrackingBranch, relationToRemote, customAnnotation, statusHookOutput,
+        worktreeRootHoldingBranch, forkPoint, uniqueCommits.map(CommitOfManagedBranch::new),
+        commitsUntilParent.map(CommitOfManagedBranch::new), syncToParentStatus);
     return CreatedAndDuplicatedAndSkippedBranches.of(List.of(result),
         childBranches.getDuplicatedBranchNames(), childBranches.getSkippedBranchNames());
   }

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTestSuite.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+import io.vavr.collection.HashMap;
 import io.vavr.collection.List;
 import lombok.SneakyThrows;
 import lombok.val;
@@ -30,6 +31,7 @@ public class BaseGitMacheteRepositoryUnitTestSuite {
     when(gitCoreRepository.deriveConfigValue("core", "hooksPath")).thenReturn(null);
     when(gitCoreRepository.getRootDirectoryPath()).thenReturn(Paths.get("void"));
     when(gitCoreRepository.getMainGitDirectoryPath()).thenReturn(Paths.get("void"));
+    when(gitCoreRepository.deriveWorktreeRootByLocalBranchName()).thenReturn(HashMap.empty());
 
     // cannot be mocked as it is final
     val statusBranchHookExecutor = new StatusBranchHookExecutor(gitCoreRepository);

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
@@ -92,7 +92,7 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
   }
 
   @Override
-  public Path getMainGitDirectoryPath() {
+  public Path getRootDirectoryPath() {
     return Path.of("dummy");
   }
 
@@ -227,6 +227,11 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
     public @Nullable IRemoteTrackingBranchReference getRemoteTrackingBranch() {
       return null;
     }
+
+    @Override
+    public @Nullable Path getWorktreeRootHoldingBranch() {
+      return null;
+    }
   }
 
   @Getter
@@ -279,6 +284,11 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
 
     @Override
     public @Nullable IRemoteTrackingBranchReference getRemoteTrackingBranch() {
+      return null;
+    }
+
+    @Override
+    public @Nullable Path getWorktreeRootHoldingBranch() {
       return null;
     }
   }

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/EnhancedGraphTable.java
@@ -313,13 +313,13 @@ public final class EnhancedGraphTable extends BaseEnhancedGraphTable
           unmanagedBranchNotification.expire();
         }
         val snapshot = gitMacheteRepositorySnapshot;
-        Path mainGitDirectory = GitVfsUtils.getMainGitDirectory(repository).toNioPath();
+        Path repositoryRoot = GitVfsUtils.getRootDirectoryPath(repository);
         // 1. As for now, only the snapshot of the repository selected in Git Machete panel is available
         // (not all snapshots of all repositories!).
         // 2. The unmanaged branch notification works on the same snapshot as the one selected in Git Machete panel.
         // Hence, we must assure that the current branch changed belongs to the same repository as the given snapshot.
         // TODO (#1542): Handling of all repositories (not only selected) is a subject to improvement.
-        if (snapshot != null && snapshot.getMainGitDirectoryPath().equals(mainGitDirectory)) {
+        if (snapshot != null && snapshot.getRootDirectoryPath().equals(repositoryRoot)) {
           val entry = snapshot.getBranchLayout().getEntryByName(repositoryCurrentBranchName);
           if (entry == null) {
             inferParentForUnmanagedBranchNotificationAndNotify(repositoryCurrentBranchName);

--- a/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreRepository.java
+++ b/gitCore/api/src/main/java/com/virtuslab/gitcore/api/IGitCoreRepository.java
@@ -3,6 +3,7 @@ package com.virtuslab.gitcore.api;
 import java.nio.file.Path;
 
 import io.vavr.collection.List;
+import io.vavr.collection.Map;
 import io.vavr.collection.Stream;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -75,4 +76,13 @@ public interface IGitCoreRepository {
 
   @UIThreadUnsafe
   GitCoreRepositoryState deriveRepositoryState();
+
+  /**
+   * @return a map from a local-branch short name (e.g. {@code "develop"}) to the absolute path of the worktree
+   *         root directory whose {@code HEAD} currently points at that branch. Includes the main worktree and
+   *         every linked worktree visible under the common git directory. Worktrees with a detached HEAD are
+   *         skipped.
+   */
+  @UIThreadUnsafe
+  Map<String, Path> deriveWorktreeRootByLocalBranchName() throws GitCoreException;
 }

--- a/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
+++ b/gitCore/jGit/src/main/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepository.java
@@ -13,8 +13,10 @@ import java.nio.file.Path;
 import io.vavr.CheckedFunction1;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
+import io.vavr.collection.HashMap;
 import io.vavr.collection.Iterator;
 import io.vavr.collection.List;
+import io.vavr.collection.Map;
 import io.vavr.collection.Stream;
 import io.vavr.control.Option;
 import io.vavr.control.Try;
@@ -657,5 +659,78 @@ public final class GitCoreRepository implements IGitCoreRepository {
     }
 
     return Stream.ofAll(walk).take(maxCommits).map(GitCoreCommit::new);
+  }
+
+  @Override
+  @UIThreadUnsafe
+  public Map<String, Path> deriveWorktreeRootByLocalBranchName() throws GitCoreException {
+    // We have to read .git/worktrees/<name>/{HEAD,gitdir} files directly here because, as of JGit 7.6, JGit exposes
+    // no API to enumerate (or otherwise interrogate) linked worktrees - the entire `git worktree {list,add,remove,
+    // move,prune,...}` family is unimplemented. Only *read* support for an already-known linked worktree was added
+    // in JGit 7.0 (Sep 2024) via the `commondir` pointer, which is what backs the single `jgitRepo` field above;
+    // but that lets us open a Repository given its per-worktree git dir, not discover those git dirs in the first
+    // place. We could, in principle, list `worktrees/<name>` and build a fresh JGit Repository per linked worktree
+    // just to call `getFullBranch()` on it, but that's strictly more work (a Repository is non-trivial to allocate)
+    // for the same two files we'd be reading anyway.
+    //
+    // Tracking issues for full JGit worktree support:
+    //   - https://bugs.eclipse.org/bugs/show_bug.cgi?id=477475 ("git 2.5 worktree support", open since 2015)
+    //   - https://github.com/eclipse-jgit/jgit/issues/264 ("Feature Request: Git Worktree Support for JGit and EGit")
+    // Until one of the management commands lands upstream, the manual layout walk below is the only option short
+    // of shelling out to `git worktree list --porcelain`.
+    //
+    // The main worktree's HEAD lives at `<common-git-dir>/HEAD`; each linked worktree owns its own per-worktree git
+    // directory under `<common-git-dir>/worktrees/<name>/`, with `HEAD` (same format as the main one) and `gitdir`
+    // (an absolute path to the gitlink file at the worktree's root). The worktree root is therefore the parent of
+    // the path stored in `gitdir`. We deliberately skip worktrees whose HEAD is detached - those cannot collide with
+    // a checkout of a particular branch elsewhere.
+    HashMap<String, Path> result = HashMap.empty();
+    try {
+      Path mainWorktreeRoot = mainGitDirectoryPath.getParent();
+      if (mainWorktreeRoot != null) {
+        String mainBranchName = readBranchShortNameFromHeadFile(mainGitDirectoryPath.resolve(Constants.HEAD));
+        if (mainBranchName != null) {
+          result = result.put(mainBranchName, mainWorktreeRoot);
+        }
+      }
+
+      Path worktreesDir = mainGitDirectoryPath.resolve("worktrees");
+      if (Files.isDirectory(worktreesDir)) {
+        try (val entries = Files.list(worktreesDir)) {
+          for (Path linkedWtGitDir : List.ofAll(entries).filter(Files::isDirectory)) {
+            Path gitdirPointer = linkedWtGitDir.resolve("gitdir");
+            Path headFile = linkedWtGitDir.resolve(Constants.HEAD);
+            if (!Files.isRegularFile(gitdirPointer) || !Files.isRegularFile(headFile)) {
+              continue;
+            }
+            String gitdirContent = Files.readString(gitdirPointer).trim();
+            if (gitdirContent.isEmpty()) {
+              continue;
+            }
+            Path linkedWtRoot = Path.of(gitdirContent).getParent();
+            if (linkedWtRoot == null) {
+              continue;
+            }
+            String linkedWtBranchName = readBranchShortNameFromHeadFile(headFile);
+            if (linkedWtBranchName != null) {
+              result = result.put(linkedWtBranchName, linkedWtRoot);
+            }
+          }
+        }
+      }
+    } catch (IOException e) {
+      throw new GitCoreException("Unable to enumerate worktrees under ${mainGitDirectoryPath}", e);
+    }
+    return result;
+  }
+
+  @UIThreadUnsafe
+  private static @Nullable String readBranchShortNameFromHeadFile(Path headFile) throws IOException {
+    if (!Files.isRegularFile(headFile)) {
+      return null;
+    }
+    String content = Files.readString(headFile).trim();
+    String prefix = "ref: " + Constants.R_HEADS;
+    return content.startsWith(prefix) ? content.substring(prefix.length()).trim() : null;
   }
 }

--- a/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryWorktreeIntegrationTest.java
+++ b/gitCore/jGit/src/test/java/com/virtuslab/gitcore/impl/jgit/GitCoreRepositoryWorktreeIntegrationTest.java
@@ -191,6 +191,125 @@ public class GitCoreRepositoryWorktreeIntegrationTest {
 
   @Test
   @SneakyThrows
+  public void deriveWorktreeRootByLocalBranchName_excludesDetachedHeads() {
+    // Fresh SETUP_WITH_SINGLE_REMOTE leaves both the main repo and the linked worktree on
+    // detached HEADs (see TestGitRepository#addWorktreeAndDetachMain). No branch is held by any
+    // worktree, so the map must be empty.
+    val worktreeRootByBranch = worktreeScoped().deriveWorktreeRootByLocalBranchName();
+    assertTrue(worktreeRootByBranch.isEmpty(),
+        "Both worktrees are detached; map must be empty but was: ${worktreeRootByBranch}");
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  @Test
+  @SneakyThrows
+  public void deriveWorktreeRootByLocalBranchName_mapsBranchToHoldingWorktreeRoot() {
+    // Park the linked worktree on `drop-constraint`. Main stays detached, so only one entry
+    // should appear.
+    runProcessAndReturnStdout(repo.rootDirectoryPath, /* timeoutSeconds */ 30, "git", "checkout", "drop-constraint");
+
+    // Map must be identical regardless of whether we look it up from the worktree-scoped or the
+    // main-scoped repository (both share the same common git dir).
+    for (val scoped : new GitCoreRepository[]{worktreeScoped(), mainScoped()}) {
+      val worktreeRootByBranch = scoped.deriveWorktreeRootByLocalBranchName();
+      assertEquals(1, worktreeRootByBranch.size(), "Exactly one worktree is on a branch; got: ${worktreeRootByBranch}");
+      val holder = worktreeRootByBranch.get("drop-constraint").getOrNull();
+      assertNotNull(holder, "`drop-constraint` must map to the linked worktree's root");
+      assertEquals(repo.rootDirectoryPath.toRealPath(), holder.toRealPath());
+    }
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  @Test
+  @SneakyThrows
+  public void deriveWorktreeRootByLocalBranchName_includesEveryLinkedWorktreeOnABranch() {
+    // Park the fixture's existing linked worktree on `drop-constraint`, then add a second linked
+    // worktree pointed at `hotfix/add-trigger`. Both branches should show up in the map, each
+    // mapped to the worktree that holds it.
+    runProcessAndReturnStdout(repo.rootDirectoryPath, /* timeoutSeconds */ 30, "git", "checkout", "drop-constraint");
+    val mainRepo = repo.mainGitDirectoryPath.getParent();
+    val secondWorktreeRoot = repo.parentDirectoryPath.resolve("machete-sandbox-worktree-2");
+    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 30,
+        "git", "worktree", "add", secondWorktreeRoot.toString(), "hotfix/add-trigger");
+
+    val worktreeRootByBranch = worktreeScoped().deriveWorktreeRootByLocalBranchName();
+    assertEquals(2, worktreeRootByBranch.size(),
+        "Both linked worktrees are on branches; expected exactly two entries, got: ${worktreeRootByBranch}");
+
+    val dropConstraintHolder = worktreeRootByBranch.get("drop-constraint").getOrNull();
+    assertNotNull(dropConstraintHolder, "`drop-constraint` must map to its linked worktree");
+    assertEquals(repo.rootDirectoryPath.toRealPath(), dropConstraintHolder.toRealPath());
+
+    val hotfixHolder = worktreeRootByBranch.get("hotfix/add-trigger").getOrNull();
+    assertNotNull(hotfixHolder, "`hotfix/add-trigger` must map to the second linked worktree");
+    assertEquals(secondWorktreeRoot.toRealPath(), hotfixHolder.toRealPath());
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  @Test
+  @SneakyThrows
+  public void deriveWorktreeRootByLocalBranchName_reportsBranchAsHeldEvenAfterManualMoveWithoutRepair() {
+    // A worktree root moved with plain `mv` (not `git worktree move`) leaves
+    // `.git/worktrees/<wt>/gitdir` pointing at the OLD checkout dir until the user runs
+    // `git worktree repair` (https://git-scm.com/docs/git-worktree#_repair). Git itself still
+    // considers the branch held by that worktree and refuses a second checkout of it elsewhere
+    // until repair (or `prune`) is run, so we deliberately surface the stale entry as well -
+    // disabling the checkout action with a slightly-misleading tooltip is preferable to enabling
+    // it and letting `git checkout` fail.
+    runProcessAndReturnStdout(repo.rootDirectoryPath, /* timeoutSeconds */ 30, "git", "checkout", "drop-constraint");
+    val movedRoot = repo.parentDirectoryPath.resolve("machete-sandbox-worktree-moved");
+    Files.move(repo.rootDirectoryPath, movedRoot);
+
+    val worktreeRootByBranch = mainScoped().deriveWorktreeRootByLocalBranchName();
+    val holder = worktreeRootByBranch.get("drop-constraint").getOrNull();
+    assertNotNull(holder, "`drop-constraint` must remain reported as held while the stale worktree is registered");
+
+    // The returned path is the now-stale OLD checkout dir, mirroring `gitdir`'s contents
+    // verbatim. The IDE's "branch already checked out in worktree X" tooltip will therefore name
+    // a directory that no longer exists - this is the cost of avoiding a per-getter filesystem
+    // probe and matches what `git worktree list` shows before `git worktree prune`. We
+    // canonicalize the *parent* (which still exists) and re-resolve the gone child to compare
+    // without invoking `toRealPath` on a missing path.
+    val staleExpected = repo.parentDirectoryPath.toRealPath().resolve("machete-sandbox-worktree");
+    assertEquals(staleExpected, holder, "Stale `gitdir` content must be surfaced verbatim");
+
+    // After `git worktree repair` is run from the new location, `.git/worktrees/<wt>/gitdir` is
+    // rewritten to the new path; our reader must pick that up on the very next call (we hold no
+    // cache).
+    runProcessAndReturnStdout(movedRoot, /* timeoutSeconds */ 10, "git", "worktree", "repair");
+    val afterRepair = mainScoped().deriveWorktreeRootByLocalBranchName().get("drop-constraint").getOrNull();
+    assertNotNull(afterRepair, "`drop-constraint` must still be reported as held after repair");
+    assertEquals(movedRoot.toRealPath(), afterRepair.toRealPath(),
+        "`git worktree repair` must rewrite `gitdir`; our reader must pick that up on the next call");
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  @Test
+  @SneakyThrows
+  public void deriveWorktreeRootByLocalBranchName_onPlainSingleRepo_reflectsCurrentBranch() {
+    // Tear down the SETUP_WITH_SINGLE_REMOTE fixture and set up a non-worktree one for this case.
+    cleanUpDir(repo.parentDirectoryPath);
+    repo = new TestGitRepository(SETUP_FOR_NO_REMOTES);
+
+    val gitCoreRepository = new GitCoreRepository(repo.rootDirectoryPath);
+
+    // The SETUP_FOR_NO_REMOTES script leaves the repo checked out on `develop`.
+    val worktreeRootByBranch = gitCoreRepository.deriveWorktreeRootByLocalBranchName();
+    assertEquals(1, worktreeRootByBranch.size(),
+        "Plain single-worktree repo on `develop` must yield exactly one entry; got: ${worktreeRootByBranch}");
+    val holder = worktreeRootByBranch.get("develop").getOrNull();
+    assertNotNull(holder, "`develop` must map to the repo's root");
+    assertEquals(repo.rootDirectoryPath.toRealPath(), holder.toRealPath());
+
+    cleanUpDir(repo.parentDirectoryPath);
+  }
+
+  @Test
+  @SneakyThrows
   public void jgitFindGitDirFromLinkedWorktreeRoot_followsTheGitlinkFile() {
     // Pointing JGit's FileRepositoryBuilder at the linked worktree's root must yield the
     // per-worktree git dir (`<main>/.git/worktrees/<wt>`), not the main `.git` dir, by


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-06-01

* **PR #2301 (THIS ONE)**:
  `develop` ← `improve/infer-worktree-label`

    * PR #2297:
      `improve/infer-worktree-label` ← `improve/no-checkout-when-in-other-wt`

      * PR #2303:
        `improve/no-checkout-when-in-other-wt` ← `improve/wt-label-by-branch`

        * PR #2299:
          `improve/wt-label-by-branch` ← `feature/worktree-next-to-branch`

<!-- end git-machete generated -->

Extends the gitCore + backend snapshot model so callers can ask, for
each managed branch, which worktree currently has it checked out:

- `IGitCoreRepository#deriveWorktreeRootByLocalBranchName()` enumerates  the main worktree and every linked one under `<common-git-dir>/worktrees/<name>/`, skipping detached HEADs, and maps each branch name  to the absolute root of the holding worktree.
- `IManagedBranchSnapshot#getWorktreeRootHoldingBranch()` exposes that  per managed branch (nullable, returns the holder regardless of whether  it's "this" worktree or another one - so consumers that need the  distinction can make it themselves).
- `IGitMacheteRepositorySnapshot#getRootDirectoryPath()` exposes the  worktree root the snapshot was built against, so the "is this branch held *elsewhere*?" check is a plain `Path#equals` against the holder.
- `CreateGitMacheteRepositoryHelper` canonicalizes both the snapshot's  own root and every holder path via `toRealPath` up front (off-EDT),  so downstream comparisons on the UI thread never have to do filesystem  I/O.

No behavioral change yet; this is purely the model groundwork that the follow-up "block checkout-like actions when target branch is held elsewhere" change builds on. Coverage is added in `GitCoreRepositoryWorktreeIntegrationTest` for both the linked-worktree mapping and the detached-HEAD skipping.