### PR TITLE
Drop `BaseCheckoutAction.getTargetBranchName` in favor of `getNameOfBranchUnderAction`

### DIFF
--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseCheckoutAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/base/BaseCheckoutAction.java
@@ -9,7 +9,6 @@ import git4idea.branch.GitBrancher;
 import lombok.experimental.ExtensionMethod;
 import lombok.val;
 import org.checkerframework.checker.guieffect.qual.UIEffect;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
@@ -20,13 +19,12 @@ import com.virtuslab.qual.async.ContinuesInBackground;
 @ExtensionMethod({GitVfsUtils.class, GitMacheteBundle.class})
 public abstract class BaseCheckoutAction extends BaseGitMacheteRepositoryReadyAction
     implements
+      IBranchNameProvider,
       IExpectsKeySelectedBranchName {
   @Override
   protected boolean isSideEffecting() {
     return true;
   }
-
-  protected abstract @Nullable String getTargetBranchName(AnActionEvent anActionEvent);
 
   protected abstract @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent);
 
@@ -40,7 +38,7 @@ public abstract class BaseCheckoutAction extends BaseGitMacheteRepositoryReadyAc
       return;
     }
 
-    val targetBranchName = getTargetBranchName(anActionEvent);
+    val targetBranchName = getNameOfBranchUnderAction(anActionEvent);
 
     // It's very unlikely that targetBranchName is empty at this point since it's assigned directly before invoking this
     // action in EnhancedGraphTable.EnhancedGraphTableMouseAdapter#mouseClicked; still, it's better to be safe.
@@ -80,7 +78,7 @@ public abstract class BaseCheckoutAction extends BaseGitMacheteRepositoryReadyAc
   @ContinuesInBackground
   @UIEffect
   public void actionPerformed(AnActionEvent anActionEvent) {
-    val targetBranchName = getTargetBranchName(anActionEvent);
+    val targetBranchName = getNameOfBranchUnderAction(anActionEvent);
     if (targetBranchName == null || targetBranchName.isEmpty()) {
       return;
     }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/contextmenu/CheckoutSelectedAction.java
@@ -10,15 +10,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
-import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.gitmachete.frontend.vfsutils.GitVfsUtils;
 
 @ExtensionMethod({GitVfsUtils.class, GitMacheteBundle.class})
 @CustomLog
-public class CheckoutSelectedAction extends BaseCheckoutAction
-    implements
-      IExpectsKeySelectedBranchName {
+public class CheckoutSelectedAction extends BaseCheckoutAction {
 
   @Override
   public LambdaLogger log() {
@@ -26,7 +23,7 @@ public class CheckoutSelectedAction extends BaseCheckoutAction
   }
 
   @Override
-  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+  public @Nullable String getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
     return getSelectedBranchName(anActionEvent);
   }
 

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutFirstChildAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutFirstChildAction.java
@@ -11,14 +11,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
-import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
 @CustomLog
 @ExtensionMethod(GitMacheteBundle.class)
-public class CheckoutFirstChildAction extends BaseCheckoutAction
-    implements
-      IExpectsKeySelectedBranchName {
+public class CheckoutFirstChildAction extends BaseCheckoutAction {
 
   @Override
   protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
@@ -29,7 +26,7 @@ public class CheckoutFirstChildAction extends BaseCheckoutAction
   }
 
   @Override
-  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+  public @Nullable String getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
     val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
     val currentBranch = getManagedBranchByName(anActionEvent, currentBranchName);
     if (currentBranch != null) {

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutNextAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutNextAction.java
@@ -11,14 +11,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
-import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
 @CustomLog
 @ExtensionMethod(GitMacheteBundle.class)
-public class CheckoutNextAction extends BaseCheckoutAction
-    implements
-      IExpectsKeySelectedBranchName {
+public class CheckoutNextAction extends BaseCheckoutAction {
 
   @Override
   protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
@@ -29,7 +26,7 @@ public class CheckoutNextAction extends BaseCheckoutAction
   }
 
   @Override
-  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+  public @Nullable String getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
     val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
     val branchLayout = getBranchLayout(anActionEvent);
     if (branchLayout != null && currentBranchName != null) {

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutParentAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutParentAction.java
@@ -11,14 +11,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
-import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
 @CustomLog
 @ExtensionMethod(GitMacheteBundle.class)
-public class CheckoutParentAction extends BaseCheckoutAction
-    implements
-      IExpectsKeySelectedBranchName {
+public class CheckoutParentAction extends BaseCheckoutAction {
 
   @Override
   protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
@@ -29,7 +26,7 @@ public class CheckoutParentAction extends BaseCheckoutAction
   }
 
   @Override
-  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+  public @Nullable String getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
     val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
     val currentBranch = getManagedBranchByName(anActionEvent, currentBranchName);
     if (currentBranch != null && currentBranch.isNonRoot()) {

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutPreviousAction.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/navigation/CheckoutPreviousAction.java
@@ -11,14 +11,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 import com.virtuslab.gitmachete.frontend.actions.base.BaseCheckoutAction;
-import com.virtuslab.gitmachete.frontend.actions.expectedkeys.IExpectsKeySelectedBranchName;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
 @CustomLog
 @ExtensionMethod(GitMacheteBundle.class)
-public class CheckoutPreviousAction extends BaseCheckoutAction
-    implements
-      IExpectsKeySelectedBranchName {
+public class CheckoutPreviousAction extends BaseCheckoutAction {
 
   @Override
   protected @Untainted String getNonExistentBranchMessage(AnActionEvent anActionEvent) {
@@ -29,7 +26,7 @@ public class CheckoutPreviousAction extends BaseCheckoutAction
   }
 
   @Override
-  protected @Nullable String getTargetBranchName(AnActionEvent anActionEvent) {
+  public @Nullable String getNameOfBranchUnderAction(AnActionEvent anActionEvent) {
     val currentBranchName = getCurrentBranchNameIfManaged(anActionEvent);
     val branchLayout = getBranchLayout(anActionEvent);
     if (branchLayout != null && currentBranchName != null) {


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2306

## Chain of upstream PRs as of 2026-06-02

* PR #2306:
  `master` ← `develop`

  * **PR #2309 (THIS ONE)**:
    `develop` ← `refactor/unify-getTargetBranchName`

<!-- end git-machete generated -->
