### PR TITLE
Extract `IWorktreeGuardedBranchAction` mixin for the "branch held by another worktree" guard

### DIFF
--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseCheckoutAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseCheckoutAction.java
@@ -20,7 +20,8 @@ import com.virtuslab.qual.async.ContinuesInBackground;
 public abstract class BaseCheckoutAction extends BaseGitMacheteRepositoryReadyAction
     implements
       IBranchNameProvider,
-      IExpectsKeySelectedBranchName {
+      IExpectsKeySelectedBranchName,
+      IWorktreeGuardedBranchAction {
   @Override
   protected boolean isSideEffecting() {
     return true;
@@ -58,15 +59,10 @@ public abstract class BaseCheckoutAction extends BaseGitMacheteRepositoryReadyAc
       return;
     }
 
-    val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, targetBranchName);
-    if (worktreeRootHoldingBranch != null) {
-      // Git refuses to check out a branch already held by another worktree, so block the action up-front
-      // and surface the holding worktree's path in the tooltip rather than letting the user discover this
-      // through a side-effecting failure.
-      presentation.setEnabled(false);
-      presentation.setDescription(
-          getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
-              .fmt(targetBranchName, worktreeRootHoldingBranch.toString()));
+    // Git refuses to check out a branch already held by another worktree; surface the holding
+    // worktree's path in the tooltip rather than letting the user discover this through a
+    // side-effecting failure.
+    if (disableIfBranchHeldByOtherWorktree(anActionEvent, targetBranchName)) {
       return;
     }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardMergeToParentAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseFastForwardMergeToParentAction.java
@@ -6,7 +6,6 @@ import static org.checkerframework.checker.i18nformatter.qual.I18nConversionCate
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.vavr.collection.List;
-import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -15,14 +14,12 @@ import org.checkerframework.checker.tainting.qual.Untainted;
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.frontend.actions.common.FastForwardMerge;
 import com.virtuslab.gitmachete.frontend.actions.common.MergeProps;
-import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.async.ContinuesInBackground;
 
-@ExtensionMethod(GitMacheteBundle.class)
 public abstract class BaseFastForwardMergeToParentAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
-      ISyncToParentStatusDependentAction {
+      ISyncToParentStatusDependentAction,
+      IWorktreeGuardedBranchAction {
 
   @Override
   protected boolean isSideEffecting() {
@@ -50,23 +47,12 @@ public abstract class BaseFastForwardMergeToParentAction extends BaseGitMacheteR
     super.onUpdate(anActionEvent);
     syncToParentStatusDependentActionUpdate(anActionEvent);
 
-    val presentation = anActionEvent.getPresentation();
-    if (!presentation.isEnabledAndVisible()) {
+    if (!anActionEvent.getPresentation().isEnabledAndVisible()) {
       return;
     }
-    val branchName = getNameOfBranchUnderAction(anActionEvent);
-    if (branchName == null) {
-      return;
-    }
-    val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
-    if (worktreeRootHoldingBranch != null) {
-      // FF-merge target is the (non-root) branch under action - same `git fetch . <parent>:<child>`
-      // refspec as Pull, just sourced locally; git refuses to fast-forward a branch held elsewhere.
-      presentation.setEnabled(false);
-      presentation.setDescription(
-          getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
-              .fmt(branchName, worktreeRootHoldingBranch.toString()));
-    }
+    // FF-merge target is the (non-root) branch under action - same `git fetch . <parent>:<child>`
+    // refspec as Pull, just sourced locally; git refuses to fast-forward a branch held elsewhere.
+    disableIfBranchHeldByOtherWorktree(anActionEvent, getNameOfBranchUnderAction(anActionEvent));
   }
 
   @Override

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BasePullAction.java
@@ -1,6 +1,5 @@
 package com.virtuslab.gitmachete.frontend.actions.base;
 
-import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -12,16 +11,14 @@ import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 import com.virtuslab.gitmachete.frontend.actions.common.Pull;
-import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.async.ContinuesInBackground;
 
 @ExtensionMethod(GitMacheteBundle.class)
 public abstract class BasePullAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
-      IExpectsKeyGitMacheteRepository,
-      ISyncToRemoteStatusDependentAction {
+      ISyncToRemoteStatusDependentAction,
+      IWorktreeGuardedBranchAction {
 
   @Override
   protected boolean isSideEffecting() {
@@ -51,24 +48,13 @@ public abstract class BasePullAction extends BaseGitMacheteRepositoryReadyAction
     super.onUpdate(anActionEvent);
     syncToRemoteStatusDependentActionUpdate(anActionEvent);
 
-    val presentation = anActionEvent.getPresentation();
-    if (!presentation.isEnabledAndVisible()) {
+    if (!anActionEvent.getPresentation().isEnabledAndVisible()) {
       return;
     }
-    val branchName = getNameOfBranchUnderAction(anActionEvent);
-    if (branchName == null) {
-      return;
-    }
-    val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
-    if (worktreeRootHoldingBranch != null) {
-      // Pull fast-forwards the target branch via `git fetch . <remote>:<local>`; git refuses to update a
-      // local branch ref while it is checked out in another worktree (the same `refusing to fetch into
-      // branch ... checked out at ...` failure as a bare `git pull` in that situation).
-      presentation.setEnabled(false);
-      presentation.setDescription(
-          getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
-              .fmt(branchName, worktreeRootHoldingBranch.toString()));
-    }
+    // Pull fast-forwards the target branch via `git fetch . <remote>:<local>`; git refuses to update
+    // a local branch ref while it is checked out in another worktree (the same `refusing to fetch
+    // into branch ... checked out at ...` failure as a bare `git pull` in that situation).
+    disableIfBranchHeldByOtherWorktree(anActionEvent, getNameOfBranchUnderAction(anActionEvent));
   }
 
   @Override

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetToRemoteAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseResetToRemoteAction.java
@@ -39,7 +39,8 @@ import com.virtuslab.qual.async.ContinuesInBackground;
 public abstract class BaseResetToRemoteAction extends BaseGitMacheteRepositoryReadyAction
     implements
       IBranchNameProvider,
-      ISyncToRemoteStatusDependentAction {
+      ISyncToRemoteStatusDependentAction,
+      IWorktreeGuardedBranchAction {
 
   public static final String VCS_NOTIFIER_TITLE = getString(
       "action.GitMachete.BaseResetToRemoteAction.notification.title");
@@ -89,14 +90,8 @@ public abstract class BaseResetToRemoteAction extends BaseGitMacheteRepositoryRe
 
       val presentation = anActionEvent.getPresentation();
       if (presentation.isEnabledAndVisible()) {
-        val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branch);
-        if (worktreeRootHoldingBranch != null) {
-          // Reset moves the local branch ref; git refuses to update a branch held by another worktree.
-          presentation.setEnabled(false);
-          presentation.setDescription(
-              getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
-                  .fmt(branch, worktreeRootHoldingBranch.toString()));
-        }
+        // Reset moves the local branch ref; git refuses to update a branch held by another worktree.
+        disableIfBranchHeldByOtherWorktree(anActionEvent, branch);
       }
     }
   }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSquashAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSquashAction.java
@@ -36,7 +36,8 @@ import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 @ExtensionMethod(GitMacheteBundle.class)
 public abstract class BaseSquashAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider {
+      IBranchNameProvider,
+      IWorktreeGuardedBranchAction {
 
   private final String NL = System.lineSeparator();
 
@@ -70,7 +71,6 @@ public abstract class BaseSquashAction extends BaseGitMacheteRepositoryReadyActi
         val description = getNonHtmlString("action.GitMachete.BaseSquashAction.not-enough-commits")
             .fmt(branchName, numberOfCommits + "", numberOfCommits == 1 ? "" : "s");
 
-        val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
         if (numberOfCommits < 2) {
           presentation.setDescription(description);
           presentation.setEnabled(false);
@@ -78,13 +78,10 @@ public abstract class BaseSquashAction extends BaseGitMacheteRepositoryReadyActi
           presentation.setEnabled(false);
           presentation.setDescription(getNonHtmlString("action.GitMachete.BaseSquashAction.fork-point-off")
               .fmt(branchName));
-        } else if (worktreeRootHoldingBranch != null) {
-          // Squashing a non-current branch first switches HEAD to it (see doSquash); git refuses if the branch
-          // is held in another worktree.
-          presentation.setEnabled(false);
-          presentation.setDescription(
-              getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
-                  .fmt(branchName, worktreeRootHoldingBranch.toString()));
+          // Squashing a non-current branch first switches HEAD to it (see doSquash); git refuses if
+          // the branch is held in another worktree.
+        } else if (disableIfBranchHeldByOtherWorktree(anActionEvent, branchName)) {
+          // Description already set by the helper.
         } else {
           val currentBranchIfManaged = getCurrentBranchNameIfManaged(anActionEvent);
           val isSquashingCurrentBranch = currentBranchIfManaged != null && currentBranchIfManaged.equals(branchName);

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSyncToParentByMergeAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSyncToParentByMergeAction.java
@@ -12,7 +12,6 @@ import git4idea.branch.GitBrancher;
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
 import io.vavr.control.Option;
-import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -21,14 +20,12 @@ import org.checkerframework.checker.tainting.qual.Untainted;
 import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.frontend.actions.common.MergeProps;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
-import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.async.ContinuesInBackground;
 
-@ExtensionMethod(GitMacheteBundle.class)
 public abstract class BaseSyncToParentByMergeAction extends BaseGitMacheteRepositoryReadyAction
     implements
-      IBranchNameProvider,
-      ISyncToParentStatusDependentAction {
+      ISyncToParentStatusDependentAction,
+      IWorktreeGuardedBranchAction {
 
   @Override
   protected boolean isSideEffecting() {
@@ -68,20 +65,14 @@ public abstract class BaseSyncToParentByMergeAction extends BaseGitMacheteReposi
       presentation.setText(getString("action.GitMachete.BaseSyncToParentByMergeAction.text"));
     }
 
-    if (!presentation.isEnabledAndVisible() || branchName == null) {
+    if (!presentation.isEnabledAndVisible()) {
       return;
     }
-    val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
-    if (worktreeRootHoldingBranch != null) {
-      // Merging parent into a non-current branch first checks the child out into the active worktree
-      // (see doMergeIntoNonCurrentBranch); git refuses if the branch is held elsewhere. The branch
-      // cannot be `current` here either - dual checkout of the same branch is prohibited - so the
-      // checked-out-elsewhere path is the only one that matters.
-      presentation.setEnabled(false);
-      presentation.setDescription(
-          getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
-              .fmt(branchName, worktreeRootHoldingBranch.toString()));
-    }
+    // Merging parent into a non-current branch first checks the child out into the active worktree
+    // (see doMergeIntoNonCurrentBranch); git refuses if the branch is held elsewhere. The branch
+    // cannot be `current` here either - dual checkout of the same branch is prohibited - so the
+    // checked-out-elsewhere path is the only one that matters.
+    disableIfBranchHeldByOtherWorktree(anActionEvent, branchName);
   }
 
   @Override

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSyncToParentByRebaseAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseSyncToParentByRebaseAction.java
@@ -14,7 +14,6 @@ import org.checkerframework.checker.guieffect.qual.UIEffect;
 
 import com.virtuslab.gitmachete.backend.api.INonRootManagedBranchSnapshot;
 import com.virtuslab.gitmachete.frontend.actions.backgroundables.RebaseOnParentBackgroundable;
-import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
 import com.virtuslab.gitmachete.frontend.defs.ActionPlaces;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.async.ContinuesInBackground;
@@ -23,7 +22,7 @@ import com.virtuslab.qual.async.ContinuesInBackground;
 public abstract class BaseSyncToParentByRebaseAction extends BaseGitMacheteRepositoryReadyAction
     implements
       IBranchNameProvider,
-      IExpectsKeyGitMacheteRepository {
+      IWorktreeGuardedBranchAction {
 
   @Override
   protected boolean isSideEffecting() {
@@ -94,15 +93,9 @@ public abstract class BaseSyncToParentByRebaseAction extends BaseGitMacheteRepos
       } else if (branch.isNonRoot()) {
         val nonRootBranch = branch.asNonRoot();
         val upstream = nonRootBranch.getParent();
-        val worktreeRootHoldingBranch = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
-        if (worktreeRootHoldingBranch != null) {
-          // Rebase-onto-parent checks out the branch into the active worktree before invoking rebase; git
-          // refuses if the branch is held elsewhere.
-          presentation.setEnabled(false);
-          presentation.setDescription(
-              getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
-                  .fmt(branch.getName(), worktreeRootHoldingBranch.toString()));
-        } else {
+        // Rebase-onto-parent checks out the branch into the active worktree before invoking rebase; git
+        // refuses if the branch is held elsewhere.
+        if (!disableIfBranchHeldByOtherWorktree(anActionEvent, branchName)) {
           presentation.setDescription(getNonHtmlString("action.GitMachete.BaseSyncToParentByRebaseAction.description")
               .fmt(branch.getName(), upstream.getName()));
         }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IWorktreeGuardedBranchAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/IWorktreeGuardedBranchAction.java
@@ -1,0 +1,76 @@
+package com.virtuslab.gitmachete.frontend.actions.base;
+
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
+
+import java.nio.file.Path;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import lombok.experimental.ExtensionMethod;
+import lombok.val;
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeyGitMacheteRepository;
+import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
+
+/**
+ * Mixin for actions whose underlying git operation either moves the branch ref (e.g. pull, reset,
+ * rebase-onto-parent, fast-forward merge) or first checks the branch out (e.g. checkout, squash,
+ * merge-from-parent into a non-current child). Git refuses any such operation when the target
+ * branch is already checked out in another worktree, so these actions need an up-front guard that
+ * disables them with a uniform "branch held by another worktree" tooltip rather than letting the
+ * user discover the failure through a side-effecting error.
+ *
+ * <p>Mirrors {@link ISyncToParentStatusDependentAction} / {@link ISyncToRemoteStatusDependentAction}
+ * in shape: a default helper that mutates the {@link AnActionEvent}'s presentation in-place. Unlike
+ * those two, the branch name is passed explicitly (not pulled via {@link IBranchNameProvider}),
+ * because {@code BaseCheckoutAction} sources it from a different data key.
+ */
+@ExtensionMethod(GitMacheteBundle.class)
+public interface IWorktreeGuardedBranchAction extends IExpectsKeyGitMacheteRepository {
+
+  /**
+   * @return the absolute root of an <i>other</i> worktree currently holding {@code branchName} checked out, or
+   *         {@code null} if no other worktree holds it (or the branch is not managed). "Other" means a
+   *         worktree different from the one the enclosing snapshot was built against. Both paths are already
+   *         canonicalized at snapshot creation time, so a plain {@link Path#equals} comparison is sufficient.
+   */
+  default @Nullable Path getWorktreeRootHoldingBranchIfHeldElsewhere(
+      AnActionEvent anActionEvent, @Nullable String branchName) {
+    val snapshot = getGitMacheteRepositorySnapshot(anActionEvent);
+    val branch = getManagedBranchByName(anActionEvent, branchName);
+    if (snapshot == null || branch == null) {
+      return null;
+    }
+    val holder = branch.getWorktreeRootHoldingBranch();
+    if (holder == null || holder.equals(snapshot.getRootDirectoryPath())) {
+      return null;
+    }
+    return holder;
+  }
+
+  /**
+   * Disables the action's presentation with the standard "branch held by another worktree" tooltip
+   * iff {@code branchName} is held by some other worktree. Otherwise leaves the presentation
+   * untouched.
+   *
+   * @return {@code true} iff the presentation was disabled, so callers in an if-else chain can
+   *         short-circuit cleanly (mirrors the {@code BaseSquashAction} usage shape).
+   */
+  @UIEffect
+  default boolean disableIfBranchHeldByOtherWorktree(AnActionEvent anActionEvent, @Nullable String branchName) {
+    if (branchName == null) {
+      return false;
+    }
+    val holder = getWorktreeRootHoldingBranchIfHeldElsewhere(anActionEvent, branchName);
+    if (holder == null) {
+      return false;
+    }
+    val presentation = anActionEvent.getPresentation();
+    presentation.setEnabled(false);
+    presentation.setDescription(
+        getNonHtmlString("action.GitMachete.description.disabled.branch-held-by-other-worktree")
+            .fmt(branchName, holder.toString()));
+    return true;
+  }
+}

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/expectedkeys/IExpectsKeyGitMacheteRepository.java
@@ -1,7 +1,5 @@
 package com.virtuslab.gitmachete.frontend.actions.expectedkeys;
 
-import java.nio.file.Path;
-
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import lombok.val;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -55,27 +53,5 @@ public interface IExpectsKeyGitMacheteRepository extends IWithLogger {
       log().warn(branchName + " Git Machete branch is undefined");
     }
     return branch;
-  }
-
-  /**
-   * @return the absolute root of an <i>other</i> worktree currently holding {@code branchName} checked out, or
-   *         {@code null} if no other worktree holds it (or the branch is not managed). "Other" means a
-   *         worktree different from the one the enclosing snapshot was built against. Both paths are already
-   *         canonicalized at snapshot creation time, so a plain {@link Path#equals} comparison is sufficient.
-   *         Surfacing this from the action layer lets every checkout-like action share the same up-front
-   *         guard, since git will refuse any operation that tries to switch HEAD to a branch already held
-   *         elsewhere.
-   */
-  default @Nullable Path getWorktreeRootHoldingBranchIfHeldElsewhere(AnActionEvent anActionEvent, @Nullable String branchName) {
-    val snapshot = getGitMacheteRepositorySnapshot(anActionEvent);
-    val branch = getManagedBranchByName(anActionEvent, branchName);
-    if (snapshot == null || branch == null) {
-      return null;
-    }
-    val holder = branch.getWorktreeRootHoldingBranch();
-    if (holder == null || holder.equals(snapshot.getRootDirectoryPath())) {
-      return null;
-    }
-    return holder;
   }
 }


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2306

## Chain of upstream PRs as of 2026-06-02

* PR #2306:
  `master` ← `develop`

  * **PR #2308 (THIS ONE)**:
    `develop` ← `refactor/wt-guarded-branch-action`

<!-- end git-machete generated -->
