### PR TITLE
Refresh Git repositories after .git deletion

### DIFF
--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v8.0.2
-- Fixed: removing a Git root's `.git` directory no longer causes an error.
+- Fixed: removing a Git root's `.git` directory no longer causes an error (contributed by @Guflly).
 
 ## v8.0.1
 - Fixed: compatibility issues with IntelliJ 2026.2

--- a/CHANGE-NOTES.md
+++ b/CHANGE-NOTES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v8.0.2
+- Fixed: removing a Git root's `.git` directory no longer causes an error.
 
 ## v8.0.1
 - Fixed: compatibility issues with IntelliJ 2026.2

--- a/frontend/base/src/main/resources/GitMacheteBundle.properties
+++ b/frontend/base/src/main/resources/GitMacheteBundle.properties
@@ -318,6 +318,12 @@ action.GitMachete.SlideOutSelectedAction.description=Slide out this branch
 string.GitMachete.error-report-submitter.report-action-text=Open Issue On GitHub
 
 
+# Git repository selection
+
+string.GitMachete.GitRepositoryComboBox.removed-git-root.notification.title=Git repository removed
+string.GitMachete.GitRepositoryComboBox.removed-git-root.notification.text=The Git directory for ''{0}'' no longer exists.
+
+
 # Graph Table
 
 string.GitMachete.BranchOrCommitCellRendererComponent.inferred-fork-point.commit=commit

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/gitrepositoryselection/GitRepositoryComboBox.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/gitrepositoryselection/GitRepositoryComboBox.java
@@ -1,5 +1,8 @@
 package com.virtuslab.gitmachete.frontend.ui.impl.gitrepositoryselection;
 
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.fmt;
+import static com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle.getString;
+
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JList;
@@ -11,11 +14,17 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.vcs.VcsNotifier;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.newvfs.BulkFileListener;
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.ui.ComboboxSpeedSearch;
 import com.intellij.ui.MutableCollectionComboBoxModel;
 import com.intellij.ui.SimpleListCellRenderer;
 import com.intellij.util.ModalityUiUtil;
 import com.intellij.util.SmartList;
+import com.intellij.util.messages.MessageBusConnection;
 import git4idea.GitUtil;
 import git4idea.repo.GitRepository;
 import io.vavr.collection.List;
@@ -47,13 +56,26 @@ public final class GitRepositoryComboBox extends JComboBox<GitRepository>
     setRenderer(new ShortRepositoryNameRenderer());
 
     val messageBusConnection = project.getMessageBus().connect();
+    subscribeToRepositoryChanges(messageBusConnection);
+    ComboboxSpeedSearch.installSpeedSearch(this, DvcsUtil::getShortRepositoryName);
+  }
+
+  private void subscribeToRepositoryChanges(MessageBusConnection messageBusConnection) {
     messageBusConnection
         .<VcsRepositoryMappingListener>subscribe(VcsRepositoryManager.VCS_REPOSITORY_MAPPING_UPDATED, () -> {
           LOG.debug("Git repository mappings changed");
           ModalityUiUtil.invokeLaterIfNeeded(ModalityState.nonModal(), () -> updateRepositories());
         });
+    messageBusConnection.subscribe(VirtualFileManager.VFS_CHANGES, new BulkFileListener() {
+      @Override
+      public void after(java.util.List<? extends VFileEvent> events) {
+        if (events.stream().anyMatch(GitRepositoryComboBox::isGitDirectoryDeletion)) {
+          LOG.debug("Git directory deleted");
+          ModalityUiUtil.invokeLaterIfNeeded(ModalityState.nonModal(), () -> updateRepositories());
+        }
+      }
+    });
     Disposer.register(this, messageBusConnection);
-    ComboboxSpeedSearch.installSpeedSearch(this, DvcsUtil::getShortRepositoryName);
   }
 
   @Override
