### PR TITLE
Add a table of contents to CONTRIBUTING.md and docs/features.md #1192

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,36 @@
 # Development
 
+<!-- START generated TOC -->
+<!-- Keep this section in sync by running ./scripts/update-markdown-toc -->
+
+- [Prerequisites](#prerequisites)
+  - [IntelliJ](#intellij)
+  - [Git config/hooks](#git-confighooks)
+  - [Windows](#windows)
+- [Build](#build)
+  - [Fix problems with the build](#fix-problems-with-the-build)
+- [Run](#run)
+  - [Debug](#debug)
+- [Test](#test)
+  - [Regenerate pre-recorded CLI outputs](#regenerate-pre-recorded-cli-outputs)
+  - [Run UI tests](#run-ui-tests)
+- [Generate and/or install snapshot build of the plugin](#generate-andor-install-snapshot-build-of-the-plugin)
+- [Logging](#logging)
+- [Coding conventions](#coding-conventions)
+  - [Markdown table of contents](#markdown-table-of-contents)
+- [UI conventions](#ui-conventions)
+- [Versioning](#versioning)
+  - [Sample sequence of versions between releases](#sample-sequence-of-versions-between-releases)
+  - [Change notes](#change-notes)
+  - [Supported IDE versions](#supported-ide-versions)
+- [PRs & releases](#prs--releases)
+- [Plugin signing](#plugin-signing)
+  - [Plugin signing as part of the CI publish process through the Gradle Plugin](#plugin-signing-as-part-of-the-ci-publish-process-through-the-gradle-plugin)
+  - [Local plugin signing for test, through the Gradle plugin](#local-plugin-signing-for-test-through-the-gradle-plugin)
+- [Scenario recordings](#scenario-recordings)
+
+<!-- END generated TOC -->
+
 ## Prerequisites
 
 ### IntelliJ
@@ -219,6 +250,17 @@ Most non-standard/project-specific conventions are enforced by:
   (see [tests in top-level project](src/test/java/com/virtuslab/archunit))
 * [Checker Framework](https://checkerframework.org/manual/) for formal correctness, esp. wrt. null safety and UI thread handling
   (most config in [build.gradle.kts](build.gradle.kts), stubs in [config/checker/](config/checker))
+
+### Markdown table of contents
+
+`CONTRIBUTING.md` and [`docs/features.md`](docs/features.md) include a generated table of contents.
+After you add or rename headings, regenerate it with:
+
+```shell
+./scripts/update-markdown-toc
+```
+
+The [pre-commit hook](scripts/run-pre-build-checks) fails when the ToC is stale.
 
 Other coding conventions include:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,5 +1,32 @@
 # Git Machete Features
 
+<!-- START generated TOC -->
+<!-- Keep this section in sync by running ./scripts/update-markdown-toc -->
+
+- [Where to find the plugin tab](#where-to-find-the-plugin-tab)
+- [Branch layout graph](#branch-layout-graph)
+- [Check out branches](#check-out-branches)
+- [Toggle listing commits](#toggle-listing-commits)
+- [Traverse](#traverse)
+- [Sync by rebase](#sync-by-rebase)
+- [Sync by merge](#sync-by-merge)
+- [Push](#push)
+- [Pull](#pull)
+- [Reset to remote](#reset-to-remote)
+- [Fast-forward merge into parent](#fast-forward-merge-into-parent)
+- [Rename branch](#rename-branch)
+- [Slide out branch](#slide-out-branch)
+- [Slide in branch](#slide-in-branch)
+- [Override fork point](#override-fork-point)
+- [Squash](#squash)
+- [Show in Git log](#show-in-git-log)
+- [Discover](#discover)
+- [Edit machete file](#edit-machete-file)
+- [Other actions](#other-actions)
+- [Multi-repository support](#multi-repository-support)
+
+<!-- END generated TOC -->
+
 ## Where to find the plugin tab
 
 Git Machete IntelliJ Plugin is available under the `Git` tool window in the `Git Machete` tab.

--- a/scripts/enforce-markdown-toc-up-to-date
+++ b/scripts/enforce-markdown-toc-up-to-date
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
+"$self_dir"/update-markdown-toc --check

--- a/scripts/run-pre-build-checks
+++ b/scripts/run-pre-build-checks
@@ -26,6 +26,7 @@ _ enforce-astub-explicit-annotation-import
 _ enforce-change-notes-updated-on-pr-to-master
 _ enforce-indent-two-spaces-outside-java
 _ enforce-issue-number-for-todos
+_ enforce-markdown-toc-up-to-date
 _ enforce-newline-at-eof
 _ enforce-properties-keys-with-valid-class-names
 _ enforce-settings-gradle-match-directories

--- a/scripts/update-markdown-toc
+++ b/scripts/update-markdown-toc
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail -u
+
+self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
+root_dir=$(cd "$self_dir/.." &>/dev/null; pwd -P)
+source "$self_dir"/utils.sh
+
+check_only=0
+if [[ ${1-} == --check ]]; then
+  check_only=1
+fi
+
+# Keep this list in sync with the files named in CONTRIBUTING.md.
+toc_files=(
+  CONTRIBUTING.md
+  docs/features.md
+)
+
+start_marker='<!-- START generated TOC -->'
+end_marker='<!-- END generated TOC -->'
+
+generate_toc() {
+  local file=$1
+  python3 - "$file" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+heading_re = re.compile(r'^(#{2,3})\s+(.*)$')
+punct_re = re.compile(r'[^a-z0-9 _-]')
+
+def slugify(title):
+    text = title
+    text = re.sub(r'`([^`]*)`', r'\1', text)
+    text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', text)
+    text = text.replace('*', '')
+    text = text.lower()
+    text = punct_re.sub('', text)
+    text = text.replace(' ', '-')
+    text = text.strip('-')
+    return text
+
+seen = {}
+lines = []
+with open(path, encoding='utf-8') as fh:
+    in_toc = False
+    for raw in fh:
+        line = raw.rstrip('\n')
+        if line == '<!-- START generated TOC -->':
+            in_toc = True
+            continue
+        if line == '<!-- END generated TOC -->':
+            in_toc = False
+            continue
+        if in_toc:
+            continue
+        match = heading_re.match(line)
+        if not match:
+            continue
+        hashes, title = match.groups()
+        slug = slugify(title)
+        if slug in seen:
+            seen[slug] += 1
+            slug = '%s-%s' % (slug, seen[slug])
+        else:
+            seen[slug] = 0
+        indent = '  ' if len(hashes) == 3 else ''
+        lines.append('%s- [%s](#%s)' % (indent, title, slug))
+
+print('\n'.join(lines))
+PY
+}
+
+insert_or_replace_toc() {
+  local file=$1
+  local toc=$2
+  python3 - "$file" "$start_marker" "$end_marker" "$toc" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+start = sys.argv[2]
+end = sys.argv[3]
+toc = sys.argv[4].rstrip('\n')
+text = path.read_text(encoding='utf-8')
+block = (
+    start
+    + '\n<!-- Keep this section in sync by running ./scripts/update-markdown-toc -->\n\n'
+    + toc
+    + '\n\n'
+    + end
+)
+if start in text and end in text:
+    pre = text.split(start, 1)[0]
+    post = text.split(end, 1)[1]
+    if not pre.endswith('\n\n'):
+        if pre.endswith('\n'):
+            pre += '\n'
+        else:
+            pre += '\n\n'
+    if not post.startswith('\n'):
+        post = '\n' + post
+    new = pre + block + post
+else:
+    lines = text.splitlines(keepends=True)
+    if not lines:
+        raise SystemExit('%s: empty file' % path)
+    idx = 0
+    while idx < len(lines) and not lines[idx].startswith('# '):
+        idx += 1
+    if idx >= len(lines):
+        raise SystemExit('%s: no H1 heading found' % path)
+    idx += 1
+    if idx < len(lines) and lines[idx].strip() == '':
+        idx += 1
+    new = ''.join(lines[:idx]) + block + '\n\n' + ''.join(lines[idx:])
+if not new.endswith('\n'):
+    new += '\n'
+path.write_text(new, encoding='utf-8')
+PY
+}
+
+stale=0
+cd "$root_dir"
+for rel in "${toc_files[@]}"; do
+  if [[ ! -f $rel ]]; then
+    die "expected $rel to exist for the markdown ToC check"
+  fi
+  toc=$(generate_toc "$rel")
+  if [[ -z $toc ]]; then
+    die "$rel has no ## / ### headings to put in the ToC"
+  fi
+  if [[ $check_only -eq 1 ]]; then
+    current=$(python3 - "$rel" "$start_marker" "$end_marker" <<'PY'
+import sys
+from pathlib import Path
+text = Path(sys.argv[1]).read_text(encoding='utf-8')
+start, end = sys.argv[2], sys.argv[3]
+if start not in text or end not in text:
+    sys.exit(0)
+body = text.split(start, 1)[1].split(end, 1)[0]
+lines = [ln for ln in body.splitlines() if ln and not ln.startswith('<!--')]
+print('\n'.join(lines))
+PY
+)
+    if [[ $current != "$toc" ]]; then
+      error "$rel table of contents is out of date"
+      stale=1
+    fi
+  else
+    insert_or_replace_toc "$rel" "$toc"
+    echo "updated $rel"
+  fi
+done
+
+if [[ $check_only -eq 1 && $stale -ne 0 ]]; then
+  die 'Markdown ToC is out of date, run ./scripts/update-markdown-toc'
+fi


### PR DESCRIPTION
I added a generated table of contents at the top of `CONTRIBUTING.md` and `docs/features.md`.

Regenerate it with `./scripts/update-markdown-toc`. The pre-build checks fail if it is stale.

Closes #1192