### PR TITLE
Rename *TestSuite test classes to *Test #1546

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ set `printTestOutput` project property: `./gradlew -PprintTestOutput test`.
 ### Regenerate pre-recorded CLI outputs
 
 See [`backend/impl/src/test/resources`](backend/impl/src/test/resources) and
-[`StatusAndDiscoverIntegrationTestSuite`](backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTestSuite.java)
+[`StatusAndDiscoverIntegrationTest`](backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTest.java)
 for context.
 
 Regeneration is needed when:

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/BaseIntegrationTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/BaseIntegrationTest.java
@@ -15,7 +15,7 @@ import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositoryCache;
 import com.virtuslab.gitmachete.backend.impl.GitMacheteRepositoryCache;
 import com.virtuslab.gitmachete.testcommon.TestGitRepository;
 
-class BaseIntegrationTestSuite {
+class BaseIntegrationTest {
   protected static final IGitCoreRepositoryFactory gitCoreRepositoryFactory = new GitCoreRepositoryFactory();
   protected static final IGitMacheteRepositoryCache gitMacheteRepositoryCache = new GitMacheteRepositoryCache();
   protected static final IBranchLayoutReader branchLayoutReader = new BranchLayoutReader();

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/ParentInferenceIntegrationTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/ParentInferenceIntegrationTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot;
 
-public class ParentInferenceIntegrationTestSuite extends BaseIntegrationTestSuite {
+public class ParentInferenceIntegrationTest extends BaseIntegrationTest {
 
   public static String[][] getTestData() {
     return new String[][]{

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/integration/StatusAndDiscoverIntegrationTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.virtuslab.gitmachete.backend.api.*;
 
-public class StatusAndDiscoverIntegrationTestSuite extends BaseIntegrationTestSuite {
+public class StatusAndDiscoverIntegrationTest extends BaseIntegrationTest {
 
   public static String[] getScriptNames() {
     return ALL_SETUP_SCRIPTS;

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/BaseGitMacheteRepositoryUnitTest.java
@@ -17,7 +17,7 @@ import com.virtuslab.gitcore.api.IGitCoreRepository;
 import com.virtuslab.gitmachete.backend.impl.StatusBranchHookExecutor;
 import com.virtuslab.gitmachete.backend.impl.helper.CreateGitMacheteRepositoryHelper;
 
-public class BaseGitMacheteRepositoryUnitTestSuite {
+public class BaseGitMacheteRepositoryUnitTest {
 
   protected final IGitCoreRepository gitCoreRepository = mock(IGitCoreRepository.class);
 

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranches_UnitTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranches_UnitTest.java
@@ -19,9 +19,9 @@ import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitmachete.backend.api.IGitMacheteRepositorySnapshot;
 import com.virtuslab.gitmachete.backend.api.IManagedBranchSnapshot;
 
-public class GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranches_UnitTestSuite
+public class GitMacheteRepository_deriveCreatedAndDuplicatedAndSkippedBranches_UnitTest
     extends
-      BaseGitMacheteRepositoryUnitTestSuite {
+      BaseGitMacheteRepositoryUnitTest {
 
   @SneakyThrows
   private IGitMacheteRepositorySnapshot invokeCreateSnapshot(

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveParentAwareForkPoint_UnitTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveParentAwareForkPoint_UnitTest.java
@@ -16,7 +16,7 @@ import com.virtuslab.gitcore.api.IGitCoreCommit;
 import com.virtuslab.gitcore.api.IGitCoreLocalBranchSnapshot;
 import com.virtuslab.gitmachete.backend.impl.ForkPointCommitOfManagedBranch;
 
-public class GitMacheteRepository_deriveParentAwareForkPoint_UnitTestSuite extends BaseGitMacheteRepositoryUnitTestSuite {
+public class GitMacheteRepository_deriveParentAwareForkPoint_UnitTest extends BaseGitMacheteRepositoryUnitTest {
 
   @SneakyThrows
   private @Nullable IGitCoreCommit invokeDeriveParentAwareForkPoint(

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveRelationToRemote_UnitTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveRelationToRemote_UnitTest.java
@@ -19,7 +19,7 @@ import com.virtuslab.gitcore.api.IGitCoreRemoteBranchSnapshot;
 import com.virtuslab.gitmachete.backend.api.RelationToRemote;
 import com.virtuslab.gitmachete.backend.api.SyncToRemoteStatus;
 
-public class GitMacheteRepository_deriveRelationToRemote_UnitTestSuite extends BaseGitMacheteRepositoryUnitTestSuite {
+public class GitMacheteRepository_deriveRelationToRemote_UnitTest extends BaseGitMacheteRepositoryUnitTest {
 
   private static final String ORIGIN = "origin";
 

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToParentStatus_UnitTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/GitMacheteRepository_deriveSyncToParentStatus_UnitTest.java
@@ -19,7 +19,7 @@ import com.virtuslab.gitmachete.backend.api.SyncToParentStatus;
 import com.virtuslab.gitmachete.backend.impl.ForkPointCommitOfManagedBranch;
 import com.virtuslab.gitmachete.backend.impl.RemoteTrackingBranchReference;
 
-public class GitMacheteRepository_deriveSyncToParentStatus_UnitTestSuite extends BaseGitMacheteRepositoryUnitTestSuite {
+public class GitMacheteRepository_deriveSyncToParentStatus_UnitTest extends BaseGitMacheteRepositoryUnitTest {
 
   private static final IGitCoreCommit MISSING_FORK_POINT = createGitCoreCommit();
 

--- a/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/WorktreeLabelComputerUnitTest.java
+++ b/backend/impl/src/test/java/com/virtuslab/gitmachete/backend/unit/WorktreeLabelComputerUnitTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import com.virtuslab.gitmachete.backend.impl.helper.WorktreeLabelComputer;
 
-public class WorktreeLabelComputerUnitTestSuite {
+public class WorktreeLabelComputerUnitTest {
 
   private static final Path MAIN = Path.of("/repos/proj/main");
   private static final Path WT_A = Path.of("/repos/proj/wt-a");

--- a/branchLayout/api/src/test/java/com/virtuslab/branchlayout/api/BranchLayoutTest.java
+++ b/branchLayout/api/src/test/java/com/virtuslab/branchlayout/api/BranchLayoutTest.java
@@ -9,7 +9,7 @@ import io.vavr.collection.List;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 
-public class BranchLayoutTestSuite {
+public class BranchLayoutTest {
 
   @Test
   public void shouldBeAbleToFindNextAndPreviousBranches() {

--- a/branchLayout/impl/src/test/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReaderTest.java
+++ b/branchLayout/impl/src/test/java/com/virtuslab/branchlayout/impl/readwrite/BranchLayoutFileReaderTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import com.virtuslab.branchlayout.api.BranchLayout;
 import com.virtuslab.branchlayout.api.BranchLayoutException;
 
-public class BranchLayoutFileReaderTestSuite {
+public class BranchLayoutFileReaderTest {
 
   public static InputStream getInputStreamFromLines(List<String> lines) {
     return new ByteArrayInputStream(

--- a/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UITests.kt
+++ b/buildSrc/src/main/kotlin/com/virtuslab/gitmachete/buildsrc/UITests.kt
@@ -19,7 +19,7 @@ fun Project.configureUiTests() {
   tasks.named<KotlinCompile>("compileUiTestKotlin") {
     // See https://kotlinlang.org/docs/gradle-compilation-and-caches.html#defining-kotlin-compiler-execution-strategy
     // This is needed to avoid a fallback to In process since compilation in Kotlin daemon fails on
-    // `bindSingleton<CIServer>(overrides = true)` in BaseUITestSuite, and it's unclear how to fix/replace it.
+    // `bindSingleton<CIServer>(overrides = true)` in BaseUITest, and it's unclear how to fix/replace it.
     compilerExecutionStrategy = KotlinCompilerExecutionStrategy.IN_PROCESS
   }
 
@@ -53,7 +53,7 @@ fun Project.configureUiTests() {
       systemProperty("path.to.robot.server.plugin", robotServerPluginZip.singleFile.path)
 
       // Hand the standalone JaCoCo agent jar and a per-IDE-version `.exec` destination to
-      // `BaseUITestSuite`, which then attaches the agent to the IDE-under-test JVM via
+      // `BaseUITest`, which then attaches the agent to the IDE-under-test JVM via
       // `applyVMOptionsPatch`. The Gradle test JVM that runs RemoteRobot client code is just a
       // thin shell that doesn't load production plugin classes, so the only coverage worth
       // collecting lives in the IDE process.

--- a/frontend/base/src/test/java/com/virtuslab/gitmachete/frontend/resourcebundles/GitMacheteBundlePropertiesTest.java
+++ b/frontend/base/src/test/java/com/virtuslab/gitmachete/frontend/resourcebundles/GitMacheteBundlePropertiesTest.java
@@ -9,7 +9,7 @@ import java.util.Properties;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
-public class GitMacheteBundlePropertiesTestSuite {
+public class GitMacheteBundlePropertiesTest {
 
   private static final String macheteBundleProperties = "GitMacheteBundle.properties";
 

--- a/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/gitrepositoryselection/GitRepositoryComboBox.java
+++ b/frontend/ui/impl/src/main/java/com/virtuslab/gitmachete/frontend/ui/impl/gitrepositoryselection/GitRepositoryComboBox.java
@@ -161,7 +161,7 @@ public final class GitRepositoryComboBox extends JComboBox<GitRepository>
   }
 
   // Declared as a static nested class (rather than an anonymous subclass instantiated from the
-  // constructor) to satisfy `ClassStructureTestSuite#inner_classes_should_not_be_instantiated_from_constructor_of_enclosing_class`.
+  // constructor) to satisfy `ClassStructureTest#inner_classes_should_not_be_instantiated_from_constructor_of_enclosing_class`.
   private static final class ShortRepositoryNameRenderer extends SimpleListCellRenderer<GitRepository> {
     @UIEffect
     ShortRepositoryNameRenderer() {}

--- a/qual/src/main/java/com/virtuslab/qual/async/BackgroundableQueuedElsewhere.java
+++ b/qual/src/main/java/com/virtuslab/qual/async/BackgroundableQueuedElsewhere.java
@@ -10,10 +10,10 @@ import java.lang.annotation.Target;
  * but do <b>not</b> call {@code #queue()}.
  * <p>
  * Typically, it is a smell that indicates that the programmer forgot to actually schedule the task.
- * Such cases are detected by ArchUnit test {@code com.virtuslab.archunit.BackgroundTaskEnqueuingTestSuite}.
+ * Such cases are detected by ArchUnit test {@code com.virtuslab.archunit.BackgroundTaskEnqueuingTest}.
  * Still, in some rare cases it might happen that a method passes the newly-created backgroundable
  * to downstream APIs to actually enqueue.
- * Such methods must be marked as {@link BackgroundableQueuedElsewhere} for {@code BackgroundTaskEnqueuingTestSuite} to ignore.
+ * Such methods must be marked as {@link BackgroundableQueuedElsewhere} for {@code BackgroundTaskEnqueuingTest} to ignore.
  * <p>
  * This annotation must have runtime retention to be visible to ArchUnit tests.
  */

--- a/qual/src/main/java/com/virtuslab/qual/async/ContinuesInBackground.java
+++ b/qual/src/main/java/com/virtuslab/qual/async/ContinuesInBackground.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  * Its purpose is to make the programmer aware of the increased risk of race conditions,
  * esp. to avoid treating such methods as if they completed in a fully synchronous/blocking manner.
  * <p>
- * As for now, we use an ArchUnit test {@code com.virtuslab.archunit.BackgroundTaskEnqueuingTestSuite}
+ * As for now, we use an ArchUnit test {@code com.virtuslab.archunit.BackgroundTaskEnqueuingTest}
  * to enforce that:
  * <ol>
  * <li>methods that call {@code queue()} on classes extending {@code Task.Backgroundable} are marked as {@link ContinuesInBackground}</li>

--- a/qual/src/main/java/com/virtuslab/qual/async/DoesNotContinueInBackground.java
+++ b/qual/src/main/java/com/virtuslab/qual/async/DoesNotContinueInBackground.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
  * Used to mark methods that get a free pass on calling {@link ContinuesInBackground} methods,
  * despite <b>not</b> being marked as {@link ContinuesInBackground} themselves.
  * <p>
- * This is only taken into account by ArchUnit test {@code com.virtuslab.archunit.BackgroundTaskEnqueuingTestSuite}
+ * This is only taken into account by ArchUnit test {@code com.virtuslab.archunit.BackgroundTaskEnqueuingTest}
  * that enforces the correct usage of {@link ContinuesInBackground} annotation.
  * <p>
  * This annotation must have runtime retention to be visible to ArchUnit tests.

--- a/qual/src/main/java/com/virtuslab/qual/guieffect/IgnoreUIThreadUnsafeCalls.java
+++ b/qual/src/main/java/com/virtuslab/qual/guieffect/IgnoreUIThreadUnsafeCalls.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
  * Used to mark methods that get a free pass on calling {@link UIThreadUnsafe} methods,
  * despite <b>not</b> being marked as {@link UIThreadUnsafe} themselves.
  * <p>
- * This is only taken into account by ArchUnit test {@code com.virtuslab.archunit.UIThreadUnsafeMethodInvocationsTestSuite}
+ * This is only taken into account by ArchUnit test {@code com.virtuslab.archunit.UIThreadUnsafeMethodInvocationsTest}
  * that enforces the correct usage of {@link UIThreadUnsafe} annotation.
  * <p>
  * Needs to be used sparingly, as this basically allows for a method to call potentially heavyweight operations on UI thread.

--- a/qual/src/main/java/com/virtuslab/qual/guieffect/UIThreadUnsafe.java
+++ b/qual/src/main/java/com/virtuslab/qual/guieffect/UIThreadUnsafe.java
@@ -14,7 +14,7 @@ import org.checkerframework.checker.guieffect.qual.UIEffect;
  * <p>
  * It is <b>not</b> enforced during compilation whether the annotation is used correctly.
  * TODO (typetools/checker-framework#3253): replace with proper {@code @Heavyweight} annotation.
- * As for now, we use an ArchUnit test {@code com.virtuslab.archunit.UIThreadUnsafeMethodInvocationsTestSuite}
+ * As for now, we use an ArchUnit test {@code com.virtuslab.archunit.UIThreadUnsafeMethodInvocationsTest}
  * to enforce that:
  * <ol>
  * <li>methods that call certain known heavyweight methods (like the ones from {@code java.nio}) are marked as {@link UIThreadUnsafe}</li>

--- a/scripts/prohibit-javascript-unused-symbols
+++ b/scripts/prohibit-javascript-unused-symbols
@@ -6,7 +6,7 @@ self_dir=$(cd "$(dirname "$0")" &>/dev/null; pwd -P)
 source "$self_dir"/utils.sh
 
 script=src/uiTest/resources/project.rhino.js
-base_suite=src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITestSuite.kt
+base_suite=src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITest.kt
 
 public_declared=$(grep -Pio '(?<=this\.)[a-z]+(?= = function)' $script | sort -u)
 public_used=$(grep -Pio '(?<=project\.)[a-z]+' $base_suite | sort -u)

--- a/src/test/java/com/virtuslab/archunit/BackgroundTaskEnqueuingTest.java
+++ b/src/test/java/com/virtuslab/archunit/BackgroundTaskEnqueuingTest.java
@@ -22,7 +22,7 @@ import com.virtuslab.qual.async.ContinuesInBackground;
 import com.virtuslab.qual.async.DoesNotContinueInBackground;
 
 @ExtensionMethod(Arrays.class)
-public class BackgroundTaskEnqueuingTestSuite extends BaseArchUnitTestSuite {
+public class BackgroundTaskEnqueuingTest extends BaseArchUnitTest {
 
   private static final String ContinuesInBackgroundName = "@" + ContinuesInBackground.class.getSimpleName();
 

--- a/src/test/java/com/virtuslab/archunit/BaseArchUnitTest.java
+++ b/src/test/java/com/virtuslab/archunit/BaseArchUnitTest.java
@@ -16,7 +16,7 @@ import io.vavr.collection.List;
 import io.vavr.control.Option;
 import lombok.val;
 
-public class BaseArchUnitTestSuite {
+public class BaseArchUnitTest {
   protected static final JavaClasses productionClasses = new ClassFileImporter()
       .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
       .importPackages("com.virtuslab");

--- a/src/test/java/com/virtuslab/archunit/ClassStructureTest.java
+++ b/src/test/java/com/virtuslab/archunit/ClassStructureTest.java
@@ -25,7 +25,7 @@ import lombok.SneakyThrows;
 import lombok.val;
 import org.junit.jupiter.api.Test;
 
-public class ClassStructureTestSuite extends BaseArchUnitTestSuite {
+public class ClassStructureTest extends BaseArchUnitTest {
 
   @Test
   public void abstract_classes_should_not_declare_LOG_field() {

--- a/src/test/java/com/virtuslab/archunit/ForbiddenClassesTest.java
+++ b/src/test/java/com/virtuslab/archunit/ForbiddenClassesTest.java
@@ -4,7 +4,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import org.junit.jupiter.api.Test;
 
-public class ForbiddenClassesTestSuite extends BaseArchUnitTestSuite {
+public class ForbiddenClassesTest extends BaseArchUnitTest {
 
   @Test
   public void no_classes_should_depend_on_java_collections() {

--- a/src/test/java/com/virtuslab/archunit/ForbiddenFieldsTest.java
+++ b/src/test/java/com/virtuslab/archunit/ForbiddenFieldsTest.java
@@ -4,7 +4,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import org.junit.jupiter.api.Test;
 
-public class ForbiddenFieldsTestSuite extends BaseArchUnitTestSuite {
+public class ForbiddenFieldsTest extends BaseArchUnitTest {
 
   @Test
   public void no_classes_should_access_RevSort_TOPO() {

--- a/src/test/java/com/virtuslab/archunit/ForbiddenMethodsTest.java
+++ b/src/test/java/com/virtuslab/archunit/ForbiddenMethodsTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import com.virtuslab.gitmachete.backend.impl.GitMacheteRepositorySnapshot;
 import com.virtuslab.gitmachete.frontend.resourcebundles.GitMacheteBundle;
 
-public class ForbiddenMethodsTestSuite extends BaseArchUnitTestSuite {
+public class ForbiddenMethodsTest extends BaseArchUnitTest {
 
   @Test
   public void no_classes_should_call_AnActionEvent_getRequiredData() {

--- a/src/test/java/com/virtuslab/archunit/MethodCallsTest.java
+++ b/src/test/java/com/virtuslab/archunit/MethodCallsTest.java
@@ -11,7 +11,7 @@ import lombok.val;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.Test;
 
-public class MethodCallsTestSuite extends BaseArchUnitTestSuite {
+public class MethodCallsTest extends BaseArchUnitTest {
 
   @Test
   public void methods_calling_a_method_throwing_RevisionSyntaxException_should_catch_it_explicitly() {

--- a/src/test/java/com/virtuslab/archunit/NamingTest.java
+++ b/src/test/java/com/virtuslab/archunit/NamingTest.java
@@ -5,7 +5,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import org.junit.jupiter.api.Test;
 
-public class NamingTestSuite extends BaseArchUnitTestSuite {
+public class NamingTest extends BaseArchUnitTest {
 
   @Test
   public void exception_class_names_should_end_with_Exception() {

--- a/src/test/java/com/virtuslab/archunit/UIThreadUnsafeMethodInvocationsTest.java
+++ b/src/test/java/com/virtuslab/archunit/UIThreadUnsafeMethodInvocationsTest.java
@@ -22,7 +22,7 @@ import com.virtuslab.qual.guieffect.IgnoreUIThreadUnsafeCalls;
 import com.virtuslab.qual.guieffect.UIThreadUnsafe;
 
 @ExtensionMethod(Arrays.class)
-public class UIThreadUnsafeMethodInvocationsTestSuite extends BaseArchUnitTestSuite {
+public class UIThreadUnsafeMethodInvocationsTest extends BaseArchUnitTest {
 
   private static final String UIThreadUnsafeName = "@" + UIThreadUnsafe.class.getSimpleName();
 

--- a/src/test/kotlin/KPropertyTest.kt
+++ b/src/test/kotlin/KPropertyTest.kt
@@ -32,7 +32,7 @@ class PublicClass {
 // which doesn't lead to a fatal `.call()` on the property.
 // We no longer ban the use of private properties and/or private classes in Kotlin,
 // however we need to be aware that the risk of some of IntelliJ Kotlin libs using `.call()` still exists.
-class KPropertyTestSuite {
+class KPropertyTest {
   @Test
   fun calling_public_val_of_private_class_should_fail() {
     val prop: KCallable<Int> = PrivateClass()::publicVal

--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITest.kt
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITest.kt
@@ -27,7 +27,7 @@ import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission.*
 import kotlin.time.Duration.Companion.minutes
 
-abstract class BaseUITestSuite : TestGitRepository(SetupScripts.SETUP_WITH_SINGLE_REMOTE) {
+abstract class BaseUITest : TestGitRepository(SetupScripts.SETUP_WITH_SINGLE_REMOTE) {
   companion object {
     val robot = RemoteRobot("http://127.0.0.1:8580")
     private val intelliJVersion = System.getProperty("intellij.version")
@@ -163,8 +163,8 @@ abstract class BaseUITestSuite : TestGitRepository(SetupScripts.SETUP_WITH_SINGL
         "destfile=$execFile",
         // Append rather than overwrite if the exec already exists. Also the agent default, but
         // kept explicit as a guard for the moment ide-starter ends up restarting the IDE more
-        // than once per `uiTest_*` run - either because a second concrete `*TestSuite` is
-        // added (today there's only `UITestSuite`, so `ide.instance-per=class` restarts the
+        // than once per `uiTest_*` run - either because a second concrete `*Test` is
+        // added (today there's only `UITest`, so `ide.instance-per=class` restarts the
         // IDE once and append is a no-op), or because we switch to `ide.instance-per=method`
         // and the agent dumps after every test method. Without this flag, each restart would
         // clobber the previous one's coverage and the final exec would only cover the last

--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/ConfigurableIdeLifecycleTest.kt
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/ConfigurableIdeLifecycleTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 
-abstract class ConfigurableIdeLifecycleTestSuite : BaseUITestSuite() {
+abstract class ConfigurableIdeLifecycleTest : BaseUITest() {
 
   companion object {
     private val ideInstancePer = System.getProperty("ide.instance-per", "class")

--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators-flake-debug-notes.md
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/MyIndicators-flake-debug-notes.md
@@ -8,14 +8,14 @@ by an LLM so we don't have to re-derive the same conclusions every time.
 A spurious failure that happens every few dozen CI runs:
 
 ```text
-UITestSuite > testPullBranch() FAILED
+UITest > testPullBranch() FAILED
     com.intellij.driver.sdk.WaitForException: Timeout(2m): Failed: Indicators
         at com.intellij.driver.sdk.WaitsKt.waitFor-FbhrOv8(waits.kt:130)
         ...
         at com.virtuslab.gitmachete.uitest.MyIndicatorsKt.myWaitForIndicators-exY8QGI(MyIndicators.kt:66)
-        at com.virtuslab.gitmachete.uitest.BaseUITestSuite.doAndAwait(BaseUITestSuite.kt:138)
-        at com.virtuslab.gitmachete.uitest.BaseUITestSuite.checkoutBranch(BaseUITestSuite.kt:205)
-        at com.virtuslab.gitmachete.uitest.UITestSuite.testPullBranch(UITestSuite.kt:170)
+        at com.virtuslab.gitmachete.uitest.BaseUITest.doAndAwait(BaseUITest.kt:138)
+        at com.virtuslab.gitmachete.uitest.BaseUITest.checkoutBranch(BaseUITest.kt:205)
+        at com.virtuslab.gitmachete.uitest.UITest.testPullBranch(UITest.kt:170)
 ```
 
 Long-running flake: ~12 distinct CI occurrences logged on
@@ -336,10 +336,10 @@ suspender never resumes) is enough for the platform team to investigate.
   Inlined-from-platform copy of `Indicators.kt` with extra logging; this is
   the spot to add more diagnostics if needed. The TODO at the top references
   this issue (#2194).
-- `src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITestSuite.kt`
+- `src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/BaseUITest.kt`
   `doAndAwait` (line ~141) calls `myWaitForIndicators(2.minutes)` - the
   effective per-step timeout.
-- `src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/UITestSuite.kt`
+- `src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/UITest.kt`
   Each test method (`testPullBranch`, `testSkipNonExistentBranches_...`,
   `testFastForwardParentOfBranch`, ...).
 

--- a/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/UITest.kt
+++ b/src/uiTest/kotlin/com/virtuslab/gitmachete/uitest/UITest.kt
@@ -10,7 +10,7 @@ import java.nio.file.attribute.FileTime
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
-class UITestSuite : ConfigurableIdeLifecycleTestSuite() {
+class UITest : ConfigurableIdeLifecycleTest() {
 
   @Test
   fun testSkipNonExistentBranches_toggleListingCommits_slideOutRoot() {


### PR DESCRIPTION
JUnit already uses suite for a different thing, so I renamed the `*TestSuite` classes to `*Test` and updated the references.

Fixes #1546