@@ -64,7 +86,7 @@ public final class GitRepositoryComboBox extends JComboBox<GitRepository>
 
   @UIEffect
   private void updateRepositories() {
-    val repositories = List.ofAll(GitUtil.getRepositories(project));
+    val repositories = getAvailableRepositories(project);
     LOG.debug("Git repositories:");
     repositories.forEach(r -> LOG.debug("* ${r.getRoot().getName()}"));
 
@@ -72,6 +94,14 @@ public final class GitRepositoryComboBox extends JComboBox<GitRepository>
     // before `com.intellij.ui.MutableCollectionComboBoxModel.update`
     // because the update method sets the selected item to null
     val selected = getModel().getSelected();
+    if (selected != null && GitUtil.findGitDir(selected.getRoot()) == null) {
+      VcsNotifier.getInstance(project).notifyWarning(
+          /* displayId */ null,
+          getString("string.GitMachete.GitRepositoryComboBox.removed-git-root.notification.title"),
+          fmt(
+              getString("string.GitMachete.GitRepositoryComboBox.removed-git-root.notification.text"),
+              selected.getRoot().getPath()));
+    }
     if (!getModel().getItems().equals(repositories)) {
       getModel().update(DvcsUtil.sortRepositories(repositories.asJavaMutable()));
     }
@@ -92,6 +122,16 @@ public final class GitRepositoryComboBox extends JComboBox<GitRepository>
       // GitRepositoryComboBox#setSelectedItem is omitted to avoid unnecessary observers call
       getModel().setSelectedItem(selected);
     }
+  }
+
+  static List<GitRepository> getAvailableRepositories(Project project) {
+    return List.ofAll(GitUtil.getRepositories(project))
+        .filter(repository -> GitUtil.findGitDir(repository.getRoot()) != null);
+  }
+
+  static boolean isGitDirectoryDeletion(VFileEvent event) {
+    val file = event.getFile();
+    return event instanceof VFileDeleteEvent && file != null && file.getName().equals(".git");
   }
 
   @Override

--- a/frontend/ui/impl/src/test/java/com/virtuslab/gitmachete/frontend/ui/impl/gitrepositoryselection/GitRepositoryComboBoxTest.java
+++ b/frontend/ui/impl/src/test/java/com/virtuslab/gitmachete/frontend/ui/impl/gitrepositoryselection/GitRepositoryComboBoxTest.java
@@ -1,0 +1,67 @@
+package com.virtuslab.gitmachete.frontend.ui.impl.gitrepositoryselection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent;
+import git4idea.GitUtil;
+import git4idea.repo.GitRepository;
+import io.vavr.collection.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class GitRepositoryComboBoxTest {
+
+  @Test
+  public void availableRepositoriesExcludeRootsWithoutGitDirectory() {
+    Project project = mock(Project.class);
+    GitRepository availableRepository = mock(GitRepository.class);
+    GitRepository removedRepository = mock(GitRepository.class);
+    VirtualFile availableRoot = mock(VirtualFile.class);
+    VirtualFile removedRoot = mock(VirtualFile.class);
+    VirtualFile gitDirectory = mock(VirtualFile.class);
+
+    when(availableRepository.getRoot()).thenReturn(availableRoot);
+    when(removedRepository.getRoot()).thenReturn(removedRoot);
+
+    try (MockedStatic<GitUtil> gitUtil = mockStatic(GitUtil.class)) {
+      gitUtil.when(() -> GitUtil.getRepositories(project))
+          .thenReturn(Arrays.asList(availableRepository, removedRepository));
+      gitUtil.when(() -> GitUtil.findGitDir(availableRoot)).thenReturn(gitDirectory);
+      gitUtil.when(() -> GitUtil.findGitDir(removedRoot)).thenReturn(null);
+
+      assertEquals(
+          List.of(availableRepository),
+          GitRepositoryComboBox.getAvailableRepositories(project));
+    }
+  }
+
+  @Test
+  public void onlyGitDirectoryDeletionIsDetected() {
+    VirtualFile gitDirectory = mock(VirtualFile.class);
+    when(gitDirectory.getName()).thenReturn(".git");
+    VirtualFile otherDirectory = mock(VirtualFile.class);
+    when(otherDirectory.getName()).thenReturn("other");
+
+    VFileDeleteEvent deletion = mock(VFileDeleteEvent.class);
+    when(deletion.getFile()).thenReturn(gitDirectory);
+    VFileDeleteEvent otherDeletion = mock(VFileDeleteEvent.class);
+    when(otherDeletion.getFile()).thenReturn(otherDirectory);
+
+    VFileContentChangeEvent contentChange = mock(VFileContentChangeEvent.class);
+    when(contentChange.getFile()).thenReturn(gitDirectory);
+
+    assertTrue(GitRepositoryComboBox.isGitDirectoryDeletion(deletion));
+    assertFalse(GitRepositoryComboBox.isGitDirectoryDeletion(otherDeletion));
+    assertFalse(GitRepositoryComboBox.isGitDirectoryDeletion(contentChange));
+  }
+}


### PR DESCRIPTION
Refreshes the repository list when a `.git` directory is deleted, removes unavailable roots, and warns if the removed root was selected.

Tests:
- focused `GitRepositoryComboBox` tests (2 passed)
- Spotless
- relevant ArchUnit checks (10 passed)

Fixes #1856