### PR TITLE
Rebuild SlideInDialog on the Kotlin UI DSL instead of MigLayout

### DIFF
--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/SlideInDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/SlideInDialog.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.MutableCollectionComboBoxModel
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.util.ui.JBUI
 import com.virtuslab.branchlayout.api.BranchLayout
 import com.virtuslab.branchlayout.api.BranchLayoutEntry
 import com.virtuslab.gitmachete.frontend.actions.common.SlideInOptions
@@ -55,10 +56,14 @@ class SlideInDialog(
       cell(JLabel("<html><b>${escapeHtml4(parentName)}</b></html>"))
     }
     row(getString("action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.label.branch-name")) {
-      cell(branchField).align(AlignX.FILL)
+      cell(branchField)
+        .align(AlignX.FILL)
+        .applyToComponent { minimumSize = JBUI.size(MIN_VALUE_FIELD_WIDTH, 0) }
     }
     row(getString("action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.label.custom-annotation")) {
-      cell(customAnnotationField).align(AlignX.FILL)
+      cell(customAnnotationField)
+        .align(AlignX.FILL)
+        .applyToComponent { minimumSize = JBUI.size(MIN_VALUE_FIELD_WIDTH, 0) }
     }
     row("") {
       cell(reattachCheckbox)
@@ -185,5 +190,9 @@ class SlideInDialog(
 
   companion object {
     val LOG = logger<GitMergeDialog>()
+
+    // Unscaled; JBUI.size scales it. Keeps the value column from collapsing to the components'
+    // natural width once it's free to grow with the dialog (align(AlignX.FILL)).
+    private const val MIN_VALUE_FIELD_WIDTH = 300
   }
 }

--- a/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/SlideInDialog.kt
+++ b/frontend/actions/src/main/kotlin/com/virtuslab/gitmachete/frontend/actions/dialogs/SlideInDialog.kt
@@ -8,7 +8,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.MutableCollectionComboBoxModel
-import com.intellij.util.ui.JBUI
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.panel
 import com.virtuslab.branchlayout.api.BranchLayout
 import com.virtuslab.branchlayout.api.BranchLayoutEntry
 import com.virtuslab.gitmachete.frontend.actions.common.SlideInOptions
@@ -17,16 +18,11 @@ import git4idea.branch.GitBranchUtil
 import git4idea.merge.GitMergeDialog
 import git4idea.repo.GitRepository
 import git4idea.ui.ComboBoxWithAutoCompletion
-import net.miginfocom.swing.MigLayout
 import org.apache.commons.text.StringEscapeUtils.escapeHtml4
 import javax.swing.JCheckBox
 import javax.swing.JLabel
-import javax.swing.JPanel
 import javax.swing.JTextField
 import kotlin.apply
-import net.miginfocom.layout.AC as AxisConstraint
-import net.miginfocom.layout.CC as ComponentConstraint
-import net.miginfocom.layout.LC as LayoutConstraint
 
 /**
 * This class has been inspired by [git4idea.merge.GitMergeDialog].
@@ -54,8 +50,20 @@ class SlideInDialog(
 
   private val branchField = createBranchField()
   private val customAnnotationField = JTextField()
-  private val innerPanel = createInnerPanel()
-  private val panel = createPanel()
+  private val dialogPanel = panel {
+    row(getString("action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.label.parent")) {
+      cell(JLabel("<html><b>${escapeHtml4(parentName)}</b></html>"))
+    }
+    row(getString("action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.label.branch-name")) {
+      cell(branchField).align(AlignX.FILL)
+    }
+    row(getString("action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.label.custom-annotation")) {
+      cell(customAnnotationField).align(AlignX.FILL)
+    }
+    row("") {
+      cell(reattachCheckbox)
+    }
+  }
 
   init {
     title = getString("action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.title")
@@ -68,7 +76,7 @@ class SlideInDialog(
     rerender()
   }
 
-  override fun createCenterPanel() = panel
+  override fun createCenterPanel() = dialogPanel
 
   override fun getPreferredFocusedComponent() = branchField
 
@@ -135,58 +143,6 @@ class SlideInDialog(
     model?.update(branches)
 
     branchField.selectAll()
-  }
-
-  private fun createPanel() = JPanel().apply {
-    layout = MigLayout(LayoutConstraint().insets("0").hideMode(3), AxisConstraint().grow())
-
-    add(innerPanel, ComponentConstraint().growX())
-  }
-
-  private fun createInnerPanel(): JPanel = JPanel().apply {
-    layout =
-      MigLayout(
-        LayoutConstraint().fillX().insets("0").gridGap("0", "0").noVisualPadding(),
-        AxisConstraint().grow(100f, 1),
-      )
-
-    add(
-      JLabel(
-        getString(
-          "action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.label.parent",
-        ),
-      ),
-      ComponentConstraint().gapAfter("0").minWidth("${JBUI.scale(100)}px"),
-    )
-
-    add(
-      JLabel("<html><b>${escapeHtml4(parentName)}</b></html>"),
-      ComponentConstraint().minWidth("${JBUI.scale(300)}px").growX().wrap(),
-    )
-
-    add(
-      JLabel(
-        getString(
-          "action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.label.branch-name",
-        ),
-      ),
-      ComponentConstraint().gapAfter("0").minWidth("${JBUI.scale(100)}px"),
-    )
-
-    add(branchField, ComponentConstraint().minWidth("${JBUI.scale(300)}px").growX().wrap())
-
-    add(
-      JLabel(
-        getString(
-          "action.GitMachete.BaseSlideInBelowAction.dialog.slide-in.label.custom-annotation",
-        ),
-      ),
-      ComponentConstraint().gapAfter("0").minWidth("${JBUI.scale(100)}px"),
-    )
-
-    add(customAnnotationField, ComponentConstraint().minWidth("${JBUI.scale(300)}px").growX().wrap())
-
-    add(reattachCheckbox)
   }
 
   private fun createBranchField(): ComboBoxWithAutoCompletion<String> = ComboBoxWithAutoCompletion(MutableCollectionComboBoxModel(mutableListOf<String>()), project)

--- a/src/test/java/com/virtuslab/archunit/UIThreadUnsafeMethodInvocationsTestSuite.java
+++ b/src/test/java/com/virtuslab/archunit/UIThreadUnsafeMethodInvocationsTestSuite.java
@@ -157,6 +157,7 @@ public class UIThreadUnsafeMethodInvocationsTestSuite extends BaseArchUnitTestSu
       "git4idea.ui.ComboBoxWithAutoCompletion.getModel()",
       "git4idea.ui.ComboBoxWithAutoCompletion.getText()",
       "git4idea.ui.ComboBoxWithAutoCompletion.selectAll()",
+      "git4idea.ui.ComboBoxWithAutoCompletion.setMinimumSize(java.awt.Dimension)",
       "git4idea.ui.ComboBoxWithAutoCompletion.setPlaceholder(java.lang.String)",
       "git4idea.ui.ComboBoxWithAutoCompletion.setPrototypeDisplayValue(java.lang.Object)",
       "git4idea.ui.ComboBoxWithAutoCompletion.setUI(javax.swing.plaf.ComboBoxUI)",


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #2316

## Chain of upstream PRs as of 2026-06-06

* PR #2314:
  `develop` ← `fix/internal-apis`

  * PR #2315:
    `fix/internal-apis` ← `fix/bincompat-violations`

    * PR #2316:
      `fix/bincompat-violations` ← `refactor/1604-completion`

      * **PR #2317 (THIS ONE)**:
        `refactor/1604-completion` ← `refactor/slide-in-dialog`

<!-- end git-machete generated -->

Replace the two hand-built MigLayout panels with a declarative `panel { ... }` block, dropping the `net.miginfocom.*` constraint plumbing and the manual `JBUI.scale` column widths.
The field components, validation and slide-in options are unchanged; only the layout construction is modernized, so the dialog now picks up the platform's standard row spacing.