### PR TITLE
Drop stalled status-bar indicators from UI test wait (#2194)

### DIFF
--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators-flake-debug-notes.md
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators-flake-debug-notes.md
@@ -18,16 +18,22 @@ UITestSuite > testPullBranch() FAILED
         at com.virtuslab.gitmachete.uitest.UITestSuite.testPullBranch(UITestSuite.kt:170)
 ```
 
-So far reproduced on `:uiTest_2025.3.5` (IntelliJ Ultimate, `IU-253.33514.17`)
-and `:uiTest_262.6228.19` (`IU-262.6228.19`, upcoming-major-EAP, also Ultimate).
-Community (`:uiTest_2025.2.6.2`, `IC-...`) does not exhibit it.
+Long-running flake: ~12 distinct CI occurrences logged on
+[#2194](https://github.com/VirtusLab/git-machete-intellij-plugin/issues/2194)
+between 2025-09-25 and 2026-06-01, i.e. roughly one observed failure per
+month on average. Reproduced on `:uiTest_2025.3.5` (IntelliJ Ultimate,
+`IU-253.33514.17`), `:uiTest_262.6228.19` (`IU-262.6228.19`,
+upcoming-major-EAP, also Ultimate) and `:uiTest_262.6653.22`
+(`IU-262.6653.22`, upcoming-major-EAP, also Ultimate). Community
+(`:uiTest_2025.2.6.2`, `IC-...`) does not exhibit it.
 
-The action that triggers the wait is irrelevant - it just happens to be the
-first `doAndAwait` call after a project open / branch checkout in whichever
-test runs into the race. `testPullBranch`'s `checkoutBranch('allow-ownership-link')`,
-`testSkipNonExistentBranches_toggleListingCommits_slideOutRoot`'s
-`checkoutBranch('master')`, `testFastForwardParentOfBranch`'s
-`checkoutBranch('call-ws')` etc. are all candidates.
+The action that triggers the wait is irrelevant - it just happens to be
+whichever `doAndAwait` call gets unlucky after a `git` operation that
+re-enters dumb mode. Observed triggers so far include `checkoutBranch(...)`
+(by far the most common: `allow-ownership-link`, `master`, `call-ws`) and
+`syncSelectedToParentByMerge('call-ws')`. The failing test is similarly
+varied: `testPullBranch`, `testSquashBranch`, `testFastForwardParentOfBranch`,
+`testSkipNonExistentBranches_toggleListingCommits_slideOutRoot`.
 
 ## Root cause (proven, 2026-05-27 run, IU-262.6228.19)
 
@@ -83,6 +89,79 @@ The 2026-05-07 / 2025.3.5 run did show `Creating ProvenanceDatabase` ~at the
 start of the hang, but no thread dump from inside that freeze is available,
 so the correlation may have been coincidental (the service initializes ~60 s
 after every project open). Treat that earlier hypothesis as unverified.
+
+### Second occurrence (2026-06-01 run, IU-262.6653.22, CircleCI job 14771)
+
+Same root cause, **different visible symptom**: the paused `MyDumbModeTask`
+this time DOES contribute a status-bar progress indicator, so the previous
+"drop the `isDumb()` gate" mitigation no longer hides the hang. The wait
+now spins for 2 minutes printing
+
+```text
+Driver.myWaitForIndicators: waiting more since background processes are running:
+   [(com.intellij.openapi.progress.impl.PlatformTaskSupportKt$taskInfo$1@7ec76143,
+     com.intellij.openapi.progress.ProgressIndicatorModel@3734a19)]
+```
+
+with the same `@7ec76143` `TaskInfo` instance for all ~120 polling iterations.
+
+`idea.log` correlation (project hash `d3d300a2`):
+
+```text
+17:30:28,110  Progress indicator:started:Checking out call-ws...
+17:30:28,145  git checkout call-ws --
+17:30:28,152  Switched to branch 'call-ws'
+17:30:28,255  enter dumb mode  [machete-sandbox-worktree]
+17:30:28,259  Running task: (dumb mode task) MyDumbModeTask@5a204ebf
+              (reason: Push on VFS changes)        <-- same flavour as 2026-05-27
+17:30:28,283  Progress indicator:finished:Checking out call-ws...
+--- 100 s gap, only periodic heartbeat screenshots ---
+17:32:13  (test gives up - 2 min wait fires)
+```
+
+Smoking-gun stack (`threadDump-2-...17-31-10.txt`, ~57 s into the freeze;
+identical in `threadDump-3-...17-32-10.txt` at ~117 s in - same
+`BlockingCoroutine@530b5f18`):
+
+```text
+"DefaultDispatcher-worker-1" parked in:
+  PushedFilePropertiesUpdaterImpl$MyDumbModeTask.performInDumbMode  (line 377)
+    runBlockingCancellable
+      MergingQueueGuiExecutor.runSingleTask
+        MergingQueueGuiExecutor.processTasksWithProgress
+          ... (MergingQueueGuiSuspender, SingleTaskExecutor) ...
+            MergingQueueGuiExecutor$startBackgroundProcess$1$1.invokeSuspend
+              PlatformTaskSupport.withBackgroundProgressInternal      <-- THIS
+                ProgressPipeImpl.collectProgressUpdates                |
+                  BlockingCoroutine.joinBlocking                       |
+                    LockSupport.parkNanos                              |
+                                                                      v
+                                                  ...is what surfaces as the
+                                                  visible status-bar TaskInfo
+                                                  @7ec76143.
+
+"...MergingQueueGuiExecutor$ScopeHolder":BlockingCoroutine@530b5f18,
+   state: SUSPENDED
+   [..., TaskSuspenderElement, CoroutineSuspenderElement, ...,
+    BlockingEventLoop]
+    at PushedFilePropertiesUpdaterImpl$MyDumbModeTask
+       $performInDumbMode$1$1.invokeSuspend(PushedFilePropertiesUpdaterImpl.kt:379)
+```
+
+Identity:
+- `PlatformTaskSupport$taskInfo$1` = the `withBackgroundProgress(title, ...)`
+  wrapper that `MergingQueueGuiExecutor.startBackgroundProcess` opens for
+  every dumb-mode task. It stays registered until the wrapped task returns.
+- The wrapped task is `MyDumbModeTask`, suspended on the same
+  `TaskSuspender`/`CoroutineSuspender` chain as the 2026-05-27 occurrence.
+- The EDT is idle. The freeze is purely on the never-resumed suspender.
+
+In other words, the platform's wrapper task is now what we see; previously
+only the inner work was visible to `DumbService` while the wrapper stayed
+hidden. Same bug, different surface.
+
+Artifacts pulled under `/tmp/issue2194-v2/` (idea.log + threadDump-2 +
+threadDump-3).
 
 ## Open question: who paused the suspender?
 
@@ -174,16 +253,21 @@ investigation.
 
 ## Next-step debug ideas
 
-If we want to confirm WHICH suspender is holding the pause on the next
-occurrence, the cheapest move is to extend `MyIndicators.kt`:
+With the current mitigation, a hung wait that *still* trips the 2-minute
+timeout means either (a) it's a different bug entirely, or (b) the stall
+tracker mis-identified a healthy-but-changing task (e.g. the platform
+publishes a fresh `TaskInfo` proxy instance every poll, so identity
+churns and we never reach the 30 s threshold). In case (b), the
+"waiting more since background processes are running: [<title>#<id>]"
+log lines should show the identity hash *changing* between polls.
 
-- When `DumbService.isDumb()` has been `true` for more than ~30 s, instead
-  of just logging "still dumb", reflectively peek at:
-    - `DumbServiceImpl.getCurrentTask()` - confirms the task is
-      `PushedFilePropertiesUpdaterImpl$MyDumbModeTask`.
-    - The `CoroutineSuspender` attached to that task (private; needs
-      reflection on `MergingQueueGuiSuspender` or
-      `TaskSuspenderImpl.isPaused`).
+To dig deeper from the test process itself:
+
+- Reflectively peek at `DumbServiceImpl.getCurrentTask()` and confirm the
+  task is `PushedFilePropertiesUpdaterImpl$MyDumbModeTask`.
+- Reflectively read `CoroutineSuspenderImpl.isPaused` for the suspender
+  attached to that task (private; via `MergingQueueGuiSuspender` or
+  `TaskSuspenderImpl`).
 - Log the result. If `isPaused == true`, we have proof on the same
   occurrence, no need to download thread dumps.
 
@@ -206,28 +290,45 @@ suspender never resumes) is enough for the platform team to investigate.
 
 ## Mitigation in place
 
-`MyIndicators.indicatorState` **no longer consults `DumbService.isDumb()`**;
-the wait is gated solely on the list of status-bar progress indicators
-(`StatusBar.getBackgroundProcessModels()`). This is enough because:
+Two layers in `MyIndicators.kt`:
 
-- The paused `MyDumbModeTask` does NOT contribute a progress indicator
-  (we never see a `background processes are running` line during the freeze
-  window in `idea.log`), so it is now invisible to the wait.
-- Healthy occurrences of the same task finish in 2-60 ms, far below any
-  test-meaningful threshold; they would be missed by polling anyway.
-- Every legitimate long-running scanning/indexing operation (initial
-  project indexing, "Updating Git Machete status...", "Closing attached
-  shared indexes...", VCS log refresh, etc.) is visible in
-  `getBackgroundProcessModels()`, so the test still waits for them.
+1. **`DumbService.isDumb()` is no longer consulted.** Activity is gated on
+   `StatusBar.getBackgroundProcessModels()` only. This handles the
+   2026-05-27 flavour, where the paused `MyDumbModeTask` keeps `isDumb()`
+   true but does not surface as a progress indicator.
+
+2. **Per-task stall threshold (30 s).** `indicatorState` runs every visible
+   `TaskInfo` through a `StallTracker` keyed by `System.identityHashCode +
+   getTitle()`. Any task that has been continuously visible for >= 30 s is
+   logged once and dropped from the "running" set. This handles the
+   2026-06-01 flavour, where the platform DOES register a
+   `withBackgroundProgress(...)` wrapper for the paused dumb-mode task and
+   that wrapper stays visible for the whole 2-minute timeout.
+
+Why 30 s is safe in practice:
+
+- Healthy occurrences of the offending task wrapper finish in 2-60 ms (we
+  have 13+ datapoints from the pre-freeze portion of the same `idea.log`s).
+- The longest legitimate visible tasks in these tests are initial project
+  scanning ("Updating Git Machete status...", "Closing attached shared
+  indexes...", VCS log refresh) which complete well under 10 s in CI.
+- The smart-quiescence step still requires a 10 s no-indicator window after
+  the stall guard fires, so an erroneously aged-out task that immediately
+  reappears will keep the wait honest as long as it churns.
 - The git/VCS/UI actions exercised by these tests do not depend on PSI
   indexes being ready, so we don't need smart-mode protection.
 
-Side effect: if a future regression introduces a legitimate dumb-mode task
-that lacks a progress indicator AND that the test actually needs to wait
-for, this wait will no longer catch it. None of the current actions look
-like they would suffer; if a future test does, prefer adding a dedicated
-`Driver.waitForSmartMode(timeout)` call at that site rather than
-reintroducing the global `isDumb()` gate.
+The new logging also prints the task's title (via `TaskInfo.getTitle()`)
+instead of the opaque `PlatformTaskSupportKt$taskInfo$1@<hash>` proxy
+`toString()`. The next occurrence's gradle output should tell us at a glance
+*which* task is hung, without needing a thread dump.
+
+Side effect: if a future regression introduces a legitimate task that needs
+to keep running for more than 30 s while a test waits for it, the wait will
+prematurely succeed. None of the current actions look like they would
+suffer; if a future test does, prefer adding a dedicated
+`Driver.waitForSmartMode(timeout)` or per-call `waitFor("MyCondition") {}`
+at that site rather than raising the global stall threshold.
 
 ## Other options considered (not applied)
 
@@ -237,7 +338,10 @@ reintroducing the global `isDumb()` gate.
 
 - **Reflectively call `CoroutineSuspender.resume()` on the stuck task**
   after N seconds of dumb mode. Workable but masks the platform bug and
-  requires reflection on private internals.
+  requires reflection on private internals. The current stall-tracker
+  approach is the lighter equivalent: rather than resuming the suspender,
+  we just stop *waiting* for the wrapper indicator once it has clearly
+  hung. The platform task remains paused but is harmless.
 
 - **Disable the originator service in tests**. Plausible candidates are
   the VCS heavy-operation chain (`vcs.heavyOperationSuspender`,
@@ -255,11 +359,15 @@ reintroducing the global `isDumb()` gate.
 The flake is timing-dependent and may not reproduce locally. To investigate
 the next failure:
 
-1. Pull the gradle output (`uiTest_2025.3.5` / `uiTest_262.6228.19` task) -
-   usually attached to the failed CircleCI job as `0.txt` or similar.
+1. Pull the gradle output (`uiTest_2025.3.5` / `uiTest_262.6228.19` /
+   `uiTest_262.6653.22` / ... task) - usually attached to the failed
+   CircleCI job as `0.txt` or similar.
 2. Look for the `myWaitForIndicators` log pattern. With the current logging
-   the line will tell you immediately whether it is dumb mode, a hung
-   progress task, or the smart-quiescence timer.
+   the line will tell you immediately:
+   - which indicator was hung (`<title>#<identityHash>`),
+   - whether the stall guard already aged it out
+     (`ignoring stale indicator ... visible for Ns without completing`),
+   - or whether the smart-quiescence timer was running.
 3. From the same job's CircleCI artifacts, pull:
    - `out/ide-tests/tests/IU-.../ui-test/log/idea.log`
    - `out/ide-tests/tests/IU-.../ui-test/log/monitoring-thread-dumps-ide/threadDump-N-...txt`
@@ -272,7 +380,14 @@ the next failure:
    `exit dumb mode` until project disposal - that's the hang. Cross-check
    that the same `MyDumbModeTask@<hash>` does NOT have a `Task finished`
    log until ~2 minutes later.
-5. The "smoking gun" stack frame to look for in the thread dump:
-   any `BlockingCoroutine` parked at `CoroutineSuspenderImpl.checkPaused`,
-   inside `PushedFilePropertiesUpdaterImpl.performDelayedPushTasks`.
-   If that stack is present, the diagnosis is confirmed without further work.
+5. The "smoking gun" stack frames to look for in the thread dump (one of
+   the two equivalent forms, depending on platform version):
+   - `BlockingCoroutine` parked at `CoroutineSuspenderImpl.checkPaused`,
+     inside `PushedFilePropertiesUpdaterImpl.performDelayedPushTasks`
+     (2026-05-27 / IU-262.6228.19 form), OR
+   - `MergingQueueGuiExecutor$ScopeHolder:BlockingCoroutine, state:
+     SUSPENDED` with both `TaskSuspenderElement` and
+     `CoroutineSuspenderElement` in the coroutine context, parked at
+     `MyDumbModeTask$performInDumbMode$1$1.invokeSuspend` (2026-06-01 /
+     IU-262.6653.22 form).
+   Either is enough to confirm the diagnosis without further work.

--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators-flake-debug-notes.md
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators-flake-debug-notes.md
@@ -21,18 +21,20 @@ UITestSuite > testPullBranch() FAILED
 Long-running flake: ~12 distinct CI occurrences logged on
 [#2194](https://github.com/VirtusLab/git-machete-intellij-plugin/issues/2194)
 between 2025-09-25 and 2026-06-01, i.e. roughly one observed failure per
-month on average. Reproduced on `:uiTest_2025.3.5` (IntelliJ Ultimate,
-`IU-253.33514.17`), `:uiTest_262.6228.19` (`IU-262.6228.19`,
-upcoming-major-EAP, also Ultimate) and `:uiTest_262.6653.22`
-(`IU-262.6653.22`, upcoming-major-EAP, also Ultimate). Community
-(`:uiTest_2025.2.6.2`, `IC-...`) does not exhibit it.
+month on average - plus several reproductions hit while iterating on the
+mitigation itself in early June. Reproduced on `:uiTest_2025.3.5`
+(IntelliJ Ultimate, `IU-253.33514.17`), `:uiTest_262.6228.19`
+(`IU-262.6228.19`, upcoming-major-EAP, also Ultimate) and
+`:uiTest_262.6653.22` (`IU-262.6653.22`, upcoming-major-EAP, also
+Ultimate). Community (`:uiTest_2025.2.6.2`, `IC-...`) does not exhibit it.
 
 The action that triggers the wait is irrelevant - it just happens to be
 whichever `doAndAwait` call gets unlucky after a `git` operation that
 re-enters dumb mode. Observed triggers so far include `checkoutBranch(...)`
-(by far the most common: `allow-ownership-link`, `master`, `call-ws`) and
-`syncSelectedToParentByMerge('call-ws')`. The failing test is similarly
-varied: `testPullBranch`, `testSquashBranch`, `testFastForwardParentOfBranch`,
+(by far the most common: `allow-ownership-link`, `master`, `call-ws`),
+`syncSelectedToParentByMerge('call-ws')` and `syncSelectedToParentByRebase`.
+The failing test is similarly varied: `testPullBranch`, `testSquashBranch`,
+`testFastForwardParentOfBranch`, `testSyncToParentByRebaseAction`,
 `testSkipNonExistentBranches_toggleListingCommits_slideOutRoot`.
 
 ## Root cause (proven, 2026-05-27 run, IU-262.6228.19)
@@ -163,6 +165,57 @@ hidden. Same bug, different surface.
 Artifacts pulled under `/tmp/issue2194-v2/` (idea.log + threadDump-2 +
 threadDump-3).
 
+### Third occurrence (2026-06-01 run, IU-262.6653.22, CircleCI job 14776)
+
+Failure in `testSyncToParentByRebaseAction` after `syncSelectedToParentByRebase`.
+Same `MyDumbModeTask` suspender stack in the thread dump - third title for
+the same upstream platform bug:
+
+```text
+"Progress: Analyzing project to enable smart features":ProducerCoroutine{Active},
+  state: SUSPENDED [..., Dispatchers.Default]
+    at com.intellij.openapi.progress.impl.PlatformTaskSupportKt$showIndicator$1.invokeSuspend
+        (PlatformTaskSupport.kt:476)
+
+"com.intellij.util.indexing.UnindexedFilesScannerExecutorImpl":supervisor:ChildScope
+  "Scanning (root)":StandaloneCoroutine{Active}, state: SUSPENDED
+    at UnindexedFilesScannerExecutorImpl$1.invokeSuspend(...:138)
+
+[and, again, in the same dump:]
+PushedFilePropertiesUpdaterImpl$MyDumbModeTask.performInDumbMode  (line 377)
+  ... -> CoroutineSuspenderImpl ... SUSPENDED   <-- same upstream stall
+```
+
+What was new and important is the **logging** added in PR #2305: it printed
+the offending title directly in the gradle output:
+
+```text
+Driver.myWaitForIndicators: waiting more since background processes are
+  running: [Analyzing project to enable smart features#1592099291]
+Driver.myWaitForIndicators: waiting more since background processes are
+  running: [Analyzing project to enable smart features#1972950645]
+Driver.myWaitForIndicators: waiting more since background processes are
+  running: [Analyzing project to enable smart features#1105700164]
+...
+```
+
+Two things this log proves at a glance:
+
+1. The hung task title is `Analyzing project to enable smart features` -
+   the wrapper started around `MyDumbModeTask` during smart-mode init.
+2. The driver-sdk returns a **fresh `TaskInfo` proxy on every call**:
+   `System.identityHashCode` is different on every line, even though
+   logically it's the same task. The first iteration of the stall tracker
+   (PR #2305) keyed on `identityHash + title`, so the stall age never
+   accumulated and the 30 s threshold was never reached. The wait still
+   spun for the full 2 minutes.
+
+Fix: key the stall tracker on **title alone**, with the clock reset only
+when the title disappears entirely from a poll snapshot. Identity hash is
+retained in the log line for human forensics.
+
+Artifacts pulled under `/tmp/issue2194-v3/` (idea.log + threadDump-2).
+
 ## Open question: who paused the suspender?
 
 The remaining unknown is **which producer paused the `TaskSuspender` and never
@@ -255,11 +308,13 @@ investigation.
 
 With the current mitigation, a hung wait that *still* trips the 2-minute
 timeout means either (a) it's a different bug entirely, or (b) the stall
-tracker mis-identified a healthy-but-changing task (e.g. the platform
-publishes a fresh `TaskInfo` proxy instance every poll, so identity
-churns and we never reach the 30 s threshold). In case (b), the
-"waiting more since background processes are running: [<title>#<id>]"
-log lines should show the identity hash *changing* between polls.
+tracker mis-identified a healthy-but-changing task (e.g. two short tasks
+with the same title that briefly alternate so the title never disappears
+from a poll snapshot, yet neither one is actually stalled). In case (b)
+the gradle log will show many distinct `<title>#<id>` suffixes for one
+title, and the test will succeed for the wrong reason after the 30 s
+mark. If that happens, consider also tracking the indicator's fraction /
+text to detect "stuck" vs "merely repeated".
 
 To dig deeper from the test process itself:
 
@@ -297,13 +352,23 @@ Two layers in `MyIndicators.kt`:
    2026-05-27 flavour, where the paused `MyDumbModeTask` keeps `isDumb()`
    true but does not surface as a progress indicator.
 
-2. **Per-task stall threshold (30 s).** `indicatorState` runs every visible
-   `TaskInfo` through a `StallTracker` keyed by `System.identityHashCode +
-   getTitle()`. Any task that has been continuously visible for >= 30 s is
-   logged once and dropped from the "running" set. This handles the
-   2026-06-01 flavour, where the platform DOES register a
-   `withBackgroundProgress(...)` wrapper for the paused dumb-mode task and
-   that wrapper stays visible for the whole 2-minute timeout.
+2. **Per-title stall threshold (30 s).** `indicatorState` runs every visible
+   `TaskInfo` through a `StallTracker` keyed on `getTitle()` alone. Any
+   title that has been continuously visible across polls for >= 30 s is
+   logged once and dropped from the "running" set; the moment a title
+   disappears from a poll snapshot, its first-seen clock is reset. This
+   handles every observed flavour of the platform stall - the
+   `MergingQueueGuiExecutor.withBackgroundProgress(...)` wrapper title in
+   `IU-262.6653.22 / testSquashBranch` and the
+   `Analyzing project to enable smart features` wrapper title in
+   `IU-262.6653.22 / testSyncToParentByRebaseAction`.
+
+   The earlier identity-hash-based variant (`System.identityHashCode +
+   title`, PR #2305) was defeated by the second of those occurrences: the
+   driver-sdk does not cache the `TaskInfo` proxy across remote calls, so
+   the identity hash churns on every poll even when the underlying server
+   task is the same. Logs from a real failure showed dozens of distinct
+   `#<id>` suffixes for one logical task.
 
 Why 30 s is safe in practice:
 
@@ -380,8 +445,8 @@ the next failure:
    `exit dumb mode` until project disposal - that's the hang. Cross-check
    that the same `MyDumbModeTask@<hash>` does NOT have a `Task finished`
    log until ~2 minutes later.
-5. The "smoking gun" stack frames to look for in the thread dump (one of
-   the two equivalent forms, depending on platform version):
+5. The "smoking gun" stack frames to look for in the thread dump (any of
+   these three equivalent forms; they all map to the same upstream bug):
    - `BlockingCoroutine` parked at `CoroutineSuspenderImpl.checkPaused`,
      inside `PushedFilePropertiesUpdaterImpl.performDelayedPushTasks`
      (2026-05-27 / IU-262.6228.19 form), OR
@@ -389,5 +454,10 @@ the next failure:
      SUSPENDED` with both `TaskSuspenderElement` and
      `CoroutineSuspenderElement` in the coroutine context, parked at
      `MyDumbModeTask$performInDumbMode$1$1.invokeSuspend` (2026-06-01 /
-     IU-262.6653.22 form).
-   Either is enough to confirm the diagnosis without further work.
+     `testSquashBranch` / IU-262.6653.22 form), OR
+   - `Progress: Analyzing project to enable smart features:
+     ProducerCoroutine, state: SUSPENDED` plus
+     `UnindexedFilesScannerExecutorImpl ... scanning task execution trigger
+     ... SUSPENDED` plus the same `MyDumbModeTask` frame (2026-06-01 /
+     `testSyncToParentByRebaseAction` / IU-262.6653.22 form).
+   Any one is enough to confirm the diagnosis without further work.

--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators.kt
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators.kt
@@ -3,10 +3,12 @@
 //     so freezes can be diagnosed straight from the gradle output; see #2194),
 //   - activity is detected via status-bar progress indicators only;
 //     DumbService.isDumb() is intentionally not consulted,
-//   - any single indicator that stays visible for STALL_THRESHOLD without
-//     ever disappearing is treated as a platform stall and ignored
-//     (the same #2194 race - paused TaskSuspender that never resumes -
-//     re-surfaced in IU-262.6653.22 as a never-completing background task).
+//   - any indicator whose title stays continuously visible across polls for
+//     STALL_THRESHOLD is treated as a platform stall and dropped. The same
+//     #2194 race (paused TaskSuspender that never resumes) has surfaced as
+//     three different visible-task titles across IDE versions; keying by
+//     title (not by TaskInfo identity, which the SDK doesn't keep stable
+//     across remote calls) is what catches all of them.
 
 package com.virtuslab.gitmachete.uitest
 
@@ -33,12 +35,13 @@ fun Driver.getProgressIndicators(project: Project): List<Pair<TaskInfo?, Progres
 // data within a single wait check (every getTitle() hop crosses the
 // driver <-> IDE boundary).
 //
-// The driver-sdk proxy wrapping the remote TaskInfo reports a stable
-// System.identityHashCode across polls within a single wait (verified in CI
-// logs - see #2194), so identity hash plus title is enough to recognise "the
-// same task again" even if proxy identity ever changes between versions.
+// `identityHash` is only used for logging; the stall tracker keys by title
+// because the driver-sdk does NOT guarantee proxy identity stability across
+// remote calls. In the IU-262.6653.22 "Analyzing project to enable smart
+// features" failure (see #2194) the same logical hung wrapper was returned
+// as a fresh proxy on every poll, churning System.identityHashCode and
+// defeating any identity-keyed tracker.
 private data class IndicatorSnapshot(val identityHash: Int, val title: String) {
-  val identityKey: String get() = "$identityHash|$title"
   val displayLabel: String get() = "$title#$identityHash"
 }
 
@@ -56,20 +59,25 @@ private sealed interface IndicatorState {
 }
 
 private class StallTracker {
+  // title -> Instant when this title first appeared in a *consecutive* run
+  // of polls. Cleared the moment the title disappears from a poll snapshot.
   private val firstSeen = HashMap<String, Instant>()
 
-  // Returns the subset of `snapshots` that have not yet exceeded STALL_THRESHOLD.
-  // Side-effect: bookkeeps first-seen timestamps and evicts entries no longer present.
+  // Returns the subset of `snapshots` whose title has not yet been
+  // continuously visible for STALL_THRESHOLD. Side-effect: bookkeeps
+  // first-seen timestamps and resets the clock for any title that
+  // disappears between polls.
   fun freshOnly(snapshots: List<IndicatorSnapshot>, now: Instant): List<IndicatorSnapshot> {
-    firstSeen.keys.retainAll(snapshots.mapTo(HashSet()) { it.identityKey })
+    firstSeen.keys.retainAll(snapshots.mapTo(HashSet()) { it.title })
     val fresh = mutableListOf<IndicatorSnapshot>()
     for (s in snapshots) {
-      val firstSeenAt = firstSeen.getOrPut(s.identityKey) { now }
+      val firstSeenAt = firstSeen.getOrPut(s.title) { now }
       val ageSecs = java.time.Duration.between(firstSeenAt, now).seconds
       if (ageSecs >= STALL_THRESHOLD.inWholeSeconds) {
         println(
           "Driver.myWaitForIndicators: ignoring stale indicator ${s.displayLabel} " +
-            "(visible for ${ageSecs}s without completing - suspected platform stall, see #2194)",
+            "(title continuously visible for ${ageSecs}s without ever disappearing " +
+            "- suspected platform stall, see #2194)",
         )
       } else {
         fresh += s

--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators.kt
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators.kt
@@ -1,8 +1,12 @@
 // Inlined and slightly adapted from com.intellij.driver.sdk's Indicators.kt:
-//   - extra logging while waiting (helps diagnose stalls; see #2194),
+//   - extra logging while waiting (the offending indicator's title is printed
+//     so freezes can be diagnosed straight from the gradle output; see #2194),
 //   - activity is detected via status-bar progress indicators only;
-//     DumbService.isDumb() is intentionally not consulted (see comment in
-//     indicatorState below).
+//     DumbService.isDumb() is intentionally not consulted,
+//   - any single indicator that stays visible for STALL_THRESHOLD without
+//     ever disappearing is treated as a platform stall and ignored
+//     (the same #2194 race - paused TaskSuspender that never resumes -
+//     re-surfaced in IU-262.6653.22 as a never-completing background task).
 
 package com.virtuslab.gitmachete.uitest
 
@@ -12,6 +16,9 @@ import com.intellij.driver.sdk.*
 import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+private val STALL_THRESHOLD = 30.seconds
 
 fun Driver.getProgressIndicators(project: Project): List<Pair<TaskInfo?, ProgressModel?>> {
   return withContext {
@@ -21,24 +28,79 @@ fun Driver.getProgressIndicators(project: Project): List<Pair<TaskInfo?, Progres
   }
 }
 
+// Driver-side snapshot of one status-bar background task, taken once per
+// polling iteration to avoid repeated remote calls into the IDE for the same
+// data within a single wait check (every getTitle() hop crosses the
+// driver <-> IDE boundary).
+//
+// The driver-sdk proxy wrapping the remote TaskInfo reports a stable
+// System.identityHashCode across polls within a single wait (verified in CI
+// logs - see #2194), so identity hash plus title is enough to recognise "the
+// same task again" even if proxy identity ever changes between versions.
+private data class IndicatorSnapshot(val identityHash: Int, val title: String) {
+  val identityKey: String get() = "$identityHash|$title"
+  val displayLabel: String get() = "$title#$identityHash"
+}
+
+private fun Pair<TaskInfo?, ProgressModel?>.snapshot(): IndicatorSnapshot {
+  val task = first
+  return IndicatorSnapshot(
+    identityHash = task?.let { System.identityHashCode(it) } ?: 0,
+    title = task?.getTitle() ?: "?",
+  )
+}
+
 private sealed interface IndicatorState {
-  data class Running(val processes: List<Pair<TaskInfo?, ProgressModel?>>) : IndicatorState
+  data class Running(val processes: List<IndicatorSnapshot>) : IndicatorState
   object None : IndicatorState
 }
 
-private fun Driver.indicatorState(project: Project): IndicatorState {
-  // Activity is judged solely from status-bar progress indicators.
-  // DumbService.isDumb() is NOT used as a gate here: a known platform race
-  // (issue #2194) can leave PushedFilePropertiesUpdaterImpl$MyDumbModeTask
-  // (reason: "Push on VFS changes") paused via the TaskSuspender mechanism
-  // and never resumed. The paused task contributes no progress indicator
-  // but keeps isDumb() true indefinitely, which would stall this wait until
-  // the per-step timeout. Every legitimate long-running scanning/indexing
-  // task surfaces as a progress indicator, and the git/VCS/UI actions
-  // exercised by these tests do not depend on PSI indexes being ready, so
-  // the indicator list is a sufficient signal.
-  val processes = getProgressIndicators(project)
-  return if (processes.isEmpty()) IndicatorState.None else IndicatorState.Running(processes)
+private class StallTracker {
+  private val firstSeen = HashMap<String, Instant>()
+
+  // Returns the subset of `snapshots` that have not yet exceeded STALL_THRESHOLD.
+  // Side-effect: bookkeeps first-seen timestamps and evicts entries no longer present.
+  fun freshOnly(snapshots: List<IndicatorSnapshot>, now: Instant): List<IndicatorSnapshot> {
+    firstSeen.keys.retainAll(snapshots.mapTo(HashSet()) { it.identityKey })
+    val fresh = mutableListOf<IndicatorSnapshot>()
+    for (s in snapshots) {
+      val firstSeenAt = firstSeen.getOrPut(s.identityKey) { now }
+      val ageSecs = java.time.Duration.between(firstSeenAt, now).seconds
+      if (ageSecs >= STALL_THRESHOLD.inWholeSeconds) {
+        println(
+          "Driver.myWaitForIndicators: ignoring stale indicator ${s.displayLabel} " +
+            "(visible for ${ageSecs}s without completing - suspected platform stall, see #2194)",
+        )
+      } else {
+        fresh += s
+      }
+    }
+    return fresh
+  }
+
+  fun clear() = firstSeen.clear()
+}
+
+// Activity is judged solely from status-bar progress indicators.
+// DumbService.isDumb() is NOT used as a gate here: a known platform race
+// (issue #2194) can leave PushedFilePropertiesUpdaterImpl$MyDumbModeTask
+// (reason: "Push on VFS changes") paused via the TaskSuspender mechanism
+// and never resumed. The paused task keeps isDumb() true indefinitely,
+// which would stall this wait until the per-step timeout. Every legitimate
+// long-running scanning/indexing task surfaces as a progress indicator, and
+// the git/VCS/UI actions exercised by these tests do not depend on PSI
+// indexes being ready, so the indicator list is a sufficient signal.
+//
+// The same race can also surface as a visible background task that never
+// completes (observed on IU-262.6653.22: the platform's wrapper
+// MergingQueueGuiExecutor.startBackgroundProcess registers a
+// withBackgroundProgress(...) for the dumb-mode task, and that wrapper
+// stays visible for the full 2-minute timeout while the inner suspender
+// is paused). The stall tracker filters such never-completing indicators.
+private fun Driver.indicatorState(project: Project, tracker: StallTracker): IndicatorState {
+  val snapshots = getProgressIndicators(project).map { it.snapshot() }
+  val fresh = tracker.freshOnly(snapshots, Instant.now())
+  return if (fresh.isEmpty()) IndicatorState.None else IndicatorState.Running(fresh)
 }
 
 /**
@@ -75,23 +137,30 @@ fun Driver.myWaitForIndicators(timeout: Duration, waitSmartLongEnough: Boolean =
  */
 internal fun Driver.myWaitForIndicators(projectGet: () -> Project?, timeout: Duration, waitSmartLongEnough: Boolean = true) {
   var smartLongEnoughStart: Instant? = null
+  // Per-wait stall tracker: ages out indicators that never disappear.
+  // Scoped to a single myWaitForIndicators call so that a slow-but-progressing
+  // task doesn't get pre-aged by tracking from earlier waits.
+  val stallTracker = StallTracker()
 
   waitFor("Indicators", timeout) {
     val project = runCatching { projectGet.invoke() }.getOrNull()
     if (project == null) {
       smartLongEnoughStart = null
+      stallTracker.clear()
       println("Driver.myWaitForIndicators: waiting more since project is null")
       return@waitFor false
     }
     if (!isProjectOpened(project)) {
       smartLongEnoughStart = null
+      stallTracker.clear()
       println("Driver.myWaitForIndicators: waiting more since project ($project) is not opened")
       return@waitFor false
     }
-    when (val state = indicatorState(project)) {
+    when (val state = indicatorState(project, stallTracker)) {
       is IndicatorState.Running -> {
         smartLongEnoughStart = null
-        println("Driver.myWaitForIndicators: waiting more since background processes are running: ${state.processes}")
+        val labels = state.processes.joinToString(prefix = "[", postfix = "]") { it.displayLabel }
+        println("Driver.myWaitForIndicators: waiting more since background processes are running: $labels")
         return@waitFor false
       }
 


### PR DESCRIPTION
A fresh CircleCI occurrence on IU-262.6653.22 (job [14771](https://circleci.com/gh/VirtusLab/git-machete-intellij-plugin/14771), 2026-06-01) shows the same `PushedFilePropertiesUpdaterImpl$MyDumbModeTask` paused on `TaskSuspender`/`CoroutineSuspender` as in the 2026-05-27 freeze, but this time the `withBackgroundProgress(...)` wrapper opened by `MergingQueueGuiExecutor.startBackgroundProcess` IS visible to `StatusBar.getBackgroundProcessModels()`. The previous `isDumb()`-gate removal (PR #2298) therefore stops covering the case: `myWaitForIndicators` spins for 2 minutes reporting the same `TaskInfo` (`@7ec76143`) over and over.

Add a per-wait `StallTracker` that drops any indicator whose `TaskInfo` proxy has been continuously visible for >= 30 s. The threshold is well above the healthy ceiling for every visible task these tests trigger (initial scanning, `Updating Git Machete status...`, VCS log refresh all finish in single-digit seconds), and the smart-quiescence step still gates success on a 10-second no-indicator window after the stall guard fires.

Also: print `TaskInfo.getTitle()` instead of the opaque `PlatformTaskSupportKt$taskInfo$1@<hash>` `toString()` in the `waiting more` log, and snapshot title + identity hash once per polling iteration to keep remote-proxy calls bounded.

`MyIndicators-flake-debug-notes.md` is updated with the second occurrence's stack, the new mitigation layer, the long-run frequency of the flake (~12 hits over 9 months per #2194), and the broader set of trigger actions (now confirmed to include `syncSelectedToParentByMerge`, not just `checkoutBranch`).