### PR TITLE
Fix UI-test clicks under mismatched buildTarget / IDE major

### DIFF
--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITestSuite.kt
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITestSuite.kt
@@ -2,8 +2,6 @@ package com.virtuslab.gitmachete.uitest
 
 import com.intellij.driver.client.Driver
 import com.intellij.driver.sdk.isProjectOpened
-import com.intellij.driver.sdk.ui.components.common.ideFrame
-import com.intellij.driver.sdk.ui.xQuery
 import com.intellij.ide.starter.ci.CIServer
 import com.intellij.ide.starter.ci.NoCIServer
 import com.intellij.ide.starter.di.di
@@ -15,6 +13,8 @@ import com.intellij.ide.starter.project.ProjectInfoSpec
 import com.intellij.ide.starter.runner.Starter
 import com.intellij.platform.testFramework.teamCity.TeamCityReporter.SyntheticTestKind
 import com.intellij.remoterobot.RemoteRobot
+import com.intellij.remoterobot.fixtures.ComponentFixture
+import com.intellij.remoterobot.search.locators.byXpath
 import com.virtuslab.gitmachete.testcommon.SetupScripts
 import com.virtuslab.gitmachete.testcommon.TestGitRepository
 import org.intellij.lang.annotations.Language
@@ -257,18 +257,20 @@ abstract class BaseUITestSuite : TestGitRepository(SetupScripts.SETUP_WITH_SINGL
   fun getHashOfCommitPointedByBranch(branch: String): String = callJs("project.getHashOfCommitPointedByBranch('$branch')")
   fun getSyncToParentStatus(child: String): String = callJs("project.getSyncToParentStatus('$child')")
 
+  // Prefer RemoteRobot over Driver `ideFrame` / `xQuery` clicks: uiTest Starter/driver-sdk is
+  // resolved once against `buildTarget` (see build.gradle.kts / IJPL-234281), so when that is an
+  // upcoming EAP major while `-Pagainst=` launches an older stable IDE, Driver remotedriver
+  // lookups fail with ClassNotFoundException for IdeRobot.
   private fun clickButton(visibleText: String) {
     println("clickButton: $visibleText")
-    driver().ideFrame {
-      x(xQuery { byVisibleText(visibleText) }).click()
-    }
+    robot.find<ComponentFixture>(
+      byXpath("//div[@text='$visibleText' or @visible_text='$visibleText']"),
+    ).click()
   }
 
   private fun clickToolbarButton(name: String) {
     println("clickToolbarButton: $name")
-    driver().ideFrame {
-      x(xQuery { byAccessibleName(name) }).click()
-    }
+    robot.find<ComponentFixture>(byXpath("//div[@accessiblename='$name']")).click()
   }
 
   fun acceptBranchDeletionOnSlideOut() = doAndAwait { clickButton("Slide Out & Delete Local Branch") }

--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITestSuite.kt
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITestSuite.kt
@@ -13,8 +13,6 @@ import com.intellij.ide.starter.project.ProjectInfoSpec
 import com.intellij.ide.starter.runner.Starter
 import com.intellij.platform.testFramework.teamCity.TeamCityReporter.SyntheticTestKind
 import com.intellij.remoterobot.RemoteRobot
-import com.intellij.remoterobot.fixtures.ComponentFixture
-import com.intellij.remoterobot.search.locators.byXpath
 import com.virtuslab.gitmachete.testcommon.SetupScripts
 import com.virtuslab.gitmachete.testcommon.TestGitRepository
 import org.intellij.lang.annotations.Language
@@ -257,20 +255,15 @@ abstract class BaseUITestSuite : TestGitRepository(SetupScripts.SETUP_WITH_SINGL
   fun getHashOfCommitPointedByBranch(branch: String): String = callJs("project.getHashOfCommitPointedByBranch('$branch')")
   fun getSyncToParentStatus(child: String): String = callJs("project.getSyncToParentStatus('$child')")
 
-  // Prefer RemoteRobot over Driver `ideFrame` / `xQuery` clicks: uiTest Starter/driver-sdk is
-  // resolved once against `buildTarget` (see build.gradle.kts / IJPL-234281), so when that is an
-  // upcoming EAP major while `-Pagainst=` launches an older stable IDE, Driver remotedriver
-  // lookups fail with ClassNotFoundException for IdeRobot.
+  // Click dialog buttons via the in-IDE Remote Robot finder (Rhino), not Driver ideFrame/xQuery.
+  // Driver UI remoting asks the IDE-under-test for classes from the Performance Testing remotedriver
+  // API that matches the Starter/driver-sdk on the test classpath (resolved once against buildTarget;
+  // see build.gradle.kts / IJPL-234281). When buildTarget is a newer major (e.g. EAP 263) than the
+  // IDE under test (e.g. 2026.2), that client may look up an FQCN such as IdeRobot that the older
+  // remotedriver module simply does not define yet - even though Performance Testing itself is present.
   private fun clickButton(visibleText: String) {
     println("clickButton: $visibleText")
-    robot.find<ComponentFixture>(
-      byXpath("//div[@text='$visibleText' or @visible_text='$visibleText']"),
-    ).click()
-  }
-
-  private fun clickToolbarButton(name: String) {
-    println("clickToolbarButton: $name")
-    robot.find<ComponentFixture>(byXpath("//div[@accessiblename='$name']")).click()
+    runJs("project.clickButton('$visibleText')")
   }
 
   fun acceptBranchDeletionOnSlideOut() = doAndAwait { clickButton("Slide Out & Delete Local Branch") }
@@ -288,9 +281,7 @@ abstract class BaseUITestSuite : TestGitRepository(SetupScripts.SETUP_WITH_SINGL
   fun fastForwardMergeCurrentToParent() = doAndAwait { runJs("project.fastForwardMergeCurrentToParent()") }
   fun fastForwardMergeSelectedToParent(branch: String) = doAndAwait { runJs("project.fastForwardMergeSelectedToParent('$branch')") }
   fun openGitMacheteTab() = runJs("project.openGitMacheteTab()")
-  fun pullCurrent() {
-    doAndAwait { clickToolbarButton("Pull Current Branch") }
-  }
+  fun pullCurrent() = doAndAwait { runJs("project.pullCurrent()") }
   fun pullSelected(branch: String) = doAndAwait { runJs("project.pullSelected('$branch')") }
   fun refreshModelAndGetManagedBranches(): Array<String> = callJs("project.refreshGraphTableModel(); project.getManagedBranches()")
   fun refreshModelAndGetManagedBranchesAndCommits(): Array<String> = callJs("project.refreshGraphTableModel(); project.getManagedBranchesAndCommits()")
@@ -298,9 +289,7 @@ abstract class BaseUITestSuite : TestGitRepository(SetupScripts.SETUP_WITH_SINGL
   fun resetCurrentToRemote() = doAndAwait { runJs("project.resetCurrentToRemote()") }
   fun resetToRemote(branch: String) = doAndAwait { runJs("project.resetToRemote('$branch')") }
   fun slideOutSelected(branch: String) = runJs("project.slideOutSelected('$branch')")
-  fun squashCurrent() {
-    doAndAwait { clickToolbarButton("Squash\u2026") }
-  }
+  fun squashCurrent() = doAndAwait { runJs("project.squashCurrent()") }
   fun squashSelected(branch: String) = doAndAwait { runJs("project.squashSelected('$branch')") }
   fun syncCurrentToParentByRebase() {
     runJs("project.syncCurrentToParentByRebase()")

--- a/src/uiTest/resources/project.rhino.js
+++ b/src/uiTest/resources/project.rhino.js
@@ -1,6 +1,8 @@
 importClass(java.lang.IllegalStateException);
+importClass(java.lang.System);
 importClass(java.lang.Thread);
 importClass(java.nio.file.Paths);
+importClass(java.util.Arrays);
 importClass(java.util.stream.Collectors);
 
 importClass(com.intellij.ide.plugins.PluginManagerCore);
@@ -23,6 +25,7 @@ importClass(com.intellij.openapi.vcs.VcsConfiguration);
 importClass(com.intellij.openapi.wm.ToolWindowId);
 importClass(com.intellij.openapi.wm.ToolWindowManager);
 importClass(com.intellij.util.ModalityUiUtil);
+importClass(org.assertj.swing.core.MouseButton);
 
 // Do not run any of the methods on the UI thread.
 function Project(underlyingProject) {
@@ -170,11 +173,50 @@ function Project(underlyingProject) {
     ApplicationManager.getApplication().invokeAndWait(() => action.actionPerformed(actionEvent));
   };
 
-  // Note that clicking the toolbar actions doesn't seem to work for most cases reliably in UI tests.
-  // Some of the errors include:
-  //  java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location
-  //  org.assertj.swing.exception.ActionFailedException: The component to click is out of the boundaries of the screen
-  // Let's invoke the toolbar actions directly instead in the more brittle cases.
+  // Note that clicking toolbar ActionButtons is brittle in UI tests
+  // (IllegalComponentStateException / ActionFailedException: out of screen boundaries).
+  // Prefer invokeAction* for toolbar/context-menu actions; use findAndClickButton only for dialog JButtons.
+
+  const clickMouseInGraphTable = function () {
+    const graphTable = getGraphTable();
+    robot.click(graphTable);
+    sleep();
+  };
+
+  // Finds a JButton (or subclass) by exact getText() and clicks it via the in-IDE robot.
+  const findAndClickButton = function (name) {
+    const button = getComponentByClassAndPredicate('javax.swing.JButton',
+        /* predicate */ component => name.equals(component.getText())
+    );
+    robot.click(button, MouseButton.LEFT_BUTTON);
+  };
+
+  // Checks for components of the provided class or any subclass.
+  const getComponentByClassAndPredicate = function (className, predicate) {
+    const searchForComponent = function () {
+      const clazz = pluginClassLoader.loadClass(className);
+      const result = robot.finder().findAll(component =>
+        clazz.isInstance(component) && predicate(component)
+      ).toArray();
+      System.out.println("getComponentByClassAndPredicate(" + className + ", [predicate]) = "
+          + Arrays.deepToString(result) + "(" + result.length + " element(s))");
+      return result.length === 1 ? result[0] : null;
+    }
+    // The action is invoked asynchronously, let's first make sure the component has already appeared.
+    let component = searchForComponent(), i = 0;
+    while (component === null && i++ < 100) {
+      clickMouseInGraphTable();
+      component = searchForComponent();
+    }
+    if (component === null) {
+      throw new IllegalStateException("Waiting for '" + className + "' component timed out");
+    }
+    return component;
+  };
+
+  this.clickButton = function (visibleText) {
+    findAndClickButton(visibleText);
+  };
 
   this.discoverBranchLayout = function () {
     invokeActionAsync('GitMachete.DiscoverAction', ActionPlaces.ACTION_SEARCH, {});
@@ -230,8 +272,16 @@ function Project(underlyingProject) {
     invokeActionAndWait('GitMachete.SquashSelectedAction', ACTION_PLACE_CONTEXT_MENU, { SELECTED_BRANCH_NAME: branchName });
   };
 
+  this.squashCurrent = function () {
+    invokeActionAndWait('GitMachete.SquashCurrentAction', ACTION_PLACE_TOOLBAR, {});
+  };
+
   this.pullSelected = function (branchName) {
     invokeActionAndWait('GitMachete.PullSelectedAction', ACTION_PLACE_CONTEXT_MENU, { SELECTED_BRANCH_NAME: branchName });
+  };
+
+  this.pullCurrent = function () {
+    invokeActionAndWait('GitMachete.PullCurrentAction', ACTION_PLACE_TOOLBAR, {});
   };
 
   this.resetToRemote = function (branchName) {


### PR DESCRIPTION
## Summary
- Root cause of the develop `ui-tests-earlier` failure was not "2026.2 lacks Performance Testing", but **Driver client / IDE remotedriver skew**: Starter is resolved once against `buildTarget` (EAP 263), and `ideFrame`/`xQuery` then ask the 2026.2 IDE for `IdeRobot`, which that older remotedriver module does not define (IJPL-234281).
- Click dialog buttons via the in-IDE Rhino `robot.finder()` path again (version-local classpath).
- Invoke `PullCurrent` / `SquashCurrent` through actions instead of toolbar clicks.

## Test plan
- [ ] CircleCI `ui-tests-earlier` (`:uiTest_2026.2.2`) passes
- [ ] CircleCI `ui-tests-recent` (`263.3889.65`) passes