### PR TITLE
Hold Codecov PR comment until both flag uploads have arrived

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+# Every build uploads exactly two coverage reports - `unit-tests` from the `build` job (via the
+# Codecov orb's working-tree walk over per-subproject `jacocoTestReport.xml`s) and `ui-tests`
+# from the `ui-tests-recent` job (via `jacocoUiTestReport.xml`).
+# By default Codecov posts the PR comment as soon as the first report lands and then edits it
+# when the second arrives, so reviewers briefly see numbers that reflect only one of the two
+# layers (e.g. ~17% "unit-tests only" before the `ui-tests` upload brings it back to ~52%).
+# Waiting for both uploads before posting keeps the initial comment showing the final numbers.
+codecov:
+  notify:
+    after_n_builds: 2
+    wait_for_ci: true
+
+comment:
+  after_n_builds: 2


### PR DESCRIPTION
## Summary

Each build sends two separate Codecov uploads - `unit-tests` from the `build` job (a tree walk over per-subproject `jacocoTestReport.xml`s) and `ui-tests` from the `ui-tests-recent` job (`jacocoUiTestReport.xml`).
Codecov's default is to post the PR comment as soon as the first report arrives and edit it in place when the second lands, so reviewers briefly see a comment that reflects only one of the two layers - typically `unit-tests` at ~17% before the `ui-tests` upload brings the number back to ~52% (see e.g. #2340, which touched no code but still produced a transient "coverage dropped" comment).

Reintroduce a minimal `codecov.yml` telling Codecov to wait for both uploads before publishing anything:

- `codecov.notify.after_n_builds: 2` - delay Codecov's own status check until both reports are in.
- `codecov.notify.wait_for_ci: true` - additionally wait for the rest of CI before finalizing notifications.
- `comment.after_n_builds: 2` - the direct control for the PR comment: don't post it until both reports have arrived.

The `2` is stable because `ui-tests-recent` now unconditionally uploads (`ui-tests-earlier` no longer uploads at all). If we ever add a third `codecov/upload` call, this number needs to bump - the file comment flags that.

## Test plan

- [ ] After merge, watch the next PR that touches coverable code - the Codecov comment should appear once, already showing the combined `unit-tests` + `ui-tests` number, rather than flashing a low `unit-tests`-only number first.