### PR TITLE
Collect JaCoCo coverage from unit tests and publish to Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,15 +146,17 @@ jobs:
       - run:
           name: Run unit & integration tests
           command: ./gradlew :buildSrc:test test
-      # Unfortunately, wildcards for test result paths aren't supported by CircleCI yet.
+      # `store_test_results` doesn't support globs (still true as of CircleCI docs 2026), so
+      # gather every subproject's JUnit XMLs into one staging dir first. This auto-tracks any
+      # new subprojects (and any new Test tasks beyond `test`) without needing CI edits.
+      - run:
+          name: Gather JUnit test result XMLs from every subproject
+          when: always
+          command: |
+            mkdir -p test-results/junit
+            find . -type f -regex '.*/build/test-results/.*\.xml' -exec cp {} test-results/junit/ \;
       - store_test_results:
-          path: branchLayout/impl/build/test-results/test/
-      - store_test_results:
-          path: backend/impl/build/test-results/test/
-      - store_test_results:
-          path: frontend/base/build/test-results/test/
-      - store_test_results:
-          path: build/test-results/
+          path: test-results
 
       - run:
           name: Build plugin artifact

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@6.0.0
+
 executors:
   ubuntu_executor:
     machine:
@@ -144,19 +147,28 @@ jobs:
           name: Compile tests
           command: ./gradlew testClasses
       - run:
-          name: Run unit & integration tests
-          command: ./gradlew :buildSrc:test test
+          name: Run unit & integration tests and generate coverage reports
+          command: ./gradlew :buildSrc:test test jacocoTestReport
       # `store_test_results` doesn't support globs (still true as of CircleCI docs 2026), so
       # gather every subproject's JUnit XMLs into one staging dir first. This auto-tracks any
       # new subprojects (and any new Test tasks beyond `test`) without needing CI edits.
+      # Gradle names each file `TEST-<fully-qualified-class-name>.xml` (one per test class), and
+      # every subproject in this repo uses a package prefix matching its module coordinates
+      # (`com.virtuslab.branchlayout.*`, `com.virtuslab.gitcore.*`, `com.virtuslab.gitmachete.backend.*`,
+      # ...), so two subprojects can't end up with the same FQN and a flat copy can't clobber files.
       - run:
           name: Gather JUnit test result XMLs from every subproject
           when: always
           command: |
             mkdir -p test-results/junit
-            find . -type f -regex '.*/build/test-results/.*\.xml' -exec cp {} test-results/junit/ \;
+            find . -type f -regex '.*/build/test-results/.*\.xml' -exec cp -v {} test-results/junit/ \;
       - store_test_results:
           path: test-results
+      # The Codecov uploader walks the working tree by default, picks up every subproject's
+      # `<sub>/build/reports/jacoco/test/jacocoTestReport.xml`, and merges them server-side by
+      # file path - no Gradle-side aggregation needed.
+      - codecov/upload:
+          flags: unit-tests
 
       - run:
           name: Build plugin artifact
@@ -170,14 +182,20 @@ jobs:
       - run:
           name: Verify binary compatibility with supported IntelliJ versions
           command: ./gradlew verifyPlugin
-      # Upload the entire reports tree (Gradle's `problems/` report + per-IDE
-      # `pluginVerifier/` reports, with their CSS/JS assets) so the violation
-      # details are inspectable from the CircleCI run page even when the build
-      # is red. Runs unconditionally - `store_artifacts` silently skips a
-      # missing path, so a clean build (no reports generated) doesn't fail.
+      # Upload only the `verifyPlugin`-related reports: Gradle's `problems/` summary and the
+      # per-IDE `pluginVerifier/` reports (with their CSS/JS assets), so the violation details
+      # are inspectable from the CircleCI run page even when the build is red. The sibling
+      # `build/reports/jacoco/` (uploaded to Codecov above) and `build/reports/tests/` (HTML
+      # mirror of the JUnit XMLs we already ship to `store_test_results`) are deliberately left
+      # out. Runs unconditionally - `store_artifacts` silently skips a missing path, so a clean
+      # build (no reports generated) doesn't fail.
       - store_artifacts:
-          path: build/reports/
-          destination: reports
+          path: build/reports/problems/
+          destination: reports/problems
+          when: always
+      - store_artifacts:
+          path: build/reports/pluginVerifier/
+          destination: reports/pluginVerifier
           when: always
 
       - when:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build/
 *.log
 /out/
 *.pem
+/test-results/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion as GradleKotlinVersion
 
 plugins {
   checkstyle
+  jacoco
   `java-library`
   alias(libs.plugins.jetbrains.changelog)
   alias(libs.plugins.jetbrains.intellij)
@@ -76,6 +77,13 @@ allprojects {
   }
 
   apply<JavaLibraryPlugin>()
+  apply<JacocoPlugin>()
+
+  // The `jacocoTestReport` task that JaCoCo plugin auto-creates per subproject only emits HTML
+  // by default; Codecov ingests JaCoCo XML, so flip XML on for every subproject's report.
+  tasks.withType<JacocoReport>().configureEach {
+    reports.xml.required.set(true)
+  }
 
   java {
     // Drives sourceCompatibility, targetCompatibility and `javac --release` in one place.


### PR DESCRIPTION
Sets up unit/integration test coverage reporting via Codecov, plus a couple of CI-side cleanups that the new coverage upload exposed.

## CI: gather JUnit XMLs from every subproject (#29abdd37)

CircleCI's `store_test_results` still doesn't accept globs (confirmed against the 2026 docs), so the previous setup hardcoded one `store_test_results` entry per subproject - and silently lost results from any subproject not on the list.
`branchLayout/api`, `gitCore/jGit`, `frontend/ui/impl`, `frontend/actions` and `buildSrc` were all being dropped.

Replace the four hardcoded paths with the official find+cp staging pattern from CircleCI's docs.
A single `*/build/test-results/*.xml` regex now picks up the results of every subproject's `test` task (and any future Test tasks beyond `test`) without further CI edits.
Gradle names each file `TEST-<fully-qualified-class-name>.xml` (one per test class) and every subproject uses a package prefix matching its module coordinates, so a flat copy can't clobber files.

## Coverage: JaCoCo + Codecov (#e509d82a)

Apply Gradle's built-in `jacoco` plugin to every subproject.
That plugin auto-attaches its agent to every `Test` task and registers a `jacocoTestReport` task per subproject, so no further build-side wiring is needed beyond flipping XML output on (Codecov ingests JaCoCo XML; HTML-only is the plugin's default).

In CI, append `jacocoTestReport` to the existing unit-test command and add a single `codecov/upload` step under the `unit-tests` flag.
The Codecov orb walks the working tree, picks up every subproject's `<sub>/build/reports/jacoco/test/jacocoTestReport.xml`, and merges them server-side by file path - no Gradle-side aggregation task or `codecov.yml` overrides needed for the regular-test layer.

Also scopes the existing `build/reports/` artifact upload (which previously grabbed the entire tree) down to just the two directories `verifyPlugin` actually produces - `problems/` and `pluginVerifier/` - since the sibling `jacoco/` is already on Codecov and `tests/` is just the HTML mirror of the JUnit XMLs we ship to `store_test_results`.
Adds `/test-results/` to `.gitignore` so the local CI staging dir can't accidentally be committed.

Toward #1060.