### PR TITLE
Disable actions like pull, FF-merge, sync to parent by merge when the parent is checked out in a different worktree

### DIFF
--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardMergeToParentAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardMergeToParentAction.java
@@ -6,6 +6,7 @@ import static org.checkerframework.checker.i18nformatter.qual.I18nConversionCate
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.collection.List;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -14,8 +15,10 @@ import org.checkerframework.checker.tainting.qual.Untainted;
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.frontend.actions.common.FastForwardMerge;
 import com.virtuslab.gitmachete.frontend.actions.common.MergeProps;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.async.ContinuesInBackground;
 
+@ExtensionMethod(GitMacheteBundle.class)
 public abstract class BaseFastForwardMergeToParentAction extends BaseGitMacheteRepositoryReadyAction
     implements
       IBranchNameProvider,
@@ -46,6 +49,24 @@ public abstract class BaseFastForwardMergeToParentAction extends BaseGitMacheteR
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
     syncToParentStatusDependentActionUpdate(anActionEvent);
+
+    val presentation = anActionEvent.getPresentation();
+    if (!presentation.isEnabledAndVisible()) {
+      return;
+    }
+    val branchName = getNameOfBranchUnderAction(anActionEvent);
+    if (branchName == null) {
+      return;
+    }
+    val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
+    if (worktreeRootHoldingBranch != null) {
+      // FF-merge target is the (non-root) branch under action - same `git fetch . <parent>:<child>`
+      // refspec as Pull, just sourced locally; git refuses to fast-forward a branch held elsewhere.
+      presentation.setEnabled(false);
+      presentation.setDescription(
+          getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
+              .fmt(branchName, worktreeRootHoldingBranch.toString()));
+    }
   }
 
   @Override

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullAction.java
@@ -1,5 +1,6 @@
 package com.virtuslab.gitmachete.frontend.actions.base;
 
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -49,6 +50,25 @@ public abstract class BasePullAction extends BaseGitMacheteRepositoryReadyAction
   protected void onUpdate(AnActionEvent anActionEvent) {
     super.onUpdate(anActionEvent);
     syncToRemoteStatusDependentActionUpdate(anActionEvent);
+
+    val presentation = anActionEvent.getPresentation();
+    if (!presentation.isEnabledAndVisible()) {
+      return;
+    }
+    val branchName = getNameOfBranchUnderAction(anActionEvent);
+    if (branchName == null) {
+      return;
+    }
+    val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
+    if (worktreeRootHoldingBranch != null) {
+      // Pull fast-forwards the target branch via `git fetch . <remote>:<local>`; git refuses to update a
+      // local branch ref while it is checked out in another worktree (the same `refusing to fetch into
+      // branch ... checked out at ...` failure as a bare `git pull` in that situation).
+      presentation.setEnabled(false);
+      presentation.setDescription(
+          getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
+              .fmt(branchName, worktreeRootHoldingBranch.toString()));
+    }
   }
 
   @Override

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSyncToParentByMergeAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSyncToParentByMergeAction.java
@@ -12,6 +12,7 @@ import git4idea.branch.GitBrancher;
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
+import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -20,8 +21,10 @@ import org.checkerframework.checker.tainting.qual.Untainted;
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.frontend.actions.common.MergeProps;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.async.ContinuesInBackground;
 
+@ExtensionMethod(GitMacheteBundle.class)
 public abstract class BaseSyncToParentByMergeAction extends BaseGitMacheteRepositoryReadyAction
     implements
       IBranchNameProvider,
@@ -63,6 +66,21 @@ public abstract class BaseSyncToParentByMergeAction extends BaseGitMacheteReposi
         && currentBranchNameIfManaged.equals(branch.getName());
     if (isCalledFromContextMenu && isMergingIntoCurrent) {
       presentation.setText(getString("action.GitMachete.BaseSyncToParentByMergeAction.text"));
+    }
+
+    if (!presentation.isEnabledAndVisible() || branchName == null) {
+      return;
+    }
+    val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
+    if (worktreeRootHoldingBranch != null) {
+      // Merging parent into a non-current branch first checks the child out into the active worktree
+      // (see doMergeIntoNonCurrentBranch); git refuses if the branch is held elsewhere. The branch
+      // cannot be `current` here either - dual checkout of the same branch is prohibited - so the
+      // checked-out-elsewhere path is the only one that matters.
+      presentation.setEnabled(false);
+      presentation.setDescription(
+          getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
+              .fmt(branchName, worktreeRootHoldingBranch.toString()));
     }
   }
 


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2306

## Chain of upstream PRs as of 2026-06-01

* PR #2306:
  `master` ← `develop`

  * **PR #2307 (THIS ONE)**:
    `develop` ← `fix/pull-different-worktree`

<!-- end git-machete generated -->
