### PR TITLE
Anchor Spotless targets at the project dir so input snapshotting stays cheap

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -66,14 +66,17 @@ spotless {
     "ktlint_standard_no-wildcard-imports" to "disabled",
   )
 
+  // Both targets are anchored at the project dir rather than starting with `**/`,
+  // so that Gradle can prune `build/` and IDE-managed output dirs while snapshotting these tasks' inputs
+  // instead of walking and pattern-matching the whole tree.
   kotlin {
     ktlint().editorConfigOverride(ktlintEditorConfig)
-    target("**/*.kt")
+    target("src/**/*.kt")
   }
 
   kotlinGradle {
     ktlint().editorConfigOverride(ktlintEditorConfig)
-    target("**/*.gradle.kts")
+    target("*.gradle.kts")
   }
 }
 

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Spotless.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/Spotless.kt
@@ -10,6 +10,17 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun Project.configureSpotless() {
   apply<SpotlessPlugin>()
+  // Every target below is anchored at the project directory (`src/...`, `*.gradle.kts`) rather than starting with `**/`.
+  // Spotless compiles each pattern into a `fileTree(projectDir)` carrying that single include,
+  // and a leading `**/` matches at any depth, which forbids Gradle from pruning a single directory
+  // while snapshotting the task's inputs - it then walks and pattern-matches the entire project tree,
+  // `.git` and the multi-gigabyte `.intellijPlatform` IDE sandbox included, on every build.
+  // Anchoring also keeps out of scope, by construction rather than by exclusion:
+  // generated sources under `build/` (GrammarKit parser/lexer, the baked-in version constant),
+  // the sandbox that `prepareTestSandbox` populates (see JetBrains/intellij-platform-gradle-plugin#2096),
+  // and IDE-managed output dirs such as `bin/`, whose stale copies of our sources would otherwise
+  // get reformatted and invalidate these tasks whenever the IDE refreshes them.
+  // Finally, it stops every parent project from redundantly formatting its children's sources.
   configure<SpotlessExtension> {
     java {
       importOrder("java", "javax", "", "com.virtuslab")
@@ -17,7 +28,7 @@ fun Project.configureSpotless() {
       // and exporting settings from Eclipse
       eclipse().configFile("$rootDir/config/spotless/formatting-rules.xml")
       removeUnusedImports()
-      targetExclude("**/build/generated/**/*.*", "**/.intellijPlatform/**")
+      target("src/**/*.java")
     }
 
     val ktlintEditorConfig = mapOf(
@@ -32,16 +43,14 @@ fun Project.configureSpotless() {
 
     kotlin {
       ktlint().editorConfigOverride(ktlintEditorConfig)
-      target("**/*.kt")
-      // Workaround for JetBrains/intellij-platform-gradle-plugin#2096: exclude plugin sandbox so Spotless
-      // doesn't touch outputs of prepareTestSandbox (previously under build/idea-sandbox, now under .intellijPlatform).
-      targetExclude("**/.intellijPlatform/**")
+      target("src/**/*.kt")
     }
 
     kotlinGradle {
       ktlint().editorConfigOverride(ktlintEditorConfig)
-      target("**/*.gradle.kts")
-      targetExclude("**/.intellijPlatform/**")
+      // Each project covers its own build script, the root project additionally `settings.gradle.kts`
+      // and `version.gradle.kts`; buildSrc has its own Spotless setup.
+      target("*.gradle.kts")
     }
   }
 

--- a/frontend/base/build.gradle.kts
+++ b/frontend/base/build.gradle.kts
@@ -14,12 +14,3 @@ vavr()
 // Pull in the version constant baked at build time by the root project, so `PlatformInfoProvider`
 // in the error reporter can include it in bug reports without hitting any internal IDE accessor.
 sourceSets["main"].java.srcDir(rootProject.tasks.named("generatePluginVersionSource"))
-
-// Restrict Spotless to project-local sources; the wiring above pulls in a generated source
-// directory under the root project's `build/`, and Spotless's safety check rejects targets
-// outside the project dir before any `targetExclude` pattern can take effect.
-spotless {
-  java {
-    target("src/**/*.java")
-  }
-}


### PR DESCRIPTION
Spotless compiles every `target`/`targetExclude` pattern into a `fileTree(projectDir)` carrying that single include, and a leading `**/` matches at any depth, which forbids Gradle from pruning a single directory while snapshotting a task's inputs.
The root project's tasks therefore walked and pattern-matched the entire repository - `.git` and the multi-gigabyte `.intellijPlatform` sandbox included - on every build: in a fully up-to-date `./gradlew build`, `:spotlessKotlin`, `:spotlessJava` and `:spotlessKotlinGradle` took 32s of the 33s total while all three reported UP-TO-DATE.
The `**/.intellijPlatform/**` exclusion was self-defeating in particular: to exclude the sandbox, Gradle first had to enumerate all of it.

Anchoring every target at the project directory lets Gradle prune, and keeps out of scope by construction what used to be excluded after the fact: generated sources under `build/`, the sandbox that `prepareTestSandbox` populates, and IDE-managed output dirs such as `bin/`, whose stale copies of our sources were both getting reformatted and invalidating the Kotlin tasks whenever the IDE refreshed them.
It also stops every parent project from redundantly formatting its children's sources, and makes `:frontend:base`'s own target override redundant.

The set of formatted files is unchanged apart from those `bin/` copies, verified by dumping each Spotless task's resolved target list before and after.
A warm `./gradlew build` now takes 1s instead of 33s.