### PR TITLE
Surface worktree label per managed branch on the model

### DIFF
--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/IGitMacheteRepositorySnapshot.java
@@ -3,6 +3,7 @@ package com.virtuslab.gitmachete.backend.api;
 import java.nio.file.Path;
 
 import io.vavr.collection.List;
+import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import lombok.Data;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -38,6 +39,31 @@ public interface IGitMacheteRepositorySnapshot {
   Set<String> getDuplicatedBranchNames();
 
   Set<String> getSkippedBranchNames();
+
+  /**
+   * Per-branch label naming the worktree currently holding that branch checked out, suitable for
+   * rendering next to the branch name in status. The result is empty unless the labeling feature
+   * fires, which requires at least one <i>linked</i> worktree to exist; in a plain single-worktree
+   * repo every branch is unambiguously in (or absent from) the only worktree, so a label would be
+   * pure clutter.
+   *
+   * <p>When the feature does fire, the value for a labeled branch is one of:
+   * <ul>
+   *   <li>{@code "<this worktree>"} - the branch lives in the worktree this snapshot was built
+   *       against, regardless of whether that's the main or a linked one;</li>
+   *   <li>{@code "<main worktree>"} - the branch lives in the main worktree and the snapshot is
+   *       taken from a linked one;</li>
+   *   <li>otherwise - the holding linked worktree's path with the longest common path prefix of
+   *       <em>all linked-worktree paths</em> stripped (typical layouts like {@code ~/wts/foo} and
+   *       {@code ~/wts/bar} collapse to {@code foo} and {@code bar}). The main worktree is
+   *       deliberately excluded from the prefix computation so that it can't artificially lengthen
+   *       every linked label - e.g. when main lives under {@code ~/projects} but linked worktrees
+   *       sit under {@code /tmp}, the only shared component would be {@code /}.</li>
+   * </ul>
+   *
+   * <p>Branches not currently checked out in any worktree are simply absent from the map.
+   */
+  Map<String, String> getWorktreeLabelByLocalBranchName();
 
   @Data
   // So that Interning Checker doesn't complain about enum comparison (by `equals` and not by `==`) in Lombok-generated `equals`

--- a/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/NullGitMacheteRepositorySnapshot.java
+++ b/backend/api/src/main/java/com/virtuslab/gitmachete/backend/api/NullGitMacheteRepositorySnapshot.java
@@ -2,7 +2,9 @@ package com.virtuslab.gitmachete.backend.api;
 
 import java.nio.file.Path;
 
+import io.vavr.collection.HashMap;
 import io.vavr.collection.List;
+import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import io.vavr.collection.TreeSet;
 import lombok.Getter;
@@ -57,6 +59,11 @@ public final class NullGitMacheteRepositorySnapshot implements IGitMacheteReposi
   @Override
   public Set<String> getSkippedBranchNames() {
     return TreeSet.empty();
+  }
+
+  @Override
+  public Map<String, String> getWorktreeLabelByLocalBranchName() {
+    return HashMap.empty();
   }
 
   @Getter

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/GitMacheteRepositorySnapshot.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 
 import io.vavr.collection.LinkedHashMap;
 import io.vavr.collection.List;
+import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,9 @@ public class GitMacheteRepositorySnapshot implements IGitMacheteRepositorySnapsh
 
   @Getter
   private final Set<String> skippedBranchNames;
+
+  @Getter
+  private final Map<String, String> worktreeLabelByLocalBranchName;
 
   @Getter
   private final OngoingRepositoryOperation ongoingRepositoryOperation;

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/CreateGitMacheteRepositoryHelper.java
@@ -56,6 +56,7 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
   private final java.util.Set<String> createdBranches = new java.util.HashSet<>();
   private final Path rootDirectoryPath;
   private final Map<String, Path> worktreeRootByLocalBranchName;
+  private final Map<String, String> worktreeLabelByLocalBranchName;
 
   @UIThreadUnsafe
   public CreateGitMacheteRepositoryHelper(
@@ -71,6 +72,13 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
     this.rootDirectoryPath = toRealPathOrSelf(gitCoreRepository.getRootDirectoryPath());
     this.worktreeRootByLocalBranchName = gitCoreRepository.deriveWorktreeRootByLocalBranchName()
         .mapValues(CreateGitMacheteRepositoryHelper::toRealPathOrSelf);
+    // The main worktree's root is the parent of the common git directory (we make sure to
+    // canonicalize that too, so the comparison inside the computer can rely on plain Path#equals).
+    val mainGitDirectoryPath = gitCoreRepository.getMainGitDirectoryPath();
+    val mainGitDirParent = mainGitDirectoryPath.getParent();
+    val mainWorktreeRoot = mainGitDirParent != null ? toRealPathOrSelf(mainGitDirParent) : mainGitDirectoryPath;
+    this.worktreeLabelByLocalBranchName = WorktreeLabelComputer.compute(
+        worktreeRootByLocalBranchName, rootDirectoryPath, mainWorktreeRoot);
   }
 
   @UIThreadUnsafe
@@ -121,6 +129,7 @@ public class CreateGitMacheteRepositoryHelper extends Helper {
 
     return new GitMacheteRepositorySnapshot(rootDirectoryPath, List.narrow(rootBranches), branchLayout,
         currentBranchIfManaged, managedBranchByName, duplicatedBranchNames, skippedBranchNames,
+        worktreeLabelByLocalBranchName,
         new IGitMacheteRepositorySnapshot.OngoingRepositoryOperation(ongoingOperationType, operationsBaseBranchName));
   }
 

--- a/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/WorktreeLabelComputer.java
+++ b/backend/impl/src/main/java/com/virtuslab/gitmachete/backend/impl/helper/WorktreeLabelComputer.java
@@ -1,0 +1,143 @@
+package com.virtuslab.gitmachete.backend.impl.helper;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import io.vavr.collection.HashMap;
+import io.vavr.collection.Map;
+import io.vavr.collection.SortedSet;
+import lombok.val;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import com.virtuslab.qual.guieffect.UIThreadUnsafe;
+
+/**
+ * Computes the per-branch worktree labels surfaced as {@link com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot#getWorktreeLabelByLocalBranchName()}.
+ *
+ * <p>The shape of the result and the labeling rules are documented on that interface method.
+ */
+public final class WorktreeLabelComputer {
+  private static final String THIS_WORKTREE_LABEL = "<this worktree>";
+  private static final String MAIN_WORKTREE_LABEL = "<main worktree>";
+
+  private WorktreeLabelComputer() {}
+
+  /**
+   * @param worktreeRootByLocalBranchName per-branch worktree root path of the worktree currently
+   *        holding that branch; branches not held by any worktree must be absent
+   * @param currentWorktreeRoot           the root path of the worktree this snapshot was built against
+   * @param mainWorktreeRoot              the root path of the main worktree (= parent of the common
+   *                                      git dir); the only worktree if no linked ones exist
+   * @return per-branch label, or an empty map if the feature does not fire
+   */
+  @UIThreadUnsafe
+  public static Map<String, String> compute(
+      Map<String, Path> worktreeRootByLocalBranchName,
+      Path currentWorktreeRoot,
+      Path mainWorktreeRoot) {
+
+    // Feature gating: at least one *linked* worktree (i.e. a holder distinct from the main worktree)
+    // must exist among the labeled branches. In a plain single-worktree repo the only possible
+    // holder is the main worktree, and tagging every branch with `<this worktree>` would just be
+    // pure clutter.
+    val linkedPaths = worktreeRootByLocalBranchName.values()
+        .filter(p -> !p.equals(mainWorktreeRoot))
+        .toSortedSet(Path::compareTo);
+    if (linkedPaths.isEmpty()) {
+      return HashMap.empty();
+    }
+
+    val labelByLinkedPath = stripLongestCommonPathPrefix(linkedPaths);
+
+    Map<String, String> result = HashMap.empty();
+    for (val tuple : worktreeRootByLocalBranchName) {
+      val branch = tuple._1;
+      val path = tuple._2;
+      String label;
+      if (path.equals(currentWorktreeRoot)) {
+        label = THIS_WORKTREE_LABEL;
+      } else if (path.equals(mainWorktreeRoot)) {
+        label = MAIN_WORKTREE_LABEL;
+      } else {
+        label = labelByLinkedPath.get(path).getOrElse(path::toString);
+      }
+      result = result.put(branch, label);
+    }
+    return result;
+  }
+
+  /**
+   * Returns each input path with the longest leading path-<i>component</i> prefix shared by all
+   * inputs stripped. The stripping is always done component-wise (full path segments), never
+   * character-wise: {@code ["/a/b/foo", "/a/b/bar"]} collapses to {@code ["foo", "bar"]}, whereas
+   * {@code ["/a/proj-foo", "/a/proj-bar"]} collapses to {@code ["proj-foo", "proj-bar"]} (not
+   * {@code ["foo", "bar"]}) - the result always names a real directory entry.
+   *
+   * <p>Edge cases:
+   * <ul>
+   *   <li>a single input has no shared prefix to speak of; we return its basename so callers always
+   *       get a printable label rather than the empty string;</li>
+   *   <li>if one input is a prefix of another (e.g. {@code ["/a/b", "/a/b/c"]}), we keep at least
+   *       one trailing component for every input - so the shorter one doesn't collapse to the empty
+   *       string;</li>
+   *   <li>if the inputs share nothing beyond the filesystem root, we keep that root in each result
+   *       so the labels remain recognizable absolute paths rather than misleadingly-relative-looking
+   *       strings.</li>
+   * </ul>
+   *
+   * <p>Inputs with mismatching filesystem roots are returned as-is (each mapped to its own full
+   * path string), since there's no meaningful prefix to strip across them.
+   */
+  @UIThreadUnsafe
+  public static Map<Path, String> stripLongestCommonPathPrefix(SortedSet<Path> paths) {
+    if (paths.isEmpty()) {
+      return HashMap.empty();
+    }
+    if (paths.size() == 1) {
+      val only = paths.head();
+      val name = only.getFileName();
+      return HashMap.of(only, name != null ? name.toString() : only.toString());
+    }
+
+    val first = paths.head();
+    val firstRoot = first.getRoot();
+    val allSameRoot = paths.forAll(p -> Objects.equals(p.getRoot(), firstRoot));
+    if (!allSameRoot) {
+      Map<Path, String> result = HashMap.empty();
+      for (val p : paths) {
+        result = result.put(p, p.toString());
+      }
+      return result;
+    }
+
+    val minNameCount = paths.map(Path::getNameCount).min().get();
+    int uncappedCommonLen = 0;
+    for (int i = 0; i < minNameCount; i++) {
+      val firstName = first.getName(i);
+      final int idx = i;
+      val allMatch = paths.forAll(p -> p.getName(idx).equals(firstName));
+      if (allMatch) {
+        uncappedCommonLen = i + 1;
+      } else {
+        break;
+      }
+    }
+
+    // Cap so the shortest doesn't collapse to "" (`["/a/b", "/a/b/c"]` -> `["b", "b/c"]`, not `["", "c"]`).
+    int commonLen = Math.min(uncappedCommonLen, minNameCount - 1);
+
+    // Keep the filesystem root on each label only when nothing beyond it is shared - otherwise the
+    // stripped tails would look misleadingly relative (`x/foo` vs `/x/foo`). When the cap above
+    // drove commonLen down to 0 (e.g. `["/a", "/a/b"]` capped from 1 to 0), we explicitly do NOT
+    // re-attach the root: `/a` really is a shared prefix component and ought to be stripped.
+    @Nullable Path resultRoot = uncappedCommonLen == 0 ? firstRoot : null;
+
+    Map<Path, String> result = HashMap.empty();
+    for (val p : paths) {
+      val tail = p.subpath(commonLen, p.getNameCount());
+      val s = resultRoot != null ? resultRoot.toString() + tail.toString() : tail.toString();
+      result = result.put(p, s);
+    }
+    return result;
+  }
+}

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/RegenerateCliOutputs.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/RegenerateCliOutputs.java
@@ -15,6 +15,8 @@ import io.vavr.collection.List;
 import io.vavr.collection.Stream;
 import lombok.SneakyThrows;
 
+import com.virtuslab.gitmachete.testcommon.TestGitRepository;
+
 public class RegenerateCliOutputs {
   @SneakyThrows
   public static void main(String[] args) {
@@ -27,17 +29,20 @@ public class RegenerateCliOutputs {
       System.out.println("Regenerating the output for ${scriptName}...");
 
       Path parentDir = Files.createTempDirectory("machete-tests-");
-      Path repositoryMainDir = parentDir.resolve("machete-sandbox");
 
       copyScriptFromResources("common.sh", parentDir);
       copyScriptFromResources(scriptName, parentDir);
       prepareRepoFromScript(scriptName, parentDir);
-      String statusOutput = runGitMacheteCommandAndReturnStdout(/* workingDirectory */ repositoryMainDir,
+      // Mirror the same post-script setup the tests apply, so the CLI sees the same fixture
+      // shape as our snapshot (e.g. linked worktrees added in Java rather than in the script).
+      TestGitRepository.applyPostScriptSetup(scriptName, parentDir);
+      Path repositoryDir = TestGitRepository.cliWorkingDirectory(scriptName, parentDir);
+      String statusOutput = runGitMacheteCommandAndReturnStdout(/* workingDirectory */ repositoryDir,
           /* timeoutSeconds */ 15, /* command */ "status", "--list-commits");
 
       saveFile(outputDirectory, "${scriptName}-status.txt", statusOutput);
 
-      String rawDiscoverOutput = runGitMacheteCommandAndReturnStdout(/* workingDirectory */ repositoryMainDir,
+      String rawDiscoverOutput = runGitMacheteCommandAndReturnStdout(/* workingDirectory */ repositoryDir,
           /* timeoutSeconds */ 15, /* command */ "discover", "--list-commits", "--yes");
 
       String discoverOutput = Stream.of(rawDiscoverOutput.split(System.lineSeparator()))

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java
@@ -171,6 +171,17 @@ public class StatusAndDiscoverIntegrationTestSuite extends BaseIntegrationTestSu
       sb.append("  ");
       sb.append(customAnnotation);
     }
+
+    // Slot the worktree label between annotation and the sync-to-remote suffix, mirroring
+    // `git machete status`. Absent unless at least one linked worktree exists for this repo.
+    val worktreeLabel = gitMacheteRepositorySnapshot.getWorktreeLabelByLocalBranchName()
+        .get(branch.getName()).getOrNull();
+    if (worktreeLabel != null) {
+      sb.append(" [");
+      sb.append(worktreeLabel);
+      sb.append("]");
+    }
+
     val relationToRemote = branch.getRelationToRemote();
 
     SyncToRemoteStatus syncToRemoteStatus = relationToRemote.getSyncToRemoteStatus();

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/WorktreeLabelComputerUnitTestSuite.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/WorktreeLabelComputerUnitTestSuite.java
@@ -1,0 +1,138 @@
+package com.virtuslab.gitmachete.backend.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import io.vavr.collection.HashMap;
+import io.vavr.collection.List;
+import io.vavr.collection.Map;
+import io.vavr.collection.SortedSet;
+import io.vavr.collection.TreeSet;
+import org.junit.jupiter.api.Test;
+
+import com.virtuslab.gitmachete.backend.impl.helper.WorktreeLabelComputer;
+
+public class WorktreeLabelComputerUnitTestSuite {
+
+  private static final Path MAIN = Path.of("/repos/proj/main");
+  private static final Path WT_A = Path.of("/repos/proj/wt-a");
+  private static final Path WT_B = Path.of("/repos/proj/wt-b");
+
+  @Test
+  public void emptyWhenNoLinkedWorktrees() {
+    // No linked worktree => feature does not fire, even if every branch is in the main worktree.
+    Map<String, Path> input = HashMap.<String, Path>empty().put("master", MAIN).put("develop", MAIN);
+
+    Map<String, String> result = WorktreeLabelComputer.compute(input, /* current */ MAIN, /* main */ MAIN);
+
+    assertEquals(HashMap.empty(), result);
+  }
+
+  @Test
+  public void labelsThisWorktreeMainWorktreeAndStrippedLinkedLabels() {
+    Map<String, Path> input = HashMap.<String, Path>empty()
+        .put("master", MAIN)
+        .put("feature-a", WT_A)
+        .put("feature-b", WT_B);
+
+    Map<String, String> result = WorktreeLabelComputer.compute(input, /* current */ MAIN, /* main */ MAIN);
+
+    assertEquals(
+        HashMap.<String, String>empty()
+            .put("master", "<this worktree>")
+            .put("feature-a", "wt-a")
+            .put("feature-b", "wt-b"),
+        result);
+  }
+
+  @Test
+  public void labelsMainWorktreeWhenCurrentIsLinked() {
+    Map<String, Path> input = HashMap.<String, Path>empty()
+        .put("master", MAIN)
+        .put("feature-a", WT_A)
+        .put("feature-b", WT_B);
+
+    // We are now standing in `wt-a` (a linked worktree).
+    Map<String, String> result = WorktreeLabelComputer.compute(input, /* current */ WT_A, /* main */ MAIN);
+
+    assertEquals(
+        HashMap.<String, String>empty()
+            .put("master", "<main worktree>")
+            .put("feature-a", "<this worktree>")
+            .put("feature-b", "wt-b"),
+        result);
+  }
+
+  @Test
+  public void mainWorktreeDoesNotInflateLinkedPrefix() {
+    // Linked worktrees live under `/tmp/wts`; main lives under `/home/user`. The main worktree must
+    // be excluded from the prefix computation, otherwise the only shared component across {main,
+    // linked-A, linked-B} would be `/` and the linked labels would degrade to full absolute paths.
+    Path tmpA = Path.of("/tmp/wts/foo");
+    Path tmpB = Path.of("/tmp/wts/bar");
+    Path home = Path.of("/home/user/proj");
+    Map<String, Path> input = HashMap.<String, Path>empty()
+        .put("master", home)
+        .put("feature-a", tmpA)
+        .put("feature-b", tmpB);
+
+    Map<String, String> result = WorktreeLabelComputer.compute(input, /* current */ home, /* main */ home);
+
+    assertEquals(
+        HashMap.<String, String>empty()
+            .put("master", "<this worktree>")
+            .put("feature-a", "foo")
+            .put("feature-b", "bar"),
+        result);
+  }
+
+  @Test
+  public void stripLongestCommonPathPrefix_collapsesPerComponent() {
+    // Component-wise stripping: `proj-foo` and `proj-bar` share the *parent* component but not the
+    // string prefix `proj-`, so the result is the basenames in full - never the character prefix.
+    Path foo = Path.of("/a/proj-foo");
+    Path bar = Path.of("/a/proj-bar");
+
+    Map<Path, String> result = WorktreeLabelComputer.stripLongestCommonPathPrefix(sortedPaths(foo, bar));
+
+    assertEquals(HashMap.<Path, String>empty().put(foo, "proj-foo").put(bar, "proj-bar"), result);
+  }
+
+  @Test
+  public void stripLongestCommonPathPrefix_keepsTrailingComponentWhenOneIsPrefixOfOther() {
+    // `/a/b` is a prefix of `/a/b/c`; without the cap the shorter path would collapse to "".
+    Path shorter = Path.of("/a/b");
+    Path longer = Path.of("/a/b/c");
+
+    Map<Path, String> result = WorktreeLabelComputer.stripLongestCommonPathPrefix(sortedPaths(shorter, longer));
+
+    assertEquals(HashMap.<Path, String>empty().put(shorter, "b").put(longer, "b/c"), result);
+  }
+
+  @Test
+  public void stripLongestCommonPathPrefix_keepsFilesystemRootWhenItIsTheOnlyShared() {
+    // When the only shared component is `/`, we keep it in each result so the labels still look
+    // like absolute paths instead of misleadingly-relative-looking strings.
+    Path x = Path.of("/x/foo");
+    Path y = Path.of("/y/bar");
+
+    Map<Path, String> result = WorktreeLabelComputer.stripLongestCommonPathPrefix(sortedPaths(x, y));
+
+    assertEquals(HashMap.<Path, String>empty().put(x, "/x/foo").put(y, "/y/bar"), result);
+  }
+
+  @Test
+  public void stripLongestCommonPathPrefix_singleInputReturnsBasename() {
+    Path only = Path.of("/a/b/c");
+
+    Map<Path, String> result = WorktreeLabelComputer.stripLongestCommonPathPrefix(sortedPaths(only));
+
+    assertEquals(HashMap.<Path, String>empty().put(only, "c"), result);
+  }
+
+  private static SortedSet<Path> sortedPaths(Path... paths) {
+    return TreeSet.ofAll(Comparator.<Path>naturalOrder(), List.of(paths));
+  }
+}

--- a/backend/impl/src/test/resources/setup-with-worktrees.sh-discover.txt
+++ b/backend/impl/src/test/resources/setup-with-worktrees.sh-discover.txt
@@ -1,0 +1,9 @@
+  master [<main worktree>]
+
+  develop
+  |
+  | Feature A commit
+  o-feature-a * [<this worktree>]
+  |
+  | Feature B commit
+  o-feature-b [worktree-b]

--- a/backend/impl/src/test/resources/setup-with-worktrees.sh-status.txt
+++ b/backend/impl/src/test/resources/setup-with-worktrees.sh-status.txt
@@ -1,0 +1,9 @@
+  master [<main worktree>]
+
+  develop
+  |
+  | Feature A commit
+  o-feature-a * [<this worktree>]
+  |
+  | Feature B commit
+  o-feature-b [worktree-b]

--- a/backend/impl/src/test/resources/version.txt
+++ b/backend/impl/src/test/resources/version.txt
@@ -1,1 +1,1 @@
-git-machete version 3.41.0
+git-machete version 3.42.0

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/table/DemoGitMacheteRepositorySnapshot.java
@@ -4,7 +4,9 @@ import java.nio.file.Path;
 import java.time.Instant;
 
 import io.vavr.NotImplementedError;
+import io.vavr.collection.HashMap;
 import io.vavr.collection.List;
+import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import io.vavr.collection.TreeSet;
 import lombok.AllArgsConstructor;
@@ -129,6 +131,11 @@ public class DemoGitMacheteRepositorySnapshot implements IGitMacheteRepositorySn
   @Override
   public Set<String> getSkippedBranchNames() {
     return TreeSet.empty();
+  }
+
+  @Override
+  public Map<String, String> getWorktreeLabelByLocalBranchName() {
+    return HashMap.empty();
   }
 
   @Getter

--- a/testCommon/src/testFixtures/java/com/virtuslab/gitmachete/testcommon/SetupScripts.java
+++ b/testCommon/src/testFixtures/java/com/virtuslab/gitmachete/testcommon/SetupScripts.java
@@ -4,6 +4,7 @@ public final class SetupScripts {
   private SetupScripts() {}
   public static final String SETUP_FOR_NO_REMOTES = "setup-with-no-remotes.sh";
   public static final String SETUP_WITH_SINGLE_REMOTE = "setup-with-single-remote.sh";
+  public static final String SETUP_WITH_WORKTREES = "setup-with-worktrees.sh";
   public static final String SETUP_README_SCENARIOS = "setup-readme-scenarios.sh";
   public static final String SETUP_WITH_MULTIPLE_REMOTES = "setup-with-multiple-remotes.sh";
   public static final String SETUP_FOR_DIVERGED_AND_OLDER_THAN = "setup-for-diverged-and-older-than.sh";
@@ -14,6 +15,7 @@ public final class SetupScripts {
   public static final String[] ALL_SETUP_SCRIPTS = {
       SETUP_FOR_NO_REMOTES,
       SETUP_WITH_SINGLE_REMOTE,
+      SETUP_WITH_WORKTREES,
       SETUP_WITH_MULTIPLE_REMOTES,
       SETUP_FOR_DIVERGED_AND_OLDER_THAN,
       SETUP_FOR_YELLOW_EDGES,

--- a/testCommon/src/testFixtures/java/com/virtuslab/gitmachete/testcommon/TestGitRepository.java
+++ b/testCommon/src/testFixtures/java/com/virtuslab/gitmachete/testcommon/TestGitRepository.java
@@ -9,6 +9,9 @@ import java.nio.file.Path;
 
 import lombok.SneakyThrows;
 
+// `"git"` and `".git"` repeat naturally in subprocess-driven Git fixture code; extracting them
+// into constants would only obscure the call sites without any readability gain.
+@SuppressWarnings("MultipleStringLiterals")
 public class TestGitRepository {
 
   // When set, TestGitRepository copies `<prebuiltTemplatesDir>/<scriptName>/` into the per-test
@@ -19,6 +22,11 @@ public class TestGitRepository {
   private static final String PREBUILT_TEMPLATES_DIR_PROPERTY = "testFixtures.prebuiltTemplatesDir";
 
   private static final String SETUP_WITH_SINGLE_REMOTE = "setup-with-single-remote.sh";
+  private static final String SETUP_WITH_WORKTREES = "setup-with-worktrees.sh";
+
+  private static final String MAIN_REPO_DIR_NAME = "machete-sandbox";
+  private static final String WORKTREE_A_DIR_NAME = "worktree-a";
+  private static final String WORKTREE_B_DIR_NAME = "worktree-b";
 
   public final Path parentDirectoryPath;
   public final Path rootDirectoryPath;
@@ -30,21 +38,39 @@ public class TestGitRepository {
     parentDirectoryPath = Files.createTempDirectory("machete-tests-");
     if (scriptName.equals(SETUP_WITH_SINGLE_REMOTE)) {
       rootDirectoryPath = parentDirectoryPath.resolve("machete-sandbox-worktree");
-      mainGitDirectoryPath = parentDirectoryPath.resolve("machete-sandbox").resolve(".git");
+      mainGitDirectoryPath = parentDirectoryPath.resolve(MAIN_REPO_DIR_NAME).resolve(".git");
       worktreeGitDirectoryPath = mainGitDirectoryPath.resolve("worktrees").resolve("machete-sandbox-worktree");
+    } else if (scriptName.equals(SETUP_WITH_WORKTREES)) {
+      // Drive both the snapshot and the CLI from a linked worktree (not the main repo), so the
+      // status output covers all three worktree-label variants in one shot: `<this worktree>`
+      // (the linked one we're rooted at), `<main worktree>` (the main repo holding `master`),
+      // and an explicitly-named linked worktree (the other one, holding `feature-b`).
+      rootDirectoryPath = parentDirectoryPath.resolve(WORKTREE_A_DIR_NAME);
+      mainGitDirectoryPath = parentDirectoryPath.resolve(MAIN_REPO_DIR_NAME).resolve(".git");
+      worktreeGitDirectoryPath = mainGitDirectoryPath.resolve("worktrees").resolve(WORKTREE_A_DIR_NAME);
     } else {
-      rootDirectoryPath = parentDirectoryPath.resolve("machete-sandbox");
+      rootDirectoryPath = parentDirectoryPath.resolve(MAIN_REPO_DIR_NAME);
       mainGitDirectoryPath = rootDirectoryPath.resolve(".git");
       worktreeGitDirectoryPath = rootDirectoryPath.resolve(".git");
     }
 
     materializeBaseRepo(scriptName);
-
-    if (scriptName.equals(SETUP_WITH_SINGLE_REMOTE)) {
-      addWorktreeAndDetachMain();
-    }
+    applyPostScriptSetup(scriptName, parentDirectoryPath);
 
     System.out.println("Set up a test repo in " + rootDirectoryPath);
+  }
+
+  /**
+   * Working directory from which to invoke {@code git machete} so its output matches the snapshot
+   * built by {@link #TestGitRepository(String)}. Kept in sync with the {@code rootDirectoryPath}
+   * branches above; {@link com.virtuslab.gitmachete.backend.integration.RegenerateCliOutputs}
+   * dispatches here so the regenerated CLI fixtures don't drift from what the tests assert.
+   */
+  public static Path cliWorkingDirectory(String scriptName, Path parentDirectoryPath) {
+    if (scriptName.equals(SETUP_WITH_WORKTREES)) {
+      return parentDirectoryPath.resolve(WORKTREE_A_DIR_NAME);
+    }
+    return parentDirectoryPath.resolve(MAIN_REPO_DIR_NAME);
   }
 
   @SneakyThrows
@@ -69,22 +95,56 @@ public class TestGitRepository {
     return Files.isRegularFile(tarball) ? tarball : null;
   }
 
-  // Mirrors the tail that setup-with-single-remote.sh used to do inline. Kept in Java so that the
-  // absolute paths baked into `.git/worktrees/<wt>/gitdir` are stamped against the per-test
-  // parent dir, not against the build-time prebuild dir.
-  private void addWorktreeAndDetachMain() {
-    final String git = "git";
-    Path mainRepo = parentDirectoryPath.resolve("machete-sandbox");
+  /**
+   * Mirrors the worktree-add tail that some setup scripts intentionally leave out (see their
+   * top-of-file comment). Kept in Java so that the absolute paths baked into
+   * {@code .git/worktrees/<wt>/gitdir} get stamped against the actual {@code parentDirectoryPath}
+   * - not against the build-time prebuild dir. {@link RegenerateCliOutputs} dispatches here too
+   * so the CLI sees the same fixture shape as the tests.
+   */
+  public static void applyPostScriptSetup(String scriptName, Path parentDirectoryPath) {
+    if (scriptName.equals(SETUP_WITH_SINGLE_REMOTE)) {
+      addWorktreeAndDetachMain(parentDirectoryPath);
+    } else if (scriptName.equals(SETUP_WITH_WORKTREES)) {
+      addLinkedWorktreesOnBranches(parentDirectoryPath);
+    }
+  }
+
+  private static void addWorktreeAndDetachMain(Path parentDirectoryPath) {
+    Path mainRepo = parentDirectoryPath.resolve(MAIN_REPO_DIR_NAME);
+    Path worktreeRoot = parentDirectoryPath.resolve("machete-sandbox-worktree");
     // Pin the worktree to HEAD (a commit, not a branch) so that git doesn't auto-create a
     // `machete-sandbox-worktree` branch.
-    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 30, git, "worktree", "add", "../machete-sandbox-worktree", "HEAD");
+    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 30, "git", "worktree", "add", "../machete-sandbox-worktree",
+        "HEAD");
     // Stash the worktree's per-repo hooks override before detaching HEAD on the main repo,
     // matching the original script's ordering.
-    runProcessAndReturnStdout(rootDirectoryPath, /* timeoutSeconds */ 10,
-        git, "config", "--local", "core.hooksPath", "../machete-sandbox/.git/hooks");
+    runProcessAndReturnStdout(worktreeRoot, /* timeoutSeconds */ 10,
+        "git", "config", "--local", "core.hooksPath", "../machete-sandbox/.git/hooks");
     // git refuses to check out a branch already held by another worktree, so flip the main repo
     // into detached HEAD to give the worktree free rein over every branch.
-    String headSha = runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 10, git, "rev-parse", "HEAD").trim();
-    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 10, git, "checkout", headSha);
+    String headSha = runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 10, "git", "rev-parse", "HEAD").trim();
+    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 10, "git", "checkout", headSha);
+  }
+
+  // Adds two linked worktrees, each on a distinct managed branch, so that `git machete status`
+  // exercises every worktree-label rendering branch: `<this worktree>` for the branch held by
+  // the worktree the snapshot is rooted at (`worktree-a` / `feature-a`), `<main worktree>` for
+  // the branch held by the main repo (`master`), and a stripped-prefix linked-worktree name for
+  // the remaining linked worktree (`worktree-b` / `feature-b`).
+  @SneakyThrows
+  private static void addLinkedWorktreesOnBranches(Path parentDirectoryPath) {
+    Path mainRepo = parentDirectoryPath.resolve(MAIN_REPO_DIR_NAME);
+    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 30, "git", "worktree", "add", "../" + WORKTREE_A_DIR_NAME,
+        "feature-a");
+    runProcessAndReturnStdout(mainRepo, /* timeoutSeconds */ 30, "git", "worktree", "add", "../" + WORKTREE_B_DIR_NAME,
+        "feature-b");
+    // Skip the `machete-status-branch` hook for this fixture: `common.sh` configures
+    // `core.hooksPath=.git/hooks` (a relative path) on the main repo, which silently fails to
+    // resolve from inside a linked worktree (where `.git` is a gitlink file, not a directory).
+    // Both the CLI and JGit hit this same blind spot, so rather than papering over it with a
+    // per-worktree override, drop the hook entirely - this fixture exists to exercise worktree
+    // labels, not the status hook.
+    Files.deleteIfExists(mainRepo.resolve(".git").resolve("hooks").resolve("machete-status-branch"));
   }
 }

--- a/testCommon/src/testFixtures/resources/setup-with-worktrees.sh
+++ b/testCommon/src/testFixtures/resources/setup-with-worktrees.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
+source "$self_dir"/common.sh
+
+create_repo machete-sandbox
+cd machete-sandbox
+  create_branch master
+    commit Master commit
+
+  create_branch develop
+    commit Develop commit
+  create_branch feature-a
+    commit Feature A commit
+
+  git checkout develop
+  create_branch feature-b
+    commit Feature B commit
+
+  git checkout master
+
+  machete_file='
+  master
+  develop
+      feature-a
+      feature-b
+  '
+  sed 's/^  //' <<< "$machete_file" > .git/machete
+
+  # NB: this script intentionally does NOT do `git worktree add ...`.
+  # The matching `TestGitRepository#applyPostScriptSetup` runs that step in Java once the (possibly
+  # pre-built and copied) template is in its final location - otherwise the absolute paths baked
+  # into `.git/worktrees/<wt>/gitdir` and `<wt-root>/.git` would point at the pre-build directory
+  # rather than the per-test temp dir.
+cd -


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2297

## Chain of upstream PRs & tree of downstream PRs as of 2026-06-01

* PR #2301:
  `develop` ← `improve/infer-worktree-label`

  * PR #2297:
    `improve/infer-worktree-label` ← `improve/no-checkout-when-in-other-wt`

    * **PR #2303 (THIS ONE)**:
      `improve/no-checkout-when-in-other-wt` ← `improve/wt-label-by-branch`

        * PR #2299:
          `improve/wt-label-by-branch` ← `feature/worktree-next-to-branch`

<!-- end git-machete generated -->

Extends the snapshot model with a per-branch `[<worktree>]` label
string mirroring the equivalent feature in `git machete status`, so
the UI renderer can later slot it into the branch cell without doing
any layout work of its own.

`IGitMacheteRepositorySnapshot#getWorktreeLabelByLocalBranchName()`
returns an empty map unless the repository has at least one linked
worktree; otherwise every branch held by some worktree picks up a
label. Labels are computed component-wise (off-EDT, once per
snapshot) by `WorktreeLabelComputer`:

* `<this worktree>` for branches held by the worktree the snapshot
  was built against;
* `<main worktree>` for branches in the main worktree when the
  snapshot is taken from a linked one;
* otherwise the holding linked worktree's path with the longest
  common prefix of all linked-worktree paths stripped, so typical
  layouts like `~/wts/foo` / `~/wts/bar` collapse to `foo` / `bar`.
  The main worktree is deliberately excluded from the prefix
  computation so it can't artificially lengthen every linked label
  when main and the linked roots live in disjoint subtrees.

No UI change yet - the renderer hook-up lands in the follow-up PR.

A dedicated `setup-with-worktrees.sh` fixture adds linked worktrees
post-script in Java (so the absolute paths baked into
`.git/worktrees/<wt>/gitdir` match the per-test temp dir), with
`RegenerateCliOutputs` dispatching to the same `applyPostScriptSetup`
helper so the CLI sees the same fixture shape and the integration
test's CLI-comparison covers the new label.