### PR TITLE
Declare GrammarKit generated sources as task outputs so they survive the build cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,12 +37,12 @@ commands:
           keys:
             # First, try finding a cache entry with the same set of libraries
             # that also comes from the same branch (so as to make the best use of Gradle compilation cache).
-            - gradle-deps-v13-{{ checksum "gradle/libs.versions.toml" }}-{{ .Branch }}
+            - gradle-deps-v14-{{ checksum "gradle/libs.versions.toml" }}-{{ .Branch }}
             # If the above key is not found, try finding a cache entry with the same set of libraries
             # coming from another branch (Gradle compilation cache might then be less useful).
-            - gradle-deps-v13-{{ checksum "gradle/libs.versions.toml" }}-
+            - gradle-deps-v14-{{ checksum "gradle/libs.versions.toml" }}-
             # As a last resort, take any available cache entry.
-            - gradle-deps-v13-
+            - gradle-deps-v14-
 
   reconfigure_origin_remote:
     steps:
@@ -216,7 +216,7 @@ jobs:
                   du -h -d3 ~/.gradle/ | sort -h
             - save_cache:
                 paths: [ ~/.gradle/ ]
-                key: gradle-deps-v13-{{ checksum "gradle/libs.versions.toml" }}-{{ .Branch }}
+                key: gradle-deps-v14-{{ checksum "gradle/libs.versions.toml" }}-{{ .Branch }}
 
   ui-tests-recent:
     executor: ubuntu_executor

--- a/frontend/file/build.gradle.kts
+++ b/frontend/file/build.gradle.kts
@@ -34,6 +34,12 @@ tasks {
     // The output layout (parser class location, PSI root) is derived from the .bnf file's
     // `parserClass` and `psiPackage` attributes, so no further configuration is needed here.
     targetRootOutputDir.set(file(generatedParserJavaSourcesRoot))
+    // `targetRootOutputDir` is `@Internal`; the task's only tracked outputs are the `@Optional` `@OutputFile`/`@OutputDirectory`
+    // derived from `pathToParser`/`pathToPsiRoot`, which we deliberately leave unset.
+    // With no output declared, Gradle tracks nothing here, so on a wiped `build/` (fresh CI checkout)
+    // the task reports UP-TO-DATE / FROM-CACHE yet restores no sources, breaking `compileJava`.
+    // Declaring the generated root as an output makes the task properly incremental and cacheable.
+    outputs.dir(generatedParserJavaSourcesRoot)
   }
 
   generateLexer {
@@ -42,6 +48,7 @@ tasks {
     sourceFile.set(file("$grammarSourcesRoot/Machete.flex"))
     // The output file is placed in a subdirectory matching the `package` declared in the .flex file.
     targetRootOutputDir.set(file(generatedLexerJavaSourcesRoot))
+    outputs.dir(generatedLexerJavaSourcesRoot)
   }
 
   compileJava {


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-07-23

* **PR #2336 (THIS ONE)**:
  `develop` ← `fix/lexer-parser-outputs`

    * PR #2334:
      `fix/lexer-parser-outputs` ← `dependabot/gradle/develop/deps-93debc5a78`

<!-- end git-machete generated -->

## Problem

`frontend:file:compileJava` fails intermittently in CI (never locally) with `cannot find symbol` for every `MacheteGenerated*` class, while `generateParser`/`generateLexer` report `FROM-CACHE`:

```
error: cannot find symbol
import com.virtuslab.gitmachete.frontend.file.grammar.MacheteGeneratedElementTypes;
```

## Root cause

The `org.jetbrains.intellij.platform.grammarkit` `generateParser`/`generateLexer` tasks track their outputs only through the `@Optional` `@OutputFile`/`@OutputDirectory` properties derived from `pathToParser`/`pathToPsiRoot`; `targetRootOutputDir`/`targetOutputDir` are `@Internal`.
We deliberately leave `pathToParser`/`pathToPsiRoot` unset and rely on the layout derived from the `.bnf`/`.flex` attributes, so Gradle ends up tracking **no outputs at all** for these tasks.

Consequently the build cache stores empty entries.
The first build on a new plugin version misses the cache and generates correctly (so it passes), but it stores a no-output entry; every later build that restores that entry gets `FROM-CACHE` with nothing on disk and fails to compile.
It never reproduces locally because `build/generated` persists between runs and keeps the tasks `UP-TO-DATE` with the files already on disk.

Reproduced deterministically:

```
rm -rf frontend/file/build/generated
./gradlew :frontend:file:generateParser :frontend:file:generateLexer   # both UP-TO-DATE, nothing regenerated
./gradlew :frontend:file:compileJava                                    # fails: cannot find symbol MacheteGenerated*
```

## Fix

- Declare the generated roots via `outputs.dir(...)` on both tasks, so Gradle tracks them for up-to-date checks and stores/restores them in the build cache.
- Bump the CircleCI cache key `gradle-deps-v13-` to `-v14-` (three restore keys + the save key) to evict the already-poisoned local Gradle build cache in one shot.

## Test plan

- [x] Reproduced the exact failure locally by wiping `build/generated` and rebuilding.
- [x] Verified the cache round-trip with the fix (store to cache -> `rm -rf build/generated` -> restore -> `compileJava`): `BUILD SUCCESSFUL`.
- [x] `spotlessKotlinGradleCheck` passes; no trailing whitespace.
- [ ] CI green on this branch.