### PR TITLE
Drop usages of internal IntelliJ APIs flagged by Marketplace verifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,15 @@ jobs:
       - run:
           name: Verify binary compatibility with supported IntelliJ versions
           command: ./gradlew verifyPlugin
+      # Upload the entire reports tree (Gradle's `problems/` report + per-IDE
+      # `pluginVerifier/` reports, with their CSS/JS assets) so the violation
+      # details are inspectable from the CircleCI run page even when the build
+      # is red. Runs unconditionally - `store_artifacts` silently skips a
+      # missing path, so a clean build (no reports generated) doesn't fail.
+      - store_artifacts:
+          path: build/reports/
+          destination: reports
+          when: always
 
       - when:
           condition:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,61 @@ Guidelines for AI coding agents working in this repository.
 - Do not add obvious, redundant comments that just restate the next line of
   code (e.g. `// Increment the counter` above `counter++`). Comments should
   carry information the code itself cannot convey.
+
+## Test code
+
+- Assert on the *full* output rather than substring presence.
+  Compare the whole rendering with an equality assertion (e.g.
+  `assertEquals(expectedOutput, actualOutput)`) so the entire output is
+  pinned down at once.
+  Avoid `assertThat(output).contains("<phrase>")` / "this phrase is not in
+  the output" checks for command-output testing - a substring match silently
+  tolerates stray extra lines, misordered sections, the same phrase landing
+  on the wrong row, or new (unintended) labels appearing elsewhere, all of
+  which a full-output equality assertion would catch on the first run.
+  Exception: substring checks are legitimate when the asserted invariant is
+  genuinely scoped to one fragment of the output (e.g. "this warning text
+  appears somewhere") and the rest of the output is either non-deterministic
+  or already covered by another test.
+- Don't add code comments that narrate test-harness internals or explain why
+  an assertion's expected value was massaged to match the harness's output
+  (e.g. "the harness lower-cases this, so we compare against lower-case",
+  "the formatter strips trailing whitespace, so the expected string omits
+  it", etc.).
+  If the actual and expected values match, the assertion already documents
+  itself; if they don't, fix the production code or the harness, don't
+  annotate the workaround.
+  This generalizes the broader code-comments rule: avoid comments that
+  exist solely to justify a specific literal in a test - the test name and
+  the assertion are the contract.
+
+## Git
+
+- Don't `git commit` or `git push` unless explicitly asked.
+
+## Formatting
+
+- No trailing whitespace on any line.
+  (Enforced by `scripts/prohibit-trailing-whitespace`.)
+- Always leave a single newline at the end of every file.
+  (Enforced by `scripts/enforce-newline-at-eof`.)
+- Always use American English spelling (`color`, `behavior`, `honor`,
+  `organize`, `modeled`, `normalized`, `unrecognized`, ...) - never the
+  British variants (`colour`, `behaviour`, `honour`, `organise`, `modelled`,
+  `normalised`, `unrecognised`, ...).
+  Applies to code, identifiers, comments, Javadoc/KDoc, Markdown, commit
+  messages and PR descriptions.
+- Don't hard-wrap prose (code comments, Javadoc/KDoc, Markdown, commit
+  messages, PR descriptions) at 80 or so columns.
+  Break on sentence or clause boundaries instead, so each line carries one
+  thought rather than a fragment chopped by column count.
+  Prefer one sentence per line; for a sentence that exceeds the project's
+  line-length limit, split at a natural clause boundary (semicolons,
+  parentheticals, conjunctions, ...).
+- This matters especially for PR descriptions (and commit message bodies):
+  never insert mid-sentence line breaks at a fixed column.
+  Write them in natural flow - one sentence per line, exactly like code
+  comments - and let GitHub / the git client wrap them for display.
+  Note that a PR opened from a single commit inherits that commit's message
+  verbatim, so a hard-wrapped commit body produces a hard-wrapped PR
+  description; keep the commit body unwrapped too.

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v8.0.1
+- Fixed: compatibility issues with IntelliJ 2026.2
 
 ## v8.0.0
 - Added: support for IntelliJ 2026.2.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,6 +257,35 @@ group = "com.virtuslab"
 
 configureVersionFromGit()
 
+// Bake the plugin version into a `com.virtuslab.gitmachete.BuildInfo` constant. The generation
+// lives at the root because the version itself is a project-wide concern - any subproject that
+// needs it just wires the output of this task into its own source set (see e.g. `:frontend:base`).
+// This avoids the alternative of querying the IDE at runtime via `PluginManager`, whose every
+// relevant accessor is flagged internal by Marketplace verifier.
+val generatedVersionSourceDir = layout.buildDirectory.dir("generated/sources/version/java/main")
+
+tasks.register("generatePluginVersionSource") {
+  val pluginVersion = version.toString()
+  inputs.property("pluginVersion", pluginVersion)
+  outputs.dir(generatedVersionSourceDir)
+  doLast {
+    val pkgDir = generatedVersionSourceDir.get().asFile.resolve("com/virtuslab/gitmachete")
+    pkgDir.mkdirs()
+    pkgDir.resolve("BuildInfo.java").writeText(
+      """
+        |package com.virtuslab.gitmachete;
+        |
+        |public final class BuildInfo {
+        |  public static final String PLUGIN_VERSION = "$pluginVersion";
+        |
+        |  private BuildInfo() {}
+        |}
+        |
+      """.trimMargin(),
+    )
+  }
+}
+
 repositories {
   standardMavenRepositories()
   intellijPlatform {
@@ -434,6 +463,7 @@ intellijPlatform {
     failureLevel.set(
       setOf(
         VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+        VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
         VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
         VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
         VerifyPluginTask.FailureLevel.MISSING_DEPENDENCIES,

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/GitCommandUpdatingCurrentBranchBackgroundable.java
@@ -2,38 +2,24 @@ package com.virtuslab.gitmachete.frontend.actions.backgroundables;
 
 import static com.intellij.notification.NotificationType.INFORMATION;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-import static git4idea.GitNotificationIdsHolder.LOCAL_CHANGES_DETECTED;
 import static git4idea.commands.GitLocalChangesWouldBeOverwrittenDetector.Operation.MERGE;
 import static git4idea.update.GitUpdateSessionKt.getBodyForUpdateNotification;
 import static git4idea.update.GitUpdateSessionKt.getTitleForUpdateNotification;
 
 import com.intellij.dvcs.DvcsUtil;
-import com.intellij.history.Label;
-import com.intellij.history.LocalHistory;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationAction;
 import com.intellij.openapi.application.AccessToken;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vcs.VcsNotifier;
-import com.intellij.openapi.vcs.ex.ProjectLevelVcsManagerEx;
-import com.intellij.openapi.vcs.update.AbstractCommonUpdateAction;
-import com.intellij.openapi.vcs.update.ActionInfo;
-import com.intellij.openapi.vcs.update.UpdatedFiles;
 import com.intellij.openapi.vfs.VfsUtil;
-import com.intellij.util.ModalityUiUtil;
-import com.intellij.vcs.ViewUpdateInfoNotification;
 import git4idea.GitBranch;
-import git4idea.GitRevisionNumber;
-import git4idea.GitVcs;
 import git4idea.branch.GitBranchPair;
 import git4idea.commands.Git;
 import git4idea.commands.GitCommandResult;
 import git4idea.commands.GitLineHandler;
 import git4idea.commands.GitLocalChangesWouldBeOverwrittenDetector;
 import git4idea.commands.GitUntrackedFilesOverwrittenByOperationDetector;
-import git4idea.merge.MergeChangeCollector;
 import git4idea.repo.GitRepository;
 import git4idea.update.GitUpdateInfoAsLog;
 import git4idea.update.GitUpdatedRanges;
@@ -41,8 +27,6 @@ import git4idea.util.GitUntrackedFilesHelper;
 import git4idea.util.LocalChangesWouldBeOverwrittenHelper;
 import kr.pe.kwonnam.slf4jlambda.LambdaLogger;
 import lombok.val;
-import org.checkerframework.checker.guieffect.qual.UI;
-import org.checkerframework.checker.guieffect.qual.UIEffect;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.tainting.qual.Untainted;
@@ -51,6 +35,13 @@ import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends SideEffectingBackgroundable {
+
+  // Plugin-owned notification display-id passed to LocalChangesWouldBeOverwrittenHelper.
+  // The id only feeds notification settings/telemetry bookkeeping (Settings -> Notifications grouping
+  // and FUS) - it's not part of the notification's title, body, severity or actions, so picking a
+  // plugin-namespaced value keeps the user-facing behavior identical while leaving the plugin fully
+  // decoupled from git4idea's internal id naming.
+  public static final String LOCAL_CHANGES_DETECTED_DISPLAY_ID = "git-machete.local-changes-detected";
 
   protected final GitRepository gitRepository;
 
@@ -85,23 +76,11 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Side
     handler.addLineListener(localChangesDetector);
     handler.addLineListener(untrackedFilesDetector);
 
-    Label beforeLabel = LocalHistory.getInstance().putSystemLabel(project, /* name */ "Before update");
-
     GitUpdatedRanges updatedRanges = deriveGitUpdatedRanges(getTargetBranchName());
 
-    String beforeRevision = gitRepository.getCurrentRevision();
     try (AccessToken ignore = DvcsUtil.workingTreeChangeStarted(project, getOperationName())) {
       GitCommandResult result = Git.getInstance().runCommand(handler);
-
-      if (beforeRevision != null) {
-        GitRevisionNumber currentRev = new GitRevisionNumber(beforeRevision);
-        handleResult(result,
-            localChangesDetector,
-            untrackedFilesDetector,
-            currentRev,
-            beforeLabel,
-            updatedRanges);
-      }
+      handleResult(result, localChangesDetector, untrackedFilesDetector, updatedRanges);
     }
   }
 
@@ -127,16 +106,15 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Side
       GitCommandResult result,
       GitLocalChangesWouldBeOverwrittenDetector localChangesDetector,
       GitUntrackedFilesOverwrittenByOperationDetector untrackedFilesDetector,
-      GitRevisionNumber currentRev,
-      Label beforeLabel,
       @Nullable GitUpdatedRanges updatedRanges) {
     val root = gitRepository.getRoot();
     if (result.success()) {
       VfsUtil.markDirtyAndRefresh(/* async */ false, /* recursive */ true, /* reloadChildren */ false, root);
       gitRepository.update();
-      if (updatedRanges != null &&
-          AbstractCommonUpdateAction
-              .showsCustomNotification(java.util.Collections.singletonList(GitVcs.getInstance(project)))) {
+      // updatedRanges is null only when the ref pair couldn't be assembled (detached HEAD, or the
+      // target branch is unknown to git4idea). In that edge case we skip the post-update notification
+      // entirely - the VFS refresh + repo update above are still enough to keep the UI consistent.
+      if (updatedRanges != null) {
         val ranges = updatedRanges.calcCurrentPositions();
         GitUpdateInfoAsLog.NotificationData notificationData = new GitUpdateInfoAsLog(project, ranges)
             .calculateDataAndCreateLogTab();
@@ -162,14 +140,11 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Side
               /* content */ "", INFORMATION);
         }
         VcsNotifier.getInstance(project).notify(notification);
-
-      } else {
-        showUpdates(currentRev, beforeLabel);
       }
 
     } else if (localChangesDetector.wasMessageDetected()) {
       LocalChangesWouldBeOverwrittenHelper.showErrorNotification(project,
-          LOCAL_CHANGES_DETECTED,
+          LOCAL_CHANGES_DETECTED_DISPLAY_ID,
           gitRepository.getRoot(),
           getOperationName(),
           localChangesDetector.getRelativeFilePaths());
@@ -189,33 +164,6 @@ public abstract class GitCommandUpdatingCurrentBranchBackgroundable extends Side
               getOperationName()),
           result.getErrorOutputAsJoinedString());
       gitRepository.update();
-    }
-  }
-
-  @UIThreadUnsafe
-  private void showUpdates(GitRevisionNumber currentRev, Label beforeLabel) {
-    String operationName = GitCommandUpdatingCurrentBranchBackgroundable.this.getOperationName();
-    try {
-      UpdatedFiles files = UpdatedFiles.create();
-
-      val collector = new MergeChangeCollector(project, gitRepository, currentRev);
-      collector.collect(files);
-
-      ModalityUiUtil.invokeLaterIfNeeded(ModalityState.defaultModalityState(), new @UI Runnable() {
-        @Override
-        @UIEffect
-        public void run() {
-          val manager = ProjectLevelVcsManagerEx.getInstanceEx(project);
-          val tree = manager.showUpdateProjectInfo(files, operationName, ActionInfo.UPDATE, /* canceled */ false);
-          if (tree != null) {
-            tree.setBefore(beforeLabel);
-            tree.setAfter(LocalHistory.getInstance().putSystemLabel(project, /* name */ "After update"));
-            ViewUpdateInfoNotification.focusUpdateInfoTree(project, tree);
-          }
-        }
-      });
-    } catch (VcsException e) {
-      GitVcs.getInstance(project).showErrors(java.util.Collections.singletonList(e), operationName);
     }
   }
 }

--- a/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/ResetCurrentToRemoteBackgroundable.java
+++ b/frontend/actions/src/main/java/com/virtuslab/gitmachete/frontend/actions/backgroundables/ResetCurrentToRemoteBackgroundable.java
@@ -1,9 +1,9 @@
 package com.virtuslab.gitmachete.frontend.actions.backgroundables;
 
+import static com.virtuslab.gitmachete.frontend.actions.backgroundables.GitCommandUpdatingCurrentBranchBackgroundable.LOCAL_CHANGES_DETECTED_DISPLAY_ID;
 import static com.virtuslab.gitmachete.frontend.actions.base.BaseResetToRemoteAction.VCS_NOTIFIER_TITLE;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getNonHtmlString;
 import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
-import static git4idea.GitNotificationIdsHolder.LOCAL_CHANGES_DETECTED;
 import static git4idea.commands.GitLocalChangesWouldBeOverwrittenDetector.Operation.RESET;
 
 import com.intellij.dvcs.DvcsUtil;
@@ -72,7 +72,7 @@ public class ResetCurrentToRemoteBackgroundable extends SideEffectingBackgrounda
 
         } else if (localChangesDetector.wasMessageDetected()) {
           LocalChangesWouldBeOverwrittenHelper.showErrorNotification(project,
-              LOCAL_CHANGES_DETECTED,
+              LOCAL_CHANGES_DETECTED_DISPLAY_ID,
               gitRepository.getRoot(),
               /* operationName */ "Reset",
               localChangesDetector.getRelativeFilePaths());

--- a/frontend/base/build.gradle.kts
+++ b/frontend/base/build.gradle.kts
@@ -10,3 +10,16 @@ junit()
 lombok()
 slf4jLambdaApi()
 vavr()
+
+// Pull in the version constant baked at build time by the root project, so `PlatformInfoProvider`
+// in the error reporter can include it in bug reports without hitting any internal IDE accessor.
+sourceSets["main"].java.srcDir(rootProject.tasks.named("generatePluginVersionSource"))
+
+// Restrict Spotless to project-local sources; the wiring above pulls in a generated source
+// directory under the root project's `build/`, and Spotless's safety check rejects targets
+// outside the project dir before any `targetExclude` pattern can take effect.
+spotless {
+  java {
+    target("src/**/*.java")
+  }
+}

--- a/frontend/base/src/main/java/com/virtuslab/gitmachete/frontend/errorreport/PlatformInfoProvider.java
+++ b/frontend/base/src/main/java/com/virtuslab/gitmachete/frontend/errorreport/PlatformInfoProvider.java
@@ -1,11 +1,10 @@
 package com.virtuslab.gitmachete.frontend.errorreport;
 
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.application.ApplicationInfo;
-import com.intellij.openapi.extensions.PluginId;
 import org.apache.commons.lang3.SystemUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import com.virtuslab.gitmachete.BuildInfo;
 
 class PlatformInfoProvider {
   @Nullable
@@ -24,7 +23,9 @@ class PlatformInfoProvider {
 
   @Nullable
   String getPluginVersion() {
-    IdeaPluginDescriptor pluginDescriptor = PluginManagerCore.getPlugin(PluginId.getId("com.virtuslab.git-machete"));
-    return pluginDescriptor != null ? pluginDescriptor.getVersion() : null;
+    // Baked in at build time by the `generatePluginVersionSource` Gradle task,
+    // so we don't need to query the IDE's plugin manager (all relevant accessors
+    // there are flagged internal by IntelliJ compatibility verifier).
+    return BuildInfo.PLUGIN_VERSION;
   }
 }

--- a/src/test/java/com/virtuslab/archunit/ClassStructureTestSuite.java
+++ b/src/test/java/com/virtuslab/archunit/ClassStructureTestSuite.java
@@ -132,6 +132,9 @@ public class ClassStructureTestSuite extends BaseArchUnitTestSuite {
         .and().doNotBelongToAnyOf(classesReferencedFromPluginXmlAttributes)
         // SubtypingBottom is processed by CheckerFramework based on its annotations
         .and().doNotHaveFullyQualifiedName(com.virtuslab.qual.subtyping.internal.SubtypingBottom.class.getName())
+        // BuildInfo.PLUGIN_VERSION is a compile-time String constant (JLS 13.1) that javac inlines
+        // into every consumer's constant pool, so the consumer's bytecode never names BuildInfo.
+        .and().doNotHaveFullyQualifiedName(com.virtuslab.gitmachete.BuildInfo.class.getName())
         .should(new BeReferencedFromOutsideItself())
         .check(productionClasses);
   }


### PR DESCRIPTION
Both flagged classes are class-level `@ApiStatus.Internal` in IU-262 (the
first IntelliJ version this plugin supports where they became internal),
which is why v8.0.0 was rejected by the Marketplace despite passing CI.

- Replace `git4idea.GitNotificationIdsHolder.LOCAL_CHANGES_DETECTED` with
  a plugin-owned notification display-id constant. The id only feeds
  `Settings -> Notifications` grouping and FUS, not user-visible behavior,
  so a plugin-namespaced value keeps the notification identical while
  fully decoupling from git4idea's internal id naming.
- Stop calling `AbstractCommonUpdateAction.showsCustomNotification(...)`:
  unconditionally use the `GitUpdateInfoAsLog` notification branch (this
  is what modern git4idea returns for `GitVcs` anyway) and drop the now
  unreachable legacy update-info-tree fallback, along with its
  `LocalHistory` / `MergeChangeCollector` / `ProjectLevelVcsManagerEx`
  plumbing.
- Add `INTERNAL_API_USAGES` to `verifyPlugin`'s `failureLevel` so the
  next internal-API slip-up fails CI instead of being caught only at
  Marketplace review time.